### PR TITLE
Bugfix/33843 informacoes nutricionais repetidas na consulta produto

### DIFF
--- a/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/corpoRelatorio/index.jsx
+++ b/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/corpoRelatorio/index.jsx
@@ -71,17 +71,12 @@ export default class CorpoRelatorio extends Component {
               medida: `${prodInfo.quantidade_porcao} ${info.medida}`,
               valor: `${prodInfo.valor_diario} %`
             });
-          } else {
-            dict.informacoes.push({
-              nome: info.nome,
-              uuid: info.uuid,
-              medida: `**** ${info.medida}`,
-              valor: `**** %`
-            });
           }
         });
       });
-      informacoesFormatadas.push(dict);
+      if (dict.informacoes.length > 0) {
+        informacoesFormatadas.push(dict);
+      }
     });
 
     if (informacoes.length === 0) {


### PR DESCRIPTION
Esse PR contém:

Gestão de Produtos

* Removendo duplicações na exibição de informações nutricionais.
* Exibindo apenas informações cadastradas dos produtos.
