### PR TITLE
Campos de filtro para a página de Entregas

### DIFF
--- a/src/components/screens/Logistica/ConsultaEntregas/components/Filtros/index.jsx
+++ b/src/components/screens/Logistica/ConsultaEntregas/components/Filtros/index.jsx
@@ -13,7 +13,7 @@ import "./styles.scss";
 
 const FORM_NAME = "entregasDilog";
 
-export default ({ setFiltros, setSolicitacoes, setTotal }) => {
+export default ({ setFiltros, setSolicitacoes, setTotal, dilog }) => {
   const [initialValues] = useState({});
 
   const onSubmit = async values => {
@@ -40,17 +40,17 @@ export default ({ setFiltros, setSolicitacoes, setTotal }) => {
                 />
               </div>
 
-              <div className="col-6">
-                <Field
-                  component={InputText}
-                  label="Nome do Distribuidor"
-                  name="nome_distribuidor"
-                  placeholder="Digite o nome do distribuidor"
-                  className="input-busca-produto"
-                />
-              </div>
-            </div>
-            <div className="row">
+              {dilog && (
+                <div className="col-6">
+                  <Field
+                    component={InputText}
+                    label="Nome do Distribuidor"
+                    name="nome_distribuidor"
+                    placeholder="Digite o nome do distribuidor"
+                    className="input-busca-produto"
+                  />
+                </div>
+              )}
               <div className="col-3">
                 <Field
                   component={InputComData}

--- a/src/components/screens/Logistica/ConsultaEntregas/components/ListagemSolicitacoes/index.jsx
+++ b/src/components/screens/Logistica/ConsultaEntregas/components/ListagemSolicitacoes/index.jsx
@@ -67,7 +67,9 @@ const ListagemSolicitacoes = ({ solicitacoes, ativos, setAtivos, dilog }) => {
                 <div className={`${bordas}`}>
                   {solicitacao.guias_parciais +
                     solicitacao.guias_recebidas +
-                    solicitacao.guias_nao_recebidas}
+                    solicitacao.guias_nao_recebidas +
+                    solicitacao.guias_reposicao_parcial +
+                    solicitacao.guias_reposicao_total}
                 </div>
                 <div className={`${bordas}`}>{solicitacao.guias_insucesso}</div>
                 <div className={`${bordas}`}>{solicitacao.guias_pendentes}</div>

--- a/src/components/screens/Logistica/ConsultaEntregas/index.jsx
+++ b/src/components/screens/Logistica/ConsultaEntregas/index.jsx
@@ -66,6 +66,7 @@ export default ({ dilog }) => {
             setFiltros={setFiltros}
             setSolicitacoes={setSolicitacoes}
             setTotal={setTotal}
+            dilog={dilog}
           />
           {solicitacoes && (
             <>


### PR DESCRIPTION
Este PR:
- Habilita os filtros da página de entregas do distirbuidor a partir do componente compartilhado entre as páginas de dilog e de distribuidor