### PR TITLE
Feature/53752 ver mais aguardando vigencia

### DIFF
--- a/src/components/screens/DashBoardDietaEspecial/StatusSolicitacoes.jsx
+++ b/src/components/screens/DashBoardDietaEspecial/StatusSolicitacoes.jsx
@@ -24,6 +24,7 @@ import {
   DIETA_ESPECIAL_SOLICITACOES,
   SOLICITACOES_AUTORIZADAS_TEMPORARIAMENTE,
   SOLICITACOES_INATIVAS_TEMPORARIAMENTE,
+  SOLICITACOES_AGUARDANDO_INICIO_VIGENCIA,
   INATIVAS_TEMPORARIAMENTE_DIETA,
   SOLICITACOES_INATIVAS,
   INATIVAS_DIETA
@@ -269,6 +270,26 @@ export class StatusSolicitacoes extends Component {
                 urlPaginacao: this.retornaUrlPaginacao(
                   visao,
                   AUTORIZADAS_TEMPORARIAMENTE_DIETA
+                )
+              });
+            });
+          break;
+        case SOLICITACOES_AGUARDANDO_INICIO_VIGENCIA:
+          this.props
+            .getDietaEspecialAguardandoVigencia(instituicao.uuid)
+            .then(response => {
+              this.setState({
+                solicitacoes: ajustarFormatoLog(
+                  response.data.results,
+                  "aguardando-inicio-vigencia"
+                ),
+                count: response.data.count,
+                tipoCard: CARD_TYPE_ENUM.AGUARDANDO_ANALISE_RECLAMACAO,
+                icone: ICON_CARD_TYPE_ENUM.AGUARDANDO_ANALISE_RECLAMACAO,
+                titulo: "Aguardando início da vigência",
+                urlPaginacao: this.retornaUrlPaginacao(
+                  visao,
+                  SOLICITACOES_AGUARDANDO_INICIO_VIGENCIA
                 )
               });
             });

--- a/src/components/screens/DashBoardDietaEspecial/index.jsx
+++ b/src/components/screens/DashBoardDietaEspecial/index.jsx
@@ -480,7 +480,7 @@ class DashBoardDietaEspecial extends Component {
                           : []
                       }
                       icon={ICON_CARD_TYPE_ENUM.AGUARDANDO_ANALISE_RECLAMACAO}
-                      href={`/solicitacoes-dieta-especial/solicitacoes-autorizadas-temporariamente`}
+                      href={`/solicitacoes-dieta-especial/solicitacoes-aguardando-inicio-vigencia`}
                     />
                   </div>
                 )}

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -688,6 +688,14 @@ const routesConfig = [
   },
   {
     path: `/${constants.SOLICITACOES_DIETA_ESPECIAL}/${
+      constants.SOLICITACOES_AGUARDANDO_INICIO_VIGENCIA
+    }`,
+    component: StatusSolicitacoesDietaEspecial(),
+    exact: true,
+    tipoUsuario: constants.QUALQUER_USUARIO
+  },
+  {
+    path: `/${constants.SOLICITACOES_DIETA_ESPECIAL}/${
       constants.SOLICITACOES_INATIVAS
     }`,
     component: StatusSolicitacoesDietaEspecial(),

--- a/src/configs/constants.js
+++ b/src/configs/constants.js
@@ -31,6 +31,8 @@ export const SOLICITACOES_NEGADAS = "solicitacoes-negadas";
 export const SOLICITACOES_CANCELADAS = "solicitacoes-canceladas";
 export const SOLICITACOES_AUTORIZADAS = "solicitacoes-autorizadas";
 export const QUESTIONAMENTOS_CODAE = "questionamentos-codae";
+export const SOLICITACOES_AGUARDANDO_INICIO_VIGENCIA =
+  "solicitacoes-aguardando-inicio-vigencia";
 export const SOLICITACOES_AUTORIZADAS_TEMPORARIAMENTE =
   "solicitacoes-autorizadas-temporariamente";
 export const SOLICITACOES_INATIVAS_TEMPORARIAMENTE =

--- a/src/pages/DietaEspecial/StatusSolicitacoesPage.jsx
+++ b/src/pages/DietaEspecial/StatusSolicitacoesPage.jsx
@@ -32,7 +32,9 @@ import {
   getDietaEspecialPendenteAutorizacaoCODAE,
   getDietaEspecialPendenteAutorizacaoDRE,
   getDietaEspecialPendenteAutorizacaoEscola,
-  getDietaEspecialPendenteAutorizacaoTerceirizada
+  getDietaEspecialPendenteAutorizacaoTerceirizada,
+  getDietaEspecialAguardandoVigenciaTerceirizada,
+  getDietaEspecialAguardandoVigenciaEscola
 } from "../../services/dashBoardDietaEspecial.service";
 
 export const HOME = "/painel-dieta-especial";
@@ -83,6 +85,9 @@ export const SolicitacoesDietaEspecialEscola = () => (
       getDietaEspecialInativasTemporariamenteEscola
     }
     getDietaEspecialInativas={getDietaEspecialInativasEscola}
+    getDietaEspecialAguardandoVigencia={
+      getDietaEspecialAguardandoVigenciaEscola
+    }
   />
 );
 
@@ -144,5 +149,8 @@ export const SolicitacoesDietaEspecialTerceirizada = () => (
       getDietaEspecialInativasTemporariamenteTerceirizada
     }
     getDietaEspecialInativas={getDietaEspecialInativasTerceirizada}
+    getDietaEspecialAguardandoVigencia={
+      getDietaEspecialAguardandoVigenciaTerceirizada
+    }
   />
 );


### PR DESCRIPTION
# Proposta

Este PR visa adicionar a renderização de solicitações aguardando início da vigência ao clicar no "ver mais" do card com os perfis TERCEIRIZADAS e ESCOLA.

# Referência do Azure

- 53752

# Tarefas para concluir

- [x] adicionar rotas
- [x] services para popular solicitações para Terceirizadas e Escolas
- [x] renderizar componente para solicitações aguardando início da vigência