### PR TITLE
Feature/40752 remover botao solicitar novo produto

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuDietaEspecial.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuDietaEspecial.jsx
@@ -1,9 +1,6 @@
 import React from "react";
 import { Menu, LeafItem } from "./shared";
 import {
-  GESTAO_PRODUTO,
-  AVALIAR_SOLICITACAO_CADASTRO_PRODUTO,
-  ACOMPANHAR_SOLICITACAO_CADASTRO_PRODUTO,
   DIETA_ESPECIAL,
   CANCELAMENTO,
   PROTOCOLO_PADRAO_DIETA
@@ -34,8 +31,6 @@ const MenuDietaEspecial = () => {
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhDRE();
   const exibeAtivasInativas = usuarioEhCODAEDietaEspecial();
-  const exibeAvaliarSolicitacaoCadastroProduto = usuarioEhTerceirizada();
-  const exibeAcompanharSolicitacaoCadastroProduto = usuarioEhCODAEDietaEspecial();
 
   return (
     <Menu id="DietaEspecial" icon="fa-utensils" title={"Dieta Especial"}>
@@ -58,20 +53,6 @@ const MenuDietaEspecial = () => {
       {exibeAtivasInativas && (
         <LeafItem to={`/solicitacoes-dieta-especial/solicitacoes-pendentes`}>
           {getNomeCardAguardandoAutorizacao()}
-        </LeafItem>
-      )}
-      {exibeAvaliarSolicitacaoCadastroProduto && (
-        <LeafItem
-          to={`/${GESTAO_PRODUTO}/${AVALIAR_SOLICITACAO_CADASTRO_PRODUTO}`}
-        >
-          Avaliar solic. cad. produto
-        </LeafItem>
-      )}
-      {exibeAcompanharSolicitacaoCadastroProduto && (
-        <LeafItem
-          to={`/${GESTAO_PRODUTO}/${ACOMPANHAR_SOLICITACAO_CADASTRO_PRODUTO}`}
-        >
-          Acompanhar solic. novos produtos
         </LeafItem>
       )}
       {usuarioEhEscola() && (

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
@@ -23,8 +23,11 @@ import { TIPO_SOLICITACAO_DIETA } from "../../../../../../constants/shared";
 import { required } from "../../../../../../helpers/fieldValidators";
 import {
   obtemIdentificacaoNutricionista,
-  gerarParametrosConsulta
-} from "../../../../../../helpers/utilities";
+  gerarParametrosConsulta,
+  usuarioEhCoordenadorNutriCODAE,
+  usuarioEhCODAEDietaEspecial,
+  usuarioEhTerceirizada
+} from "helpers/utilities";
 
 import { getStatusSolicitacoesVigentes } from "helpers/dietaEspecial";
 
@@ -342,6 +345,10 @@ export default class FormAutorizaDietaEspecial extends Component {
       showAutorizarAlteracaoUEModal
     } = this.state;
     const { dietaEspecial, setTemSolicitacaoCadastroProduto } = this.props;
+    const exibeBotaoSolicitarProduto =
+      !usuarioEhCoordenadorNutriCODAE() &&
+      !usuarioEhTerceirizada() &&
+      !usuarioEhCODAEDietaEspecial();
     return (
       <div>
         <Form
@@ -496,14 +503,18 @@ export default class FormAutorizaDietaEspecial extends Component {
                 {dietaEspecial.tipo_solicitacao !==
                   TIPO_SOLICITACAO_DIETA.ALTERACAO_UE && (
                   <>
-                    <Botao
-                      texto="Solicitar Novo Produto"
-                      type={BUTTON_TYPE.BUTTON}
-                      style={BUTTON_STYLE.BLUE_OUTLINE}
-                      onClick={() => this.showModalSolicitacaoCadastroProduto()}
-                      className="ml-3"
-                      disabled={submitting}
-                    />
+                    {exibeBotaoSolicitarProduto && (
+                      <Botao
+                        texto="Solicitar Novo Produto"
+                        type={BUTTON_TYPE.BUTTON}
+                        style={BUTTON_STYLE.BLUE_OUTLINE}
+                        onClick={() =>
+                          this.showModalSolicitacaoCadastroProduto()
+                        }
+                        className="ml-3"
+                        disabled={submitting}
+                      />
+                    )}
                     <Botao
                       texto="Salvar Rascunho"
                       type={BUTTON_TYPE.BUTTON}


### PR DESCRIPTION
# Proposta

Este PR visa remover o botão de "Solicitar Novo Produto" das dietas que estão no status de recebidas,  o acesso a tela de "Acompanhar solic. novos produtos" através do menu lateral quando estiver logado com um perfil Nutricodae. Também remove o acesso a tela de "Avaliar solic. cad. Produto"  no menu lateral quando estiver logado com um perfil Terceirizada.
 
# Referência do Azure

- 40752

# Tarefas para concluir

- [x] Retirar o botão de Solicitar Novo Produto.
- [x] Retirar submenus Acompanhar solic. novos produtos com perfil Nutricodae.
- [x] Retirar submenus Avaliar solic. cad. Produto com perfil Terceirizada.