### PR TITLE
Fix: formatar data enviada no momento de autorizar uma dieta 

### DIFF
--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/componentes/DataTermino/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/componentes/DataTermino/index.jsx
@@ -17,6 +17,7 @@ const DataTermino = ({ tipoSolicitacao, temData }) => {
             component={InputComData}
             label="Data de Término"
             name="data_termino"
+            dateFormat={"YYYY-MM-DD"}
             required
             className="form-control data-label"
             minDate={moment().add(1, "days")._d}


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a formatação da data enviada no payload quando a solicitação for para um aluno(a) sem matrícula na rede.

# Referência do Azure

- 47419

# Tarefas para concluir

- [x] adicionar dateFormat props para o componente de data.
