### PR TITLE
Remoção de margem direita

### DIFF
--- a/src/components/Shareable/Page/style.scss
+++ b/src/components/Shareable/Page/style.scss
@@ -16,7 +16,6 @@
 }
 
 #wrapper {
-  padding-right: 3rem;
   background-color: $whiteBackground;
 }
 


### PR DESCRIPTION
Removida uma margem direita na tela principal para otimizar uso do espaço e melhorar visualização que quebrava páginas com tabelas.