### PR TITLE
Fix: correção ao editar as orientações gerais dos produtos

### DIFF
--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
@@ -108,7 +108,9 @@ class WizardFormTerceiraPagina extends Component {
     } else {
       values["eh_para_alunos_com_dieta"] = false;
     }
-
+    if (values["outras_informacoes"] === undefined) {
+      values["outras_informacoes"] = "";
+    }
     if (values["tem_aditivos_alergenicos"] === "1") {
       values["tem_aditivos_alergenicos"] = true;
     } else {


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a edição do campo orientações gerais dos produtos com o perfil "terceirizada"

# Referência do Azure

- 50500

# Tarefas para concluir

- [x] enviar string vazia ao deixar o campo vazio ou undefined.
