### PR TITLE
Feature/53045 botao negar solicitacao cancelamento

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -137,6 +137,7 @@ export const tipoDeStatus = status => {
     case "CODAE negou":
     case "CODAE negou inativação":
     case "Terceirizada recusou":
+    case "CODAE negou cancelamento":
       return "reprovado";
     case "Questionamento pela CODAE":
       return "questionado";

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
@@ -177,16 +177,16 @@ const CorpoRelatorio = ({
         <ProtocoloLeitura key={2} />,
         <OrientacoesLeitura
           orientacoes_gerais={dietaEspecial.orientacoes_gerais}
-          key={2}
+          key={3}
         />,
         <SubstituicoesTable
           substituicoes={dietaEspecial.substituicoes}
-          key={3}
+          key={4}
         />,
-        <PeriodoVigencia key={4} />,
+        <PeriodoVigencia key={5} />,
         <InformacoesAdicionaisLeitura
           informacoes_adicionais={dietaEspecial.informacoes_adicionais}
-          key={5}
+          key={6}
         />,
         <IdentificacaoNutricionista key={7} />
       ];
@@ -201,16 +201,16 @@ const CorpoRelatorio = ({
         <ProtocoloLeitura key={2} />,
         <OrientacoesLeitura
           orientacoes_gerais={dietaEspecial.orientacoes_gerais}
-          key={2}
+          key={3}
         />,
         <SubstituicoesTable
           substituicoes={dietaEspecial.substituicoes}
-          key={3}
+          key={4}
         />,
-        <PeriodoVigencia key={4} />,
+        <PeriodoVigencia key={5} />,
         <InformacoesAdicionaisLeitura
           informacoes_adicionais={dietaEspecial.informacoes_adicionais}
-          key={5}
+          key={6}
         />,
         <IdentificacaoNutricionista key={7} />
       ];

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
@@ -433,6 +433,7 @@ const FormAutorizaDietaEspecial = ({
         getMotivos={() => getMotivosNegacaoDietaEspecial()}
         submitModal={(uuid, values) => CODAENegaDietaEspecial(uuid, values)}
         fieldJustificativa={"justificativa_negacao"}
+        tituloModal={"Deseja negar a solicitação?"}
       />
     </>
   );

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
@@ -432,6 +432,7 @@ const FormAutorizaDietaEspecial = ({
         uuid={dietaEspecial.uuid}
         getMotivos={() => getMotivosNegacaoDietaEspecial()}
         submitModal={(uuid, values) => CODAENegaDietaEspecial(uuid, values)}
+        fieldJustificativa={"justificativa_negacao"}
       />
     </>
   );

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/FormAutorizaDietaEspecial/index.jsx
@@ -24,6 +24,8 @@ import {
   CODAEAutorizaDietaEspecial
 } from "services/dietaEspecial.service";
 import { getSubstitutos } from "services/produto.service";
+import { getMotivosNegacaoDietaEspecial } from "services/painelNutricionista.service";
+import { CODAENegaDietaEspecial } from "services/dietaEspecial.service";
 
 import Diagnosticos from "./componentes/Diagnosticos";
 import ClassificacaoDaDieta from "./componentes/ClassificacaoDaDieta";
@@ -424,10 +426,12 @@ const FormAutorizaDietaEspecial = ({
         )}
       />
       <ModalNegaDietaEspecial
-        showModalNegaDieta={showModalNegaDieta}
+        showModal={showModalNegaDieta}
         closeModal={() => setShowModalNegaDieta(false)}
         onNegar={onAutorizarOuNegar}
         uuid={dietaEspecial.uuid}
+        getMotivos={() => getMotivosNegacaoDietaEspecial()}
+        submitModal={(uuid, values) => CODAENegaDietaEspecial(uuid, values)}
       />
     </>
   );

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
@@ -2,7 +2,6 @@ import HTTP_STATUS from "http-status-codes";
 import React, { Component } from "react";
 import { Modal } from "react-bootstrap";
 import { Field, Form } from "react-final-form";
-import { required } from "../../../../../../helpers/fieldValidators";
 import { TextAreaWYSIWYG } from "../../../../../Shareable/TextArea/TextAreaWYSIWYG";
 import {
   toastError,
@@ -14,6 +13,12 @@ import {
   BUTTON_STYLE
 } from "../../../../../Shareable/Botao/constants";
 import Select from "../../../../../Shareable/Select";
+import {
+  peloMenosUmCaractere,
+  required,
+  textAreaRequired
+} from "helpers/fieldValidators";
+import { composeValidators } from "helpers/utilities";
 import { agregarDefault } from "../../../../../../helpers/utilities";
 import { formataMotivos } from "./helper";
 
@@ -53,7 +58,7 @@ export default class ModalNegarSolicitacao extends Component {
         onHide={this.props.closeModal}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Deseja negar a solicitação?</Modal.Title>
+          <Modal.Title>{this.props.tituloModal}</Modal.Title>
         </Modal.Header>
         <Form
           onSubmit={this.onSubmit}
@@ -67,6 +72,7 @@ export default class ModalNegarSolicitacao extends Component {
                       label="Motivo"
                       name="motivo_negacao"
                       options={motivosNegacao}
+                      required
                       validate={required}
                     />
                   </div>
@@ -77,6 +83,12 @@ export default class ModalNegarSolicitacao extends Component {
                       component={TextAreaWYSIWYG}
                       label="Justificativa"
                       name={this.props.fieldJustificativa}
+                      className="form-control"
+                      required
+                      validate={composeValidators(
+                        textAreaRequired,
+                        peloMenosUmCaractere
+                      )}
                     />
                   </div>
                 </div>

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
@@ -76,7 +76,7 @@ export default class ModalNegarSolicitacao extends Component {
                     <Field
                       component={TextAreaWYSIWYG}
                       label="Justificativa"
-                      name="justificativa_negacao"
+                      name={this.props.fieldJustificativa}
                     />
                   </div>
                 </div>

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial/index.jsx
@@ -15,10 +15,7 @@ import {
 } from "../../../../../Shareable/Botao/constants";
 import Select from "../../../../../Shareable/Select";
 import { agregarDefault } from "../../../../../../helpers/utilities";
-import { getMotivosNegacaoDietaEspecial } from "../../../../../../services/painelNutricionista.service";
 import { formataMotivos } from "./helper";
-
-import { CODAENegaDietaEspecial } from "../../../../../../services/dietaEspecial.service";
 
 export default class ModalNegarSolicitacao extends Component {
   constructor(props) {
@@ -27,8 +24,8 @@ export default class ModalNegarSolicitacao extends Component {
   }
 
   onSubmit = async values => {
-    const { uuid } = this.props;
-    const resp = await CODAENegaDietaEspecial(uuid, values);
+    const { uuid, submitModal } = this.props;
+    const resp = await submitModal(uuid, values);
     if (resp.status === HTTP_STATUS.OK) {
       this.props.closeModal();
       toastSuccess("Solicitação negada com sucesso!");
@@ -41,7 +38,7 @@ export default class ModalNegarSolicitacao extends Component {
   };
 
   componentDidMount = async () => {
-    const motivosNegacao = await getMotivosNegacaoDietaEspecial();
+    const motivosNegacao = await this.props.getMotivos();
     this.setState({
       motivosNegacao: agregarDefault(formataMotivos(motivosNegacao.results))
     });
@@ -49,12 +46,11 @@ export default class ModalNegarSolicitacao extends Component {
 
   render() {
     const { motivosNegacao } = this.state;
-    const { showModalNegaDieta, closeModal } = this.props;
     return (
       <Modal
         dialogClassName="modal-90w"
-        show={showModalNegaDieta}
-        onHide={closeModal}
+        show={this.props.showModal}
+        onHide={this.props.closeModal}
       >
         <Modal.Header closeButton>
           <Modal.Title>Deseja negar a solicitação?</Modal.Title>
@@ -91,7 +87,7 @@ export default class ModalNegarSolicitacao extends Component {
                     <Botao
                       texto="Não"
                       type={BUTTON_TYPE.BUTTON}
-                      onClick={closeModal}
+                      onClick={this.props.closeModal}
                       style={BUTTON_STYLE.DARK_OUTLINE}
                       className="ml-3"
                     />

--- a/src/components/screens/DietaEspecial/Relatorio/helpers.js
+++ b/src/components/screens/DietaEspecial/Relatorio/helpers.js
@@ -11,7 +11,8 @@ const DESCRICAO_SOLICITACAO = {
   CANCELADO_ALUNO_MUDOU_ESCOLA:
     "Cancelamento para aluno não matriculado na Unidade Educacional",
   CANCELADO_ALUNO_NAO_PERTENCE_REDE:
-    "Cancelamento para aluno não matriculado na rede municipal"
+    "Cancelamento para aluno não matriculado na rede municipal",
+  CODAE_NEGOU_CANCELAMENTO: "Negada o Cancelamento"
 };
 
 export const cabecalhoDieta = (dietaEspecial, card) => {

--- a/src/components/screens/DietaEspecial/Relatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/index.jsx
@@ -321,6 +321,7 @@ const Relatorio = ({ visao }) => {
             CODAENegaSolicitacaoCancelamento(uuid, values)
           }
           fieldJustificativa={"justificativa"}
+          tituloModal={"Deseja negar a solicitação de cancelamento?"}
         />
       )}
       {dietaEspecial && (

--- a/src/components/screens/DietaEspecial/Relatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/index.jsx
@@ -8,6 +8,10 @@ import {
   getProtocoloDietaEspecial,
   getRelatorioDietaEspecial
 } from "services/relatorios";
+import {
+  CODAENegaSolicitacaoCancelamento,
+  getMotivosNegarSolicitacaoCancelamento
+} from "services/dietaEspecial.service";
 import { toastSuccess, toastError } from "components/Shareable/Toast/dialogs";
 import Botao from "components/Shareable/Botao";
 import {
@@ -260,16 +264,26 @@ const Relatorio = ({ visao }) => {
 
           {dietaEspecial &&
             status === statusEnum.ESCOLA_SOLICITOU_INATIVACAO &&
-            visao === CODAE && (
+            visao === CODAE && [
               <BotaoAutorizaCancelamento
+                key={0}
                 uuid={dietaEspecial.uuid}
                 showNaoAprovaModal={showNaoAprovaModal}
                 onAutorizar={() => {
                   loadSolicitacao(dietaEspecial.uuid);
                 }}
                 setCarregando={setCarregando}
-              />
-            )}
+              />,
+              <div className="form-group row float-right mt-4 mr-3" key={1}>
+                <Botao
+                  texto="Negar"
+                  type={BUTTON_TYPE.BUTTON}
+                  style={BUTTON_STYLE.RED}
+                  className="ml-3"
+                  onClick={() => setShowNaoAprovaModal(true)}
+                />
+              </div>
+            ]}
           {dietaEspecial &&
             visao === TERCEIRIZADA &&
             (status === statusEnum.CODAE_AUTORIZADO || dietaCancelada) && (
@@ -297,11 +311,15 @@ const Relatorio = ({ visao }) => {
       {dietaEspecial && (
         <ModalNegaDietaEspecial
           showModal={showNaoAprovaModal}
-          closeModal={setShowNaoAprovaModal}
+          closeModal={() => setShowNaoAprovaModal(false)}
           onNegar={() => {
             loadSolicitacao(dietaEspecial.uuid);
           }}
           uuid={dietaEspecial.uuid}
+          getMotivos={() => getMotivosNegarSolicitacaoCancelamento()}
+          submitModal={(uuid, values) =>
+            CODAENegaSolicitacaoCancelamento(uuid, values)
+          }
         />
       )}
       {dietaEspecial && (

--- a/src/components/screens/DietaEspecial/Relatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/index.jsx
@@ -320,6 +320,7 @@ const Relatorio = ({ visao }) => {
           submitModal={(uuid, values) =>
             CODAENegaSolicitacaoCancelamento(uuid, values)
           }
+          fieldJustificativa={"justificativa"}
         />
       )}
       {dietaEspecial && (

--- a/src/pages/DietaEspecial/RelatorioPage.jsx
+++ b/src/pages/DietaEspecial/RelatorioPage.jsx
@@ -5,7 +5,6 @@ import Page from "../../components/Shareable/Page/Page";
 import { ESCOLA, CODAE, TERCEIRIZADA } from "../../configs/constants";
 import { HOME } from "../Escola/constants";
 import ModalCancelaDietaEspecial from "../../components/screens/DietaEspecial/Relatorio/componentes/ModalCancelaDietaEspecial";
-import ModalNegarSolicitacao from "../../components/screens/DietaEspecial/Relatorio/componentes/ModalNegaDietaEspecial";
 import { ModalCODAEQuestiona } from "../../components/Shareable/ModalCODAEQuestiona";
 import {
   CODAENegaDietaEspecial,
@@ -57,7 +56,6 @@ export const RelatorioCODAE = () => (
   <RelatorioBase
     tituloPagina="Dieta Especial - Solicitação de Inclusão"
     visao={CODAE}
-    ModalNaoAprova={ModalNegarSolicitacao}
     ModalQuestionamento={ModalCODAEQuestiona}
     toastAprovaMensagem={"Autorização de Dieta Especial realizada com sucesso!"}
     toastAprovaMensagemErro={"Houve um erro ao autorizar a Dieta Especial"}

--- a/src/services/dietaEspecial.service.js
+++ b/src/services/dietaEspecial.service.js
@@ -99,14 +99,12 @@ export const CODAENegaDietaEspecial = async (uuid, payload) => {
 };
 
 export const CODAENegaSolicitacaoCancelamento = async (uuid, payload) => {
-  // TODO: Modificar endpoint para o desenvolvido pelo Luiz
-  const url = `${API_URL}/solicitacoes-dieta-especial/${uuid}/negar/`;
+  const url = `${API_URL}/solicitacoes-dieta-especial/${uuid}/negar-cancelamento-dieta-especial/`;
   return axios.post(url, payload);
 };
 
 export const getMotivosNegarSolicitacaoCancelamento = async () => {
-  // TODO: Modificar endpoint para o desenvolvido pelo Luiz
-  const url = `${API_URL}/motivos-negacao/`;
+  const url = `${API_URL}/motivos-negacao/?processo=CANCELAMENTO`;
   return retornoBase(url);
 };
 

--- a/src/services/dietaEspecial.service.js
+++ b/src/services/dietaEspecial.service.js
@@ -98,6 +98,18 @@ export const CODAENegaDietaEspecial = async (uuid, payload) => {
   return axios.post(url, payload);
 };
 
+export const CODAENegaSolicitacaoCancelamento = async (uuid, payload) => {
+  // TODO: Modificar endpoint para o desenvolvido pelo Luiz
+  const url = `${API_URL}/solicitacoes-dieta-especial/${uuid}/negar/`;
+  return axios.post(url, payload);
+};
+
+export const getMotivosNegarSolicitacaoCancelamento = async () => {
+  // TODO: Modificar endpoint para o desenvolvido pelo Luiz
+  const url = `${API_URL}/motivos-negacao/`;
+  return retornoBase(url);
+};
+
 export const terceirizadaTomaCienciaDietaEspecial = async uuid => {
   const url = `/solicitacoes-dieta-especial/${uuid}/tomar_ciencia/`;
   return axios.post(url);

--- a/src/services/painelNutricionista.service.js
+++ b/src/services/painelNutricionista.service.js
@@ -46,6 +46,6 @@ export const getTiposDietaEspecial = async () => {
 };
 
 export const getMotivosNegacaoDietaEspecial = async () => {
-  const url = `${API_URL}/motivos-negacao/`;
+  const url = `${API_URL}/motivos-negacao/?processo=INCLUSAO`;
   return retornoBase(url);
 };


### PR DESCRIPTION
# Proposta

Este PR visa adicionar a opção de negar uma solicitação de cancelamento de dieta especial no perfil "nutricodae"

# Referência do Azure

- 53045

# Tarefas para concluir

- [x] transformar modal nega solicitação em componente compartilhado
- [x] criar service para consultar motivos da negação de uma solicitação de cancelamento
- [x] fix warnings do corpo do relatório
- [x] criar service para negar solicitação de cancelamento
- [x] adicionar novas props ao chamar componente modal negar

