### PR TITLE
Bugfix/53217 ga problema na exibiçao escolas tela lotes

### DIFF
--- a/src/components/screens/Cadastros/CadastroLote/helper.js
+++ b/src/components/screens/Cadastros/CadastroLote/helper.js
@@ -3,7 +3,7 @@ export const formatarEscolasParaMultiselect = lista => {
     return {
       value: element.uuid,
       label: `${element.codigo_eol} - ${element.nome} - ${
-        element.lote ? element.lote : ""
+        element.lote ? element.lote.nome : ""
       }`
     };
   });


### PR DESCRIPTION
Esse PR contém:

* Ajuste na listagem das escolas no cadastro de lote.

história: [bugfix/53217](https://dev.azure.com/amcomgov/SME%20-%20Alimenta%C3%A7%C3%A3o/_sprints/taskboard/SME%20-%20Alimenta%C3%A7%C3%A3o%20Team/SME%20-%20Alimenta%C3%A7%C3%A3o/Sprint%2042?workitem=53217)