### PR TITLE
Feature/38601 fix filtros entregas

### DIFF
--- a/src/components/screens/Logistica/EntregasDilog/index.jsx
+++ b/src/components/screens/Logistica/EntregasDilog/index.jsx
@@ -43,8 +43,10 @@ export default () => {
   }, []);
 
   useEffect(() => {
-    buscarSolicitacoes(1);
-    setPage(1);
+    if (filtros) {
+      buscarSolicitacoes(1);
+      setPage(1);
+    }
   }, [filtros]);
 
   const nextPage = page => {


### PR DESCRIPTION
Este PR:
- faz com que as requisicoes só sejam carregadas após a seleção dos filtros na página de Entregas da DILOG