### PR TITLE
Altera o nome do Menu Logistica para Abastecimento

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
@@ -12,7 +12,7 @@ import { usuarioEhDistribuidora, usuarioEhLogistica } from "helpers/utilities";
 
 const MenuLogistica = () => {
   return (
-    <Menu id="Logistica" icon="fa-truck" title="Logística">
+    <Menu id="Logistica" icon="fa-truck" title="Abastecimento">
       {/* <LeafItem to={`/${LOGISTICA}/${DISPONIBILIZACAO_DE_SOLICITACOES}`}>
         Disponibilização de solicitações
       </LeafItem> */}

--- a/src/pages/Logistica/ConsultaRequisicaoEntregaDilog.jsx
+++ b/src/pages/Logistica/ConsultaRequisicaoEntregaDilog.jsx
@@ -16,7 +16,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 

--- a/src/pages/Logistica/ConsultaSolicitacaoAlteracaoPage.jsx
+++ b/src/pages/Logistica/ConsultaSolicitacaoAlteracaoPage.jsx
@@ -13,7 +13,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 

--- a/src/pages/Logistica/DisponibilizacaoDeSolicitacoesPage.jsx
+++ b/src/pages/Logistica/DisponibilizacaoDeSolicitacoesPage.jsx
@@ -13,7 +13,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 

--- a/src/pages/Logistica/FiltroRequisicaoDilog.jsx
+++ b/src/pages/Logistica/FiltroRequisicaoDilog.jsx
@@ -13,7 +13,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 

--- a/src/pages/Logistica/GestaoRequisicaoEntregaPage.jsx
+++ b/src/pages/Logistica/GestaoRequisicaoEntregaPage.jsx
@@ -13,7 +13,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 

--- a/src/pages/Logistica/GestaoSolicitacaoAlteracaoPage.jsx
+++ b/src/pages/Logistica/GestaoSolicitacaoAlteracaoPage.jsx
@@ -13,7 +13,7 @@ const atual = {
 const anteriores = [
   {
     href: `/`,
-    titulo: "Logística"
+    titulo: "Abastecimento"
   }
 ];
 


### PR DESCRIPTION
Este PR:
- Altera o nome "Logistica" para "Abastecimento" no menu lateral e de navegação