### PR TITLE
Feature/54008-GA-visualização-campo-de-informações-na-solicitação-de-inversão-de-cardápio

### DIFF
--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -10,6 +10,7 @@ import {
 
 import { getDetalheInversaoCardapio } from "../../../../services/relatorios";
 import { fluxoPartindoEscola } from "../../../Shareable/FluxoDeStatus/helper";
+import { statusEnum } from "constants/shared";
 
 export const CorpoRelatorio = props => {
   const {
@@ -135,6 +136,33 @@ export const CorpoRelatorio = props => {
           />
         </div>
       </div>
+      {inversaoDiaCardapio.logs &&
+        !inversaoDiaCardapio.foi_solicitado_fora_do_prazo &&
+        inversaoDiaCardapio.status === statusEnum.CODAE_AUTORIZADO && (
+          <div className="row">
+            <div className="col-12 report-label-value">
+              <p>
+                <b>Autorizou</b>
+              </p>
+              <div>
+                {
+                  inversaoDiaCardapio.logs[inversaoDiaCardapio.logs.length - 1]
+                    .criado_em
+                }{" "}
+                - Informações da CODAE
+              </div>
+              <p
+                className="value"
+                dangerouslySetInnerHTML={{
+                  __html:
+                    inversaoDiaCardapio.logs[
+                      inversaoDiaCardapio.logs.length - 1
+                    ].justificativa
+                }}
+              />
+            </div>
+          </div>
+        )}
     </div>
   );
 };

--- a/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
+++ b/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
@@ -64,9 +64,12 @@ export const RelatorioHistoricoQuestionamento = props => {
                     <div className="is-it-possible">
                       <div className="title">Autorizou</div>
                       {log.justificativa && (
-                        <div className="obs">
-                          Observação da CODAE: {log.justificativa}
-                        </div>
+                        <div
+                          className="obs"
+                          dangerouslySetInnerHTML={{
+                            __html: `Informações da CODAE: ${log.justificativa}`
+                          }}
+                        />
                       )}
                     </div>
                   )}


### PR DESCRIPTION
# Proposta

Este PR visa incluir campo de informações da codae no corpo do relatório e no histórico de questionamento - inversão de cardápio

# Referência do Azure

- 54008

# Tarefas para concluir

- [x] Incluir campo de informações da codae no corpo do relatório e no histórico de questionamento - inversão de cardápio