### PR TITLE
Feature/55117-GA-retirar-acesso-ao-modulo-GA-das-escolas-tipo-gestao-mista-e-parceira

### DIFF
--- a/src/components/Shareable/Sidebar/SidebarContent.jsx
+++ b/src/components/Shareable/Sidebar/SidebarContent.jsx
@@ -15,7 +15,8 @@ import {
   usuarioEhAdministradorNutriSupervisao,
   usuarioEhDistribuidora,
   usuarioComAcessoTelaEntregasDilog,
-  usuarioEhCoordenadorNutriSupervisao
+  usuarioEhCoordenadorNutriSupervisao,
+  usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 import { ListItem } from "./menus/shared";
 import {
@@ -54,7 +55,7 @@ export const SidebarContent = () => {
     !ehTreinamento &&
     (usuarioEhCODAEGestaoAlimentacao() ||
       usuarioEhDRE() ||
-      usuarioEhEscola() ||
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
       usuarioEhTerceirizada());
   const exibirDietaEspecial =
     usuarioEhCODAEGestaoAlimentacao() ||

--- a/src/components/Shareable/Sidebar/menus/MenuGestaoDeAlimentacao.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuGestaoDeAlimentacao.jsx
@@ -22,11 +22,14 @@ import {
 import {
   usuarioEhCODAEGestaoAlimentacao,
   usuarioEhDRE,
-  usuarioEhEscola
+  usuarioEhEscola,
+  usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 
 const MenuGestaoDeAlimentacao = ({ activeMenu, onSubmenuClick }) => {
-  const exibeMenuNovasSolicitacoes = usuarioEhEscola() || usuarioEhDRE();
+  const exibeMenuNovasSolicitacoes =
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    usuarioEhDRE();
   const PERFIL = usuarioEhEscola()
     ? ESCOLA
     : usuarioEhDRE()

--- a/src/components/screens/PainelInicial/index.jsx
+++ b/src/components/screens/PainelInicial/index.jsx
@@ -12,7 +12,8 @@ import {
   usuarioEhCODAEGestaoAlimentacao,
   usuarioEhCODAEDietaEspecial,
   usuarioEhDRE,
-  usuarioEhNutricionistaSupervisao
+  usuarioEhNutricionistaSupervisao,
+  usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 import { ENVIRONMENT } from "constants/config";
 
@@ -25,7 +26,7 @@ const PainelInicial = ({ history }) => {
         (usuarioEhCODAEGestaoAlimentacao() ||
           usuarioEhTerceirizada() ||
           usuarioEhDRE() ||
-          usuarioEhEscola()) && (
+          (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())) && (
           <Col xs={24} sm={24} md={24} lg={8} xl={8}>
             <CardLogo
               titulo={"Gestão de Alimentação"}

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -96,7 +96,8 @@ import {
   usuarioEhLogistica,
   usuarioEhDistribuidora,
   usuarioComAcessoTelaEntregasDilog,
-  usuarioEhCoordenadorNutriSupervisao
+  usuarioEhCoordenadorNutriSupervisao,
+  usuarioEscolaEhGestaoMistaParceira
 } from "../helpers/utilities";
 import CadastroProdutoPage from "../pages/Produto/CadastroProdutoPage";
 import AtualizacaoProdutoFormPage from "../pages/Produto/AtualizacaoProdutoFormPage";
@@ -167,7 +168,7 @@ const routesConfig = [
     component: painelGestaoAlimentacao(),
     exact: true,
     tipoUsuario:
-      usuarioEhEscola() ||
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
       usuarioEhDRE() ||
       usuarioEhCODAEGestaoAlimentacao() ||
       usuarioEhTerceirizada()
@@ -213,62 +214,62 @@ const routesConfig = [
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_AUTORIZADAS}`,
     component: StatusSolicitacoesAutorizadasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_PENDENTES}`,
     component: StatusSolicitacoesPendentesEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_CANCELADAS}`,
     component: StatusSolicitacoesCanceladasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_NEGADAS}`,
     component: StatusSolicitacoesRecusadasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/status-solicitacoes`,
     component: StatusSolicitacoesPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.INCLUSAO_ALIMENTACAO}`,
     component: inclusaoCardapio(),
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.ALTERACAO_TIPO_ALIMENTACAO}`,
     component: alteracaoCardapio(),
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACAO_KIT_LANCHE}`,
     //AQUI POW
     component: PainelPageKitLanche.PainelPedidosEscola,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.INVERSAO_CARDAPIO}`,
     component: RelatorioPageInversaoDiaCardapio.InversaoDeDiaDeCardapioPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SUSPENSAO_ALIMENTACAO}`,
     component: suspensaoAlimentacao(),
     exact: false,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${constants.DRE}/${constants.SOLICITACOES}`,

--- a/src/constants/shared.js
+++ b/src/constants/shared.js
@@ -72,6 +72,13 @@ export const TIPO_USUARIO = {
   TERCEIRIZADA: `terceirizada`
 };
 
+export const TIPO_GESTAO = {
+  PARCEIRA: `"PARCEIRA"`,
+  DIRETA: `"DIRETA"`,
+  MISTA: `"MISTA"`,
+  TERC_TOTAL: `"TERC TOTAL"`
+};
+
 export const TIPODECARD = {
   PRIORIDADE: "priority",
   NO_LIMITE: "on-limit",

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -2,7 +2,7 @@ import moment from "moment";
 import { createTextMask } from "redux-form-input-masks";
 import "moment/locale/pt-br";
 import { statusEnum, TIPO_SOLICITACAO } from "constants/shared";
-import { PERFIL, TIPO_PERFIL } from "../constants/shared";
+import { PERFIL, TIPO_PERFIL, TIPO_GESTAO } from "../constants/shared";
 import { RELATORIO } from "../configs/constants";
 
 // TODO: Quebrar esse arquivo, tem muitos helpers de diferentes tipo num único arquivo
@@ -335,6 +335,12 @@ export const usuarioEhEscola = () => {
     PERFIL.DIRETOR,
     PERFIL.DIRETOR_CEI
   ].includes(localStorage.getItem("perfil"));
+};
+
+export const usuarioEscolaEhGestaoMistaParceira = () => {
+  return [TIPO_GESTAO.MISTA, TIPO_GESTAO.PARCEIRA].includes(
+    localStorage.getItem("tipo_gestao")
+  );
 };
 
 export const usuarioEhEscolaAbastecimento = () => {

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -44,6 +44,10 @@ const login = async (email, password) => {
             "perfil",
             JSON.stringify(result.vinculo_atual.perfil.nome)
           );
+          localStorage.setItem(
+            "tipo_gestao",
+            JSON.stringify(result.vinculo_atual.instituicao.tipo_gestao)
+          );
           window.location.href = "/";
         });
       });


### PR DESCRIPTION
# Proposta

Este PR visa retirar acesso ao módulo de gestão de alimentação das escolas com tipo de gestão mista e parceira

# Referência do Azure

- 55117

# Tarefas para concluir

- [x] Incluir chave tipo_gestao no localStorage
- [x] Bloquear rotas de gestão de alimentação para escolas de gestão mista ou parceira
- [x] Remover painel de gestão de alimentação do dashboard e do menu lateral para escolas de gestão mista ou parceira