### PR TITLE
Feature/47208 melhoria arquivar desarquivar

### DIFF
--- a/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/ListagemGuias/index.jsx
+++ b/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/ListagemGuias/index.jsx
@@ -55,7 +55,7 @@ export default ({ solicitacao, situacao, arquivaDesarquivaGuias }) => {
     let invalidas = guias.filter(guia =>
       ["Aguardando envio", "Aguardando confirmação"].includes(guia.status)
     );
-    return invalidas.length > 0;
+    return invalidas.length > 0 || selecionados.length <= 0;
   };
 
   const abrirModalGuia = guia => {


### PR DESCRIPTION
### Este PR:

> Implementa melhoria na tela de requisições de entrega. Agora além das validações que já existiam para arquivar ou desarquivar uma guia, o botão só é habilitado caso a guia tenha sido selecionada.