### PR TITLE
Feature/40753 remover botão cancelar

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuDietaEspecial.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuDietaEspecial.jsx
@@ -33,8 +33,7 @@ const MenuDietaEspecial = () => {
     usuarioEhEscola() ||
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhDRE();
-  const exibeAtivasInativas =
-    usuarioEhCODAEDietaEspecial() || usuarioEhNutricionistaSupervisao();
+  const exibeAtivasInativas = usuarioEhCODAEDietaEspecial();
   const exibeAvaliarSolicitacaoCadastroProduto = usuarioEhTerceirizada();
   const exibeAcompanharSolicitacaoCadastroProduto = usuarioEhCODAEDietaEspecial();
 

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/EscolaCancelaDietaEspecial.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/EscolaCancelaDietaEspecial.jsx
@@ -6,6 +6,9 @@ import {
   BUTTON_STYLE
 } from "../../../../Shareable/Botao/constants";
 import ModalCancelaDietaEspecial from "./ModalCancelaDietaEspecial";
+import {
+  usuarioEhNutricionistaSupervisao,
+} from "helpers/utilities";
 
 export default class EscolaCancelaDietaEspecial extends Component {
   constructor(props) {
@@ -37,15 +40,17 @@ export default class EscolaCancelaDietaEspecial extends Component {
           }}
           {...this.props}
         />
-        <div className="form-group row float-right mt-4">
-          <Botao
-            texto="Cancelar"
-            className="ml-3"
-            onClick={this.onOpenModal}
-            type={BUTTON_TYPE.BUTTON}
-            style={BUTTON_STYLE.GREEN_OUTLINE}
-          />
-        </div>
+        { !usuarioEhNutricionistaSupervisao() && (
+          <div className="form-group row float-right mt-4">
+            <Botao
+              texto="Cancelar"
+              className="ml-3"
+              onClick={this.onOpenModal}
+              type={BUTTON_TYPE.BUTTON}
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+            />
+          </div>
+        )} 
       </>
     );
   }

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/EscolaCancelaDietaEspecial.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/EscolaCancelaDietaEspecial.jsx
@@ -6,9 +6,7 @@ import {
   BUTTON_STYLE
 } from "../../../../Shareable/Botao/constants";
 import ModalCancelaDietaEspecial from "./ModalCancelaDietaEspecial";
-import {
-  usuarioEhNutricionistaSupervisao,
-} from "helpers/utilities";
+import { usuarioEhNutricionistaSupervisao } from "helpers/utilities";
 
 export default class EscolaCancelaDietaEspecial extends Component {
   constructor(props) {
@@ -40,7 +38,7 @@ export default class EscolaCancelaDietaEspecial extends Component {
           }}
           {...this.props}
         />
-        { !usuarioEhNutricionistaSupervisao() && (
+        {!usuarioEhNutricionistaSupervisao() && (
           <div className="form-group row float-right mt-4">
             <Botao
               texto="Cancelar"
@@ -50,7 +48,7 @@ export default class EscolaCancelaDietaEspecial extends Component {
               style={BUTTON_STYLE.GREEN_OUTLINE}
             />
           </div>
-        )} 
+        )}
       </>
     );
   }


### PR DESCRIPTION
# Proposta

Este PR visa remover o botão de cancelar das dietas que estão no status de aguardando, e o acesso através do menu lateral quando estiver logado com um perfil Nutrisupervisor.
 
# Referência do Azure

- 40753

# Tarefas para concluir

- [x] Retirar o botão de Cancelar das dietas que estão no status de aguardando autorização.
- [x] Retirar o submenu de Aguardando Autorização acessada pelo menu lateral de Dieta Especial.
- [x] correções do prettier.