### PR TITLE
Bugfix/38237 codae historico questionamento exibe html

### DIFF
--- a/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
+++ b/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
@@ -74,9 +74,12 @@ export const RelatorioHistoricoQuestionamento = props => {
                     <div className="is-it-possible">
                       <div className="title">Negou</div>
                       {log.justificativa && (
-                        <div className="obs">
-                          Observação da CODAE: {log.justificativa}
-                        </div>
+                        <div
+                          className="obs"
+                          dangerouslySetInnerHTML={{
+                            __html: `Observação da CODAE: ${log.justificativa}`
+                          }}
+                        />
                       )}
                     </div>
                   )}


### PR DESCRIPTION
Esse PR contém:

* Não exibir html no histórico questionamento quando CODAE negou.
