### PR TITLE
Feature: alterar nome do card da gestão de produtos.

### DIFF
--- a/src/helpers/gestaoDeProdutos.js
+++ b/src/helpers/gestaoDeProdutos.js
@@ -53,7 +53,7 @@ const CARD_AGUARDANDO_ANALISE_RECLAMACAO = {
 };
 const CARD_AGUARDANDO_ANALISE_SENSORIAL = {
   id: CARD_ID.AGUARDANDO_ANALISE_SENSORIAL,
-  titulo: "Aguardando análise sensoriais",
+  titulo: "Aguardando amostra para análise sensorial",
   titulo_menu: "Ag. análise sensoriais",
   icon: "fa-search",
   style: "card-awaiting-sensory",


### PR DESCRIPTION
# Proposta

Este PR visa alterar o nome do card da gestão de produtos.
 
# Referência do Azure

- 43039

# Tarefas para concluir

- [x] alterar nome do card de gestão de produtos.