### PR TITLE
sidebar: retirar texto licensa adicionar logotipo

### DIFF
--- a/src/components/Shareable/Sidebar/index.jsx
+++ b/src/components/Shareable/Sidebar/index.jsx
@@ -100,14 +100,11 @@ export class Sidebar extends Component {
           </div>
           {!toggled && (
             <div className="text-center page-footer mx-auto justify-content-center mb-1 pb-2">
-              {/*<img
+              <img
                 src="/assets/image/logo-sme-branco.svg"
                 className="rounded"
                 alt="SME Educação"
-              />*/}
-              <p>
-                SME-SP-SGA - Distribuído sob <br />a Licença AGPL V3
-              </p>
+              />
             </div>
           )}
         </ul>


### PR DESCRIPTION
### Descrição
- Remove texto da licensa do sidebar
- Acrescenta logomarca da SME ao sidebar

### Preview
<img width="268" alt="Screen Shot 2020-04-13 at 18 20 21" src="https://user-images.githubusercontent.com/21344963/79477440-96586a00-7fe0-11ea-81e2-9e15cb5dcdf3.png">


