### PR TITLE
Fix: exibição do botão de resposta

### DIFF
--- a/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
@@ -280,14 +280,20 @@ class Relatorio extends Component {
                         )))}
                     {EXIBIR_BOTAO_QUESTIONAMENTO && (
                       <>
-                        <Botao
-                          key="1"
-                          texto="Não"
-                          type={BUTTON_TYPE.SUBMIT}
-                          onClick={() => this.showQuestionamentoModal("Não")}
-                          style={BUTTON_STYLE.GREEN_OUTLINE}
-                          className="ml-3"
-                        />
+                        {inclusaoDeAlimentacao.status ===
+                          statusEnum.CODAE_QUESTIONADO &&
+                        tipoPerfil === TIPO_PERFIL.TERCEIRIZADA ? (
+                          <Botao
+                            key="1"
+                            texto="Não"
+                            type={BUTTON_TYPE.SUBMIT}
+                            onClick={() => this.showQuestionamentoModal("Não")}
+                            style={BUTTON_STYLE.GREEN_OUTLINE}
+                            className="ml-3"
+                          />
+                        ) : (
+                          <></>
+                        )}
                         <Botao
                           key="2"
                           texto={


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição do botão de resposta "Não" em uma solicitação de inclusão de Alimentação.

# Referência do Azure

- 47553

# Tarefas para concluir

- [x] adicionar validação para exibir botão.
