### PR TITLE
Fix: permitir adicionar mais de um anexo para laudo

### DIFF
--- a/src/components/screens/DietaEspecial/Escola/componentes/Laudo/index.jsx
+++ b/src/components/screens/DietaEspecial/Escola/componentes/Laudo/index.jsx
@@ -32,6 +32,7 @@ export default ({ pertence_a_escola }) => {
             name="anexos"
             accept=".png, .doc, .pdf, .docx, .jpeg, .jpg"
             validate={[required]}
+            concatenarNovosArquivos
             toastSuccessMessage={"Laudo incluído com sucesso"}
             disabled={pertence_a_escola !== true}
           />


### PR DESCRIPTION
# Proposta

Este PR visa permitir adicionar mais de um anexo ao cadastrar o laudo da dieta especial

# Referência do Azure

- 51775

# Tarefas para concluir

- [x] adicionar props para o componente de anexos