### PR TITLE
Fix: alterar título do card para ficar de acordo com o retornado da api

### DIFF
--- a/src/constants/shared.js
+++ b/src/constants/shared.js
@@ -173,7 +173,7 @@ export const TIPOS_SOLICITACAO_LABEL = {
   INCLUSAO_DE_ALIMENTACAO: "Inclusão de Alimentação",
   INCLUSAO_DE_ALIMENTACAO_CEI: "Inclusão de Alimentacao de CEI",
   INCLUSAO_DE_ALIMENTACAO_CONTINUA: "Inclusão de Alimentação Contínua",
-  ALTERACAO_DO_TIPO_DE_ALIMENTACAO: "Alteração do Tipo de Alimentação",
+  ALTERACAO_DO_TIPO_DE_ALIMENTACAO: "Alteração do tipo de Alimentação",
   ALTERACAO_DO_TIPO_DE_ALIMENTACAO_CEI:
     "Alteração do Tipo de Alimentação de CEI",
   SOLICITACAO_DE_KIT_LANCHE_PASSEIO: "Kit Lanche Passeio",


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a contagem das solicitações de Alteração do Tipo de Alimentação pendentes.

# Referência do Azure

- 47564

# Tarefas para concluir

- [x] alterar título do card para ficar de acordo com o retornado da api.
