### PR TITLE
Fix: correção na exibição do botão para solicitações de kit lanche unificado cancelada

### DIFF
--- a/src/components/SolicitacaoUnificada/Relatorio/index.jsx
+++ b/src/components/SolicitacaoUnificada/Relatorio/index.jsx
@@ -178,9 +178,11 @@ class Relatorio extends Component {
     const EXIBIR_BOTAO_MARCAR_CONFERENCIA =
       visao === TERCEIRIZADA &&
       solicitacaoUnificada &&
-      [statusEnum.CODAE_AUTORIZADO, statusEnum.ESCOLA_CANCELOU].includes(
-        solicitacaoUnificada.status
-      );
+      [
+        statusEnum.CODAE_AUTORIZADO,
+        statusEnum.ESCOLA_CANCELOU,
+        statusEnum.DRE_CANCELOU
+      ].includes(solicitacaoUnificada.status);
 
     const BotaoMarcarConferencia = () => {
       return (

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -242,6 +242,7 @@ export const visualizaBotoesDoFluxo = solicitacao => {
         tipoPerfil
       );
     case statusEnum.ESCOLA_CANCELOU:
+    case statusEnum.DRE_CANCELOU:
       return [TIPO_PERFIL.TERCEIRIZADA].includes(tipoPerfil);
     default:
       return false;
@@ -262,6 +263,7 @@ export const visualizaBotoesDoFluxoSolicitacaoUnificada = solicitacao => {
     case statusEnum.CODAE_QUESTIONADO:
       return [TIPO_PERFIL.TERCEIRIZADA].includes(tipoPerfil);
     case statusEnum.ESCOLA_CANCELOU:
+    case statusEnum.DRE_CANCELOU:
       return [TIPO_PERFIL.TERCEIRIZADA].includes(tipoPerfil);
     case statusEnum.TERCEIRIZADA_TOMOU_CIENCIA:
       return [TIPO_PERFIL.DIRETORIA_REGIONAL].includes(tipoPerfil);


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição do botão marcar conferência nas solicitações canceladas de Kit Lanche Passeio Unificado

# Referência do Azure

- 50213

# Tarefas para concluir

- [x]  ajustar exibição dos botões