### PR TITLE
Feature/35179 ga desabilitar botao autorizar quando terceirizada nao aceita atender solicitacao

### DIFF
--- a/src/components/AlteracaoDeCardapio/Relatorio/index.jsx
+++ b/src/components/AlteracaoDeCardapio/Relatorio/index.jsx
@@ -119,7 +119,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function () {
+      function() {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -228,8 +228,9 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Alteração de Cardápio - Solicitação # ${alteracaoDeCardapio.id_externo
-              }`}</span>
+            <span className="page-title">{`Alteração de Cardápio - Solicitação # ${
+              alteracaoDeCardapio.id_externo
+            }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -278,9 +279,14 @@ class Relatorio extends Component {
                               className="ml-3"
                             />
                           )
-                        ) : (visao === CODAE && alteracaoDeCardapio.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
-                          null
-                          : (<Botao
+                        ) : visao === CODAE &&
+                          alteracaoDeCardapio.logs.filter(
+                            log =>
+                              log.status_evento_explicacao ===
+                                "Terceirizada respondeu questionamento" &&
+                              !log.resposta_sim_nao
+                          ).length > 0 ? null : (
+                          <Botao
                             texto={textoBotaoAprova}
                             type={BUTTON_TYPE.SUBMIT}
                             onClick={() =>
@@ -290,13 +296,13 @@ class Relatorio extends Component {
                             }
                             style={BUTTON_STYLE.GREEN}
                             className="ml-3"
-                          />)
+                          />
                         )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/AlteracaoDeCardapio/Relatorio/index.jsx
+++ b/src/components/AlteracaoDeCardapio/Relatorio/index.jsx
@@ -119,7 +119,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function() {
+      function () {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -228,9 +228,8 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Alteração de Cardápio - Solicitação # ${
-              alteracaoDeCardapio.id_externo
-            }`}</span>
+            <span className="page-title">{`Alteração de Cardápio - Solicitação # ${alteracaoDeCardapio.id_externo
+              }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -279,8 +278,9 @@ class Relatorio extends Component {
                               className="ml-3"
                             />
                           )
-                        ) : (
-                          <Botao
+                        ) : (visao === CODAE && alteracaoDeCardapio.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
+                          null
+                          : (<Botao
                             texto={textoBotaoAprova}
                             type={BUTTON_TYPE.SUBMIT}
                             onClick={() =>
@@ -290,13 +290,13 @@ class Relatorio extends Component {
                             }
                             style={BUTTON_STYLE.GREEN}
                             className="ml-3"
-                          />
+                          />)
                         )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
@@ -108,7 +108,7 @@ class Relatorio extends Component {
             toastError(toastAprovaMensagemErro);
           }
         },
-        function() {
+        function () {
           toastError(toastAprovaMensagemErro);
         }
       );
@@ -202,7 +202,7 @@ class Relatorio extends Component {
         {!inclusaoDeAlimentacao ? (
           <div>Carregando...</div>
         ) : (
-          <form onSubmit={this.props.handleSubmit || (() => {})}>
+          <form onSubmit={this.props.handleSubmit || (() => { })}>
             {endpointAprovaSolicitacao && (
               <ModalAutorizarAposQuestionamento
                 showModal={showAutorizarModal}
@@ -214,9 +214,8 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Inclusão de Alimentação - Solicitação # ${
-              inclusaoDeAlimentacao.id_externo
-            }`}</span>
+            <span className="page-title">{`Inclusão de Alimentação - Solicitação # ${inclusaoDeAlimentacao.id_externo
+              }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -243,23 +242,26 @@ class Relatorio extends Component {
                     )}
                     {EXIBIR_BOTAO_APROVAR &&
                       (textoBotaoAprova !== "Ciente" && (
-                        <Botao
-                          texto={textoBotaoAprova}
-                          type={BUTTON_TYPE.BUTTON}
-                          onClick={() =>
-                            EXIBIR_MODAL_AUTORIZACAO
-                              ? this.showAutorizarModal()
-                              : this.handleSubmit()
-                          }
-                          style={BUTTON_STYLE.GREEN}
-                          className="ml-3"
-                        />
+                        visao === CODAE && inclusaoDeAlimentacao.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
+                          null
+                          :
+                          (<Botao
+                            texto={textoBotaoAprova}
+                            type={BUTTON_TYPE.BUTTON}
+                            onClick={() =>
+                              EXIBIR_MODAL_AUTORIZACAO
+                                ? this.showAutorizarModal()
+                                : this.handleSubmit()
+                            }
+                            style={BUTTON_STYLE.GREEN}
+                            className="ml-3"
+                          />)
                       ))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
@@ -108,7 +108,7 @@ class Relatorio extends Component {
             toastError(toastAprovaMensagemErro);
           }
         },
-        function () {
+        function() {
           toastError(toastAprovaMensagemErro);
         }
       );
@@ -202,7 +202,7 @@ class Relatorio extends Component {
         {!inclusaoDeAlimentacao ? (
           <div>Carregando...</div>
         ) : (
-          <form onSubmit={this.props.handleSubmit || (() => { })}>
+          <form onSubmit={this.props.handleSubmit || (() => {})}>
             {endpointAprovaSolicitacao && (
               <ModalAutorizarAposQuestionamento
                 showModal={showAutorizarModal}
@@ -214,8 +214,9 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Inclusão de Alimentação - Solicitação # ${inclusaoDeAlimentacao.id_externo
-              }`}</span>
+            <span className="page-title">{`Inclusão de Alimentação - Solicitação # ${
+              inclusaoDeAlimentacao.id_externo
+            }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -241,11 +242,15 @@ class Relatorio extends Component {
                       />
                     )}
                     {EXIBIR_BOTAO_APROVAR &&
-                      (textoBotaoAprova !== "Ciente" && (
-                        visao === CODAE && inclusaoDeAlimentacao.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
-                          null
-                          :
-                          (<Botao
+                      (textoBotaoAprova !== "Ciente" &&
+                        (visao === CODAE &&
+                        inclusaoDeAlimentacao.logs.filter(
+                          log =>
+                            log.status_evento_explicacao ===
+                              "Terceirizada respondeu questionamento" &&
+                            !log.resposta_sim_nao
+                        ).length > 0 ? null : (
+                          <Botao
                             texto={textoBotaoAprova}
                             type={BUTTON_TYPE.BUTTON}
                             onClick={() =>
@@ -255,13 +260,13 @@ class Relatorio extends Component {
                             }
                             style={BUTTON_STYLE.GREEN}
                             className="ml-3"
-                          />)
-                      ))}
+                          />
+                        )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/index.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/index.jsx
@@ -131,7 +131,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function () {
+      function() {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -237,8 +237,9 @@ class Relatorio extends Component {
                 uuid={uuid}
               />
             )}
-            <span className="page-title">{`Inversão de dia de Cardápio - Solicitação # ${inversaoDiaCardapio.id_externo
-              }`}</span>
+            <span className="page-title">{`Inversão de dia de Cardápio - Solicitação # ${
+              inversaoDiaCardapio.id_externo
+            }`}</span>
             <Link to={`/`}>
               <Botao
                 texto="voltar"
@@ -274,11 +275,15 @@ class Relatorio extends Component {
                       />
                     )}
                     {EXIBIR_BOTAO_APROVAR &&
-                      (textoBotaoAprova !== "Ciente" && (
-                        visao === CODAE && inversaoDiaCardapio.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
-                          null
-                          :
-                          (<Botao
+                      (textoBotaoAprova !== "Ciente" &&
+                        (visao === CODAE &&
+                        inversaoDiaCardapio.logs.filter(
+                          log =>
+                            log.status_evento_explicacao ===
+                              "Terceirizada respondeu questionamento" &&
+                            !log.resposta_sim_nao
+                        ).length > 0 ? null : (
+                          <Botao
                             texto={textoBotaoAprova}
                             type={BUTTON_TYPE.SUBMIT}
                             onClick={() =>
@@ -288,13 +293,13 @@ class Relatorio extends Component {
                             }
                             style={BUTTON_STYLE.GREEN}
                             className="ml-3"
-                          />)
-                      ))}
+                          />
+                        )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/index.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/index.jsx
@@ -131,7 +131,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function() {
+      function () {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -237,9 +237,8 @@ class Relatorio extends Component {
                 uuid={uuid}
               />
             )}
-            <span className="page-title">{`Inversão de dia de Cardápio - Solicitação # ${
-              inversaoDiaCardapio.id_externo
-            }`}</span>
+            <span className="page-title">{`Inversão de dia de Cardápio - Solicitação # ${inversaoDiaCardapio.id_externo
+              }`}</span>
             <Link to={`/`}>
               <Botao
                 texto="voltar"
@@ -276,23 +275,26 @@ class Relatorio extends Component {
                     )}
                     {EXIBIR_BOTAO_APROVAR &&
                       (textoBotaoAprova !== "Ciente" && (
-                        <Botao
-                          texto={textoBotaoAprova}
-                          type={BUTTON_TYPE.SUBMIT}
-                          onClick={() =>
-                            EXIBIR_MODAL_AUTORIZACAO
-                              ? this.showAutorizarModal()
-                              : this.handleSubmit()
-                          }
-                          style={BUTTON_STYLE.GREEN}
-                          className="ml-3"
-                        />
+                        visao === CODAE && inversaoDiaCardapio.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
+                          null
+                          :
+                          (<Botao
+                            texto={textoBotaoAprova}
+                            type={BUTTON_TYPE.SUBMIT}
+                            onClick={() =>
+                              EXIBIR_MODAL_AUTORIZACAO
+                                ? this.showAutorizarModal()
+                                : this.handleSubmit()
+                            }
+                            style={BUTTON_STYLE.GREEN}
+                            className="ml-3"
+                          />)
                       ))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/SolicitacaoDeKitLanche/Relatorio/index.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Relatorio/index.jsx
@@ -104,7 +104,7 @@ class Relatorio extends Component {
             toastError(toastAprovaMensagemErro);
           }
         },
-        function () {
+        function() {
           toastError(toastAprovaMensagemErro);
         }
       );
@@ -210,8 +210,9 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Kit Lanche Passeio - Solicitação # ${solicitacaoKitLanche.id_externo
-              }`}</span>
+            <span className="page-title">{`Kit Lanche Passeio - Solicitação # ${
+              solicitacaoKitLanche.id_externo
+            }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -238,11 +239,15 @@ class Relatorio extends Component {
                     )}
 
                     {EXIBIR_BOTAO_APROVAR &&
-                      (textoBotaoAprova !== "Ciente" && (
-                        visao === CODAE && solicitacaoKitLanche.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
-                          null
-                          :
-                          (<Botao
+                      (textoBotaoAprova !== "Ciente" &&
+                        (visao === CODAE &&
+                        solicitacaoKitLanche.logs.filter(
+                          log =>
+                            log.status_evento_explicacao ===
+                              "Terceirizada respondeu questionamento" &&
+                            !log.resposta_sim_nao
+                        ).length > 0 ? null : (
+                          <Botao
                             texto={textoBotaoAprova}
                             type={BUTTON_TYPE.SUBMIT}
                             onClick={() =>
@@ -252,13 +257,13 @@ class Relatorio extends Component {
                             }
                             style={BUTTON_STYLE.GREEN}
                             className="ml-3"
-                          />)
-                      ))}
+                          />
+                        )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/SolicitacaoDeKitLanche/Relatorio/index.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Relatorio/index.jsx
@@ -104,7 +104,7 @@ class Relatorio extends Component {
             toastError(toastAprovaMensagemErro);
           }
         },
-        function() {
+        function () {
           toastError(toastAprovaMensagemErro);
         }
       );
@@ -210,9 +210,8 @@ class Relatorio extends Component {
                 tipoSolicitacao={this.state.tipoSolicitacao}
               />
             )}
-            <span className="page-title">{`Kit Lanche Passeio - Solicitação # ${
-              solicitacaoKitLanche.id_externo
-            }`}</span>
+            <span className="page-title">{`Kit Lanche Passeio - Solicitação # ${solicitacaoKitLanche.id_externo
+              }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -240,23 +239,26 @@ class Relatorio extends Component {
 
                     {EXIBIR_BOTAO_APROVAR &&
                       (textoBotaoAprova !== "Ciente" && (
-                        <Botao
-                          texto={textoBotaoAprova}
-                          type={BUTTON_TYPE.SUBMIT}
-                          onClick={() =>
-                            EXIBIR_MODAL_AUTORIZACAO
-                              ? this.showAutorizarModal()
-                              : this.handleSubmit()
-                          }
-                          style={BUTTON_STYLE.GREEN}
-                          className="ml-3"
-                        />
+                        visao === CODAE && solicitacaoKitLanche.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
+                          null
+                          :
+                          (<Botao
+                            texto={textoBotaoAprova}
+                            type={BUTTON_TYPE.SUBMIT}
+                            onClick={() =>
+                              EXIBIR_MODAL_AUTORIZACAO
+                                ? this.showAutorizarModal()
+                                : this.handleSubmit()
+                            }
+                            style={BUTTON_STYLE.GREEN}
+                            className="ml-3"
+                          />)
                       ))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <Botao
                         texto={
                           tipoPerfil ===
-                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                            TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
                             ? "Questionar"
                             : "Sim"
                         }

--- a/src/components/SolicitacaoUnificada/Relatorio/index.jsx
+++ b/src/components/SolicitacaoUnificada/Relatorio/index.jsx
@@ -92,7 +92,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function() {
+      function () {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -194,9 +194,8 @@ class Relatorio extends Component {
                 uuid={uuid}
               />
             )}
-            <span className="page-title">{`Solicitação Unificada - Solicitação # ${
-              solicitacaoUnificada.id_externo
-            }`}</span>
+            <span className="page-title">{`Solicitação Unificada - Solicitação # ${solicitacaoUnificada.id_externo
+              }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -212,46 +211,49 @@ class Relatorio extends Component {
                 {visualizaBotoesDoFluxoSolicitacaoUnificada(
                   solicitacaoUnificada
                 ) && (
-                  <div className="form-group row float-right mt-4">
-                    {EXIBIR_BOTAO_NAO_APROVAR && (
-                      <Botao
-                        texto={textoBotaoNaoAprova}
-                        className="ml-3"
-                        onClick={() => this.showNaoAprovaModal("Não")}
-                        type={BUTTON_TYPE.BUTTON}
-                        style={BUTTON_STYLE.GREEN_OUTLINE}
-                      />
-                    )}
-                    {EXIBIR_BOTAO_APROVAR &&
-                      (textoBotaoAprova !== "Ciente" && (
+                    <div className="form-group row float-right mt-4">
+                      {EXIBIR_BOTAO_NAO_APROVAR && (
                         <Botao
-                          texto={textoBotaoAprova}
-                          type={BUTTON_TYPE.SUBMIT}
-                          onClick={() =>
-                            EXIBIR_MODAL_AUTORIZACAO
-                              ? this.showAutorizarModal()
-                              : this.handleSubmit()
+                          texto={textoBotaoNaoAprova}
+                          className="ml-3"
+                          onClick={() => this.showNaoAprovaModal("Não")}
+                          type={BUTTON_TYPE.BUTTON}
+                          style={BUTTON_STYLE.GREEN_OUTLINE}
+                        />
+                      )}
+                      {EXIBIR_BOTAO_APROVAR &&
+                        (textoBotaoAprova !== "Ciente" && (
+                          visao === CODAE && solicitacaoUnificada.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
+                            null
+                            :
+                            (<Botao
+                              texto={textoBotaoAprova}
+                              type={BUTTON_TYPE.SUBMIT}
+                              onClick={() =>
+                                EXIBIR_MODAL_AUTORIZACAO
+                                  ? this.showAutorizarModal()
+                                  : this.handleSubmit()
+                              }
+                              style={BUTTON_STYLE.GREEN}
+                              className="ml-3"
+                            />)
+                        ))}
+                      {EXIBIR_BOTAO_QUESTIONAMENTO && (
+                        <Botao
+                          texto={
+                            tipoPerfil ===
+                              TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                              ? "Questionar"
+                              : "Sim"
                           }
+                          type={BUTTON_TYPE.SUBMIT}
+                          onClick={() => this.showQuestionamentoModal("Sim")}
                           style={BUTTON_STYLE.GREEN}
                           className="ml-3"
                         />
-                      ))}
-                    {EXIBIR_BOTAO_QUESTIONAMENTO && (
-                      <Botao
-                        texto={
-                          tipoPerfil ===
-                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
-                            ? "Questionar"
-                            : "Sim"
-                        }
-                        type={BUTTON_TYPE.SUBMIT}
-                        onClick={() => this.showQuestionamentoModal("Sim")}
-                        style={BUTTON_STYLE.GREEN}
-                        className="ml-3"
-                      />
-                    )}
-                  </div>
-                )}
+                      )}
+                    </div>
+                  )}
               </div>
             </div>
           </form>

--- a/src/components/SolicitacaoUnificada/Relatorio/index.jsx
+++ b/src/components/SolicitacaoUnificada/Relatorio/index.jsx
@@ -92,7 +92,7 @@ class Relatorio extends Component {
           toastError(toastAprovaMensagemErro);
         }
       },
-      function () {
+      function() {
         toastError(toastAprovaMensagemErro);
       }
     );
@@ -194,8 +194,9 @@ class Relatorio extends Component {
                 uuid={uuid}
               />
             )}
-            <span className="page-title">{`Solicitação Unificada - Solicitação # ${solicitacaoUnificada.id_externo
-              }`}</span>
+            <span className="page-title">{`Solicitação Unificada - Solicitação # ${
+              solicitacaoUnificada.id_externo
+            }`}</span>
             <div className="card mt-3">
               <div className="card-body">
                 <CorpoRelatorio
@@ -211,49 +212,53 @@ class Relatorio extends Component {
                 {visualizaBotoesDoFluxoSolicitacaoUnificada(
                   solicitacaoUnificada
                 ) && (
-                    <div className="form-group row float-right mt-4">
-                      {EXIBIR_BOTAO_NAO_APROVAR && (
-                        <Botao
-                          texto={textoBotaoNaoAprova}
-                          className="ml-3"
-                          onClick={() => this.showNaoAprovaModal("Não")}
-                          type={BUTTON_TYPE.BUTTON}
-                          style={BUTTON_STYLE.GREEN_OUTLINE}
-                        />
-                      )}
-                      {EXIBIR_BOTAO_APROVAR &&
-                        (textoBotaoAprova !== "Ciente" && (
-                          visao === CODAE && solicitacaoUnificada.logs.filter((log) => log.status_evento_explicacao === "Terceirizada respondeu questionamento" && !log.resposta_sim_nao).length > 0 ?
-                            null
-                            :
-                            (<Botao
-                              texto={textoBotaoAprova}
-                              type={BUTTON_TYPE.SUBMIT}
-                              onClick={() =>
-                                EXIBIR_MODAL_AUTORIZACAO
-                                  ? this.showAutorizarModal()
-                                  : this.handleSubmit()
-                              }
-                              style={BUTTON_STYLE.GREEN}
-                              className="ml-3"
-                            />)
-                        ))}
-                      {EXIBIR_BOTAO_QUESTIONAMENTO && (
-                        <Botao
-                          texto={
-                            tipoPerfil ===
-                              TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
-                              ? "Questionar"
-                              : "Sim"
-                          }
-                          type={BUTTON_TYPE.SUBMIT}
-                          onClick={() => this.showQuestionamentoModal("Sim")}
-                          style={BUTTON_STYLE.GREEN}
-                          className="ml-3"
-                        />
-                      )}
-                    </div>
-                  )}
+                  <div className="form-group row float-right mt-4">
+                    {EXIBIR_BOTAO_NAO_APROVAR && (
+                      <Botao
+                        texto={textoBotaoNaoAprova}
+                        className="ml-3"
+                        onClick={() => this.showNaoAprovaModal("Não")}
+                        type={BUTTON_TYPE.BUTTON}
+                        style={BUTTON_STYLE.GREEN_OUTLINE}
+                      />
+                    )}
+                    {EXIBIR_BOTAO_APROVAR &&
+                      (textoBotaoAprova !== "Ciente" &&
+                        (visao === CODAE &&
+                        solicitacaoUnificada.logs.filter(
+                          log =>
+                            log.status_evento_explicacao ===
+                              "Terceirizada respondeu questionamento" &&
+                            !log.resposta_sim_nao
+                        ).length > 0 ? null : (
+                          <Botao
+                            texto={textoBotaoAprova}
+                            type={BUTTON_TYPE.SUBMIT}
+                            onClick={() =>
+                              EXIBIR_MODAL_AUTORIZACAO
+                                ? this.showAutorizarModal()
+                                : this.handleSubmit()
+                            }
+                            style={BUTTON_STYLE.GREEN}
+                            className="ml-3"
+                          />
+                        )))}
+                    {EXIBIR_BOTAO_QUESTIONAMENTO && (
+                      <Botao
+                        texto={
+                          tipoPerfil ===
+                          TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+                            ? "Questionar"
+                            : "Sim"
+                        }
+                        type={BUTTON_TYPE.SUBMIT}
+                        onClick={() => this.showQuestionamentoModal("Sim")}
+                        style={BUTTON_STYLE.GREEN}
+                        className="ml-3"
+                      />
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </form>


### PR DESCRIPTION
Esse PR contém:

Desabilitar o botão autorizar quando a terceirizada não aceita atender solicitação
nas seguintes solicitações:
 
* Inclusão de Alimentação
* Alteração de cardápio (Alteração do tipo de Alimentação)
* KIT LANCHE
* Inversão de dia de cardápio
* Solicitação unificada 