### PR TITLE
Fix: não exibir rf ou cpf do usuário quando for uma dieta importada

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/index.jsx
+++ b/src/components/Shareable/FluxoDeStatus/index.jsx
@@ -8,7 +8,7 @@ import "./style.scss";
 import { deepCopy } from "../../../helpers/utilities";
 
 export const FluxoDeStatus = props => {
-  const { listaDeStatus, fluxo } = props;
+  const { listaDeStatus, fluxo, eh_importado = false } = props;
   let cloneListaDeStatus = deepCopy(listaDeStatus);
   cloneListaDeStatus = formatarLogs(cloneListaDeStatus);
   const fluxoNaoFinalizado =
@@ -62,7 +62,8 @@ export const FluxoDeStatus = props => {
                   <br />
                   {novoStatus.usuario && (
                     <span>
-                      {novoStatus.usuario.registro_funcional !== undefined &&
+                      {!eh_importado &&
+                      novoStatus.usuario.registro_funcional !== undefined &&
                       cloneListaDeStatus[key].usuario.tipo_usuario ===
                         "terceirizada"
                         ? `CPF: ${novoStatus.usuario.cpf}`
@@ -70,8 +71,9 @@ export const FluxoDeStatus = props => {
                             "Cancelamento por alteração de unidade educacional" &&
                           status.status_evento_explicacao !==
                             "Cancelamento para aluno não matriculado na rede municipal" &&
+                          !eh_importado &&
                           `RF: ${novoStatus.usuario.registro_funcional}`}
-                      <br />
+                      {!eh_importado && <br />}
                       {novoStatus.usuario &&
                         (status.status_evento_explicacao !==
                           "Cancelamento por alteração de unidade educacional" &&

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/FluxoDeStatusDieta.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/FluxoDeStatusDieta.jsx
@@ -5,7 +5,7 @@ import {
   formatarFluxoDietaEspecial
 } from "components/Shareable/FluxoDeStatus/helper";
 
-const FluxoDeStatusDieta = ({ logs }) => {
+const FluxoDeStatusDieta = ({ logs, eh_importado = false }) => {
   return (
     <div className="row mb-3">
       <div className="col-12">
@@ -19,6 +19,7 @@ const FluxoDeStatusDieta = ({ logs }) => {
               ? formatarFluxoDietaEspecial(logs)
               : fluxoDietaEspecialPartindoEscola
           }
+          eh_importado={eh_importado}
         />
       </div>
     </div>

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
@@ -233,7 +233,10 @@ const CorpoRelatorio = ({
                 <hr />
               </>
             )}
-          <FluxoDeStatusDieta logs={dietaEspecial.logs} />
+          <FluxoDeStatusDieta
+            logs={dietaEspecial.logs}
+            eh_importado={dietaEspecial.eh_importado}
+          />
           <hr />
           <DadosEscolaSolicitante />
           <hr />


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição do RF/CPF ao visualizar o fluxo de uma dieta especial importada.

# Referência do Azure

- 33348

# Tarefas para concluir

- [x] alterar regra de exibição do RF/CPF no fluxo de status
