### PR TITLE
Fix/54140-GA-quantidade-de-dietas-cadastradas-diferente-ao-cadastrar-kit-lanche

### DIFF
--- a/src/components/SolicitacaoDeKitLanche/Container/base.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Container/base.jsx
@@ -204,7 +204,7 @@ export class SolicitacaoDeKitLanche extends Component {
     const resposta = await getDietasAtivasInativasPorAluno();
     if (resposta.status === 200) {
       this.setState({
-        alunosComDietaEspecial: resposta.data.results.solicitacoes.filter(
+        alunosComDietaEspecial: resposta.data.solicitacoes.filter(
           s => s.ativas > 0
         )
       });

--- a/src/components/screens/DietaEspecial/AtivasInativasPorAluno/index.jsx
+++ b/src/components/screens/DietaEspecial/AtivasInativasPorAluno/index.jsx
@@ -43,7 +43,7 @@ const AtivasInativasPorAluno = ({
     if (firstLoad) {
       if (history && history.action === "PUSH") reset();
       setFirstLoad(false);
-    } else if (filtros) fetchData(filtros);
+    } else if (filtros) fetchData({ ...filtros, page: 1 });
   }, [filtros]);
 
   const fetchData = async filtros => {


### PR DESCRIPTION
# Proposta

Este PR visa ajustar a quantidade de alunos com dieta especial no seletor de cadastrar kit lanche

# Referência do Azure

- 54140

# Tarefas para concluir

- [x] ajustar para mostrar todos os alunos com dieta especial no seletor
- [x] ajustar para enviar parâmetro page no useEffect