### PR TITLE
Bugfix/33284 de erro ao abrir dieta inativas temporariamente com perfil terceirizada

### DIFF
--- a/src/pages/DietaEspecial/DashboardDietaEspecialPage.jsx
+++ b/src/pages/DietaEspecial/DashboardDietaEspecialPage.jsx
@@ -19,6 +19,7 @@ import {
   getDietaEspecialAutorizadasTemporariamenteCODAE,
   getDietaEspecialAutorizadasTemporariamenteDRE,
   getDietaEspecialAutorizadasTemporariamenteEscola,
+  getDietaEspecialAutorizadasTemporariamenteTerceirizada,
   getDietaEspecialAutorizadasTerceirizada,
   getDietaEspecialCanceladasCODAE,
   getDietaEspecialCanceladasDRE,
@@ -30,6 +31,7 @@ import {
   getDietaEspecialInativasTemporariamenteCODAE,
   getDietaEspecialInativasTemporariamenteDRE,
   getDietaEspecialInativasTemporariamenteEscola,
+  getDietaEspecialInativasTemporariamenteTerceirizada,
   getDietaEspecialInativasTerceirizada,
   getDietaEspecialNegadasCODAE,
   getDietaEspecialNegadasDRE,
@@ -121,10 +123,10 @@ export const DietaEspecialTerceirizada = () => (
     getDietaEspecialNegadas={getDietaEspecialNegadasTerceirizada}
     getDietaEspecialCanceladas={getDietaEspecialCanceladasTerceirizada}
     getDietaEspecialInativasTemporariamente={
-      getDietaEspecialInativasTemporariamenteCODAE
+      getDietaEspecialInativasTemporariamenteTerceirizada
     }
     getDietaEspecialAutorizadasTemporariamente={
-      getDietaEspecialAutorizadasTemporariamenteCODAE
+      getDietaEspecialAutorizadasTemporariamenteTerceirizada
     }
     getDietaEspecialInativas={getDietaEspecialInativasTerceirizada}
   />


### PR DESCRIPTION
Esse PR contém:

* Correção na chamada aos endpoints corretos nos cards de inativas temporariamente e autorizadas temporariamente no painel inicial da perfil terceirizada.