### PR TITLE
Feature/3983 dashboard dre front xii

### DIFF
--- a/src/components/screens/DashboardDRE/DashboardDRE.jsx
+++ b/src/components/screens/DashboardDRE/DashboardDRE.jsx
@@ -68,6 +68,14 @@ class DashboardDRE extends Component {
   }
 
   async carregaResumosPendencias(filtroPendencias) {
+    this.setState({
+      loadingAlteracaoCardapio : true,
+      loadingInclusoesAlimentacao : true,
+      loadingInversoesCardapio : true,
+      loadingKitLanche : true,
+      loadingSuspensaoAlimentacao : true,
+      loadingSolicitacoesUnificadas : true
+    });
     const minhaDRE = (await getMeusDados()).diretorias_regionais[0].uuid;
     const resumoPendenciasDREAlteracoesDeCardapio = await getResumoPendenciasDREAlteracoesDeCardapio(
       minhaDRE,


### PR DESCRIPTION
Esse PR:
- Corrige loading ao filtrar por data no painel DRE

Ao aplicar filtro por data nos resumos de pendências o loading não estava sendo exibido.