### PR TITLE
Fix: set protocolo salvo na solicitacao quando o campo de seleção não…

### DIFF
--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
@@ -151,6 +151,8 @@ const FormAutorizaDietaEspecial = ({ dietaEspecial, onAutorizarOuNegar }) => {
     values.alergias_intolerancias = diagnosticosSelecionados;
     if (protocoloPadrao) {
       values.nome_protocolo = protocoloPadrao.nome_protocolo;
+    } else {
+      values.nome_protocolo = dietaEspecial.nome_protocolo;
     }
     if (!values.protocolo_padrao) {
       delete values["protocolo_padrao"];
@@ -175,7 +177,11 @@ const FormAutorizaDietaEspecial = ({ dietaEspecial, onAutorizarOuNegar }) => {
     if (!diagnosticosSelecionados.length) {
       return;
     }
-    values.nome_protocolo = protocoloPadrao.nome_protocolo;
+    if (protocoloPadrao) {
+      values.nome_protocolo = protocoloPadrao.nome_protocolo;
+    } else {
+      values.nome_protocolo = dietaEspecial.nome_protocolo;
+    }
     if (
       dietaEspecial.tipo_solicitacao === TIPO_SOLICITACAO_DIETA.ALTERACAO_UE &&
       !showAutorizarAlteracaoUEModal


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o método de salvar rascunho e autorizar dietas quando o select  de protocolo padrão não sofrer nenhuma ação.
 
# Referência do Azure

- 42100

# Tarefas para concluir

- [x] correção dos métodos.