### PR TITLE
Fix: não deve permitir adicionar a escola de destino igual a de origem

### DIFF
--- a/src/components/screens/DietaEspecial/AlteracaoUE/components/FormCadastro/index.jsx
+++ b/src/components/screens/DietaEspecial/AlteracaoUE/components/FormCadastro/index.jsx
@@ -84,6 +84,12 @@ export default ({
       setDadosIniciais({ ...values, nome_escola: undefined });
       return;
     }
+
+    if (codigoEol === meusDadosEscola.codigo_eol) {
+      setDadosIniciais({ ...values, nome_escola: undefined });
+      toastError("Escola de destino deve ser diferente da escola de origem.");
+      return;
+    }
     setCarregandoEscola(true);
 
     const params = { codigo_eol: codigoEol };


### PR DESCRIPTION
# Proposta

Este PR visa impedir de adicionar no campo escola destino a mesma escola de origem da dieta.

# Referência do Azure

- 54036

# Tarefas para concluir

- [x] adicionar validação para consulta de escola na solicitação de alteração de UE.