### PR TITLE
Feature/41167 inclusao insucesso entrega

### DIFF
--- a/src/components/screens/Logistica/ConferirEntrega/components/ListagemGuias/index.js
+++ b/src/components/screens/Logistica/ConferirEntrega/components/ListagemGuias/index.js
@@ -21,7 +21,9 @@ const ListagemSolicitacoes = ({ guias }) => {
           |
         </>
       );
-    } else if (guia.status === "Pendente de conferência") {
+    } else if (
+      ["Pendente de conferência", "Insucesso de entrega"].includes(guia.status)
+    ) {
       return (
         <>
           <NavLink


### PR DESCRIPTION
Este PR:
- Inclui o botão "Conferir" para as guias com status "Insucesso de Entrega" na página "Conferir Entrega"