### PR TITLE
Feature/55118-PD-retirar-acesso-ao-módulo-PD-das-escolas-tipo-gestão-mista-e-parceira

### DIFF
--- a/src/components/Shareable/Sidebar/SidebarContent.jsx
+++ b/src/components/Shareable/Sidebar/SidebarContent.jsx
@@ -69,7 +69,7 @@ export const SidebarContent = () => {
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhNutricionistaSupervisao() ||
-    usuarioEhEscola() ||
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
     usuarioEhDRE() ||
     usuarioEhTerceirizada();
   const exibirLancamentoInicial =

--- a/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
@@ -13,17 +13,20 @@ import {
   usuarioEhEscola,
   usuarioEhTerceirizada,
   usuarioEhCODAEGestaoProduto,
-  usuarioEhNutricionistaSupervisao
+  usuarioEhNutricionistaSupervisao,
+  usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 
-const MenuGestaoDeAlimentacao = ({ activeMenu, onSubmenuClick }) => {
+const MenuGestaoDeProduto = ({ activeMenu, onSubmenuClick }) => {
   const menuItems = listarCardsPermitidos();
   const exibirBusca = true;
   const exibirCadastro = usuarioEhTerceirizada();
   const exibirAvaliarReclamacao = usuarioEhCODAEGestaoProduto();
   const exibirReclamacao =
-    usuarioEhNutricionistaSupervisao() || usuarioEhEscola();
-  const exibirReclamacaoUE = usuarioEhEscola();
+    usuarioEhNutricionistaSupervisao() ||
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira());
+  const exibirReclamacaoUE =
+    usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira();
   const exibirReclamacaoNutrisupervisao = usuarioEhNutricionistaSupervisao();
   const exibirAtivacao = usuarioEhCODAEGestaoProduto();
   const exibirResponderReclamacao = usuarioEhTerceirizada();
@@ -104,4 +107,4 @@ const MenuGestaoDeAlimentacao = ({ activeMenu, onSubmenuClick }) => {
   );
 };
 
-export default MenuGestaoDeAlimentacao;
+export default MenuGestaoDeProduto;

--- a/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
@@ -7,7 +7,8 @@ import {
   usuarioEhNutricionistaSupervisao,
   usuarioEhTerceirizada,
   usuarioEhEscola,
-  usuarioEhDRE
+  usuarioEhDRE,
+  usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 import * as constants from "configs/constants";
 
@@ -16,7 +17,7 @@ const MenuRelatorios = () => {
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhCODAEGestaoAlimentacao() ||
     usuarioEhCODAEGestaoProduto() ||
-    usuarioEhEscola() ||
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhTerceirizada();
 
@@ -28,7 +29,7 @@ const MenuRelatorios = () => {
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhTerceirizada() ||
-    usuarioEhEscola() ||
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
     usuarioEhCODAEDietaEspecial();
 
   const exibirRelatorioQuantitativoSolicDietaEsp =

--- a/src/components/screens/PainelInicial/index.jsx
+++ b/src/components/screens/PainelInicial/index.jsx
@@ -56,7 +56,7 @@ const PainelInicial = ({ history }) => {
         usuarioEhTerceirizada() ||
         usuarioEhNutricionistaSupervisao() ||
         usuarioEhDRE() ||
-        usuarioEhEscola()) && (
+        (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())) && (
         <Col xs={24} sm={24} md={24} lg={8} xl={8}>
           <CardLogo
             titulo={"Gestão de Produto"}

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -733,7 +733,9 @@ const routesConfig = [
     path: `/${constants.PESQUISA_DESENVOLVIMENTO}/${constants.BUSCA_PRODUTO}`,
     component: BuscaAvancadaProdutoPage,
     exact: true,
-    tipoUsuario: constants.QUALQUER_USUARIO
+    tipoUsuario:
+      constants.QUALQUER_USUARIO &&
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -773,7 +775,9 @@ const routesConfig = [
     }`,
     component: RelatorioProduto,
     exact: true,
-    tipoUsuario: constants.QUALQUER_USUARIO
+    tipoUsuario:
+      constants.QUALQUER_USUARIO &&
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -781,7 +785,9 @@ const routesConfig = [
     }`,
     component: RelatorioSituacaoProduto,
     exact: true,
-    tipoUsuario: constants.QUALQUER_USUARIO
+    tipoUsuario:
+      constants.QUALQUER_USUARIO &&
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -794,13 +800,13 @@ const routesConfig = [
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/responder-questionamento-ue`,
     component: ResponderQuestionamentoUEPage,
     exact: true,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
   },
   {
     path: `/${
@@ -829,7 +835,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhDRE() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -843,7 +849,7 @@ const routesConfig = [
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -858,7 +864,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhDRE() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -879,7 +885,7 @@ const routesConfig = [
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -912,7 +918,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -928,7 +934,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: "/painel-gestao-produto",
@@ -940,7 +946,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhTerceirizada() ||
-      usuarioEhEscola() ||
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
       usuarioEhDRE()
   },
   {
@@ -950,7 +956,7 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${constants.SUSPENSAO_DE_PRODUTO}`,
@@ -961,7 +967,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhTerceirizada() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -986,8 +992,8 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhQualquerCODAE() ||
       usuarioEhTerceirizada() ||
-      usuarioEhEscola() ||
-      usuarioEhNutricionistaSupervisao
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      usuarioEhNutricionistaSupervisao()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/responder-reclamacao/consulta`,


### PR DESCRIPTION
# Proposta

Este PR visa retirar acesso ao módulo de gestão de produto das escolas com tipo de gestão mista e parceira

# Referência do Azure

- 55118

# Tarefas para concluir

- [x] Bloquear rotas de produtos para escolas de gestão mista ou parceira 
- [x] Retirar painel de gestão de produto do dashboard e do menu lateral para escolas de gestão mista ou parceira
- [x] Retirar relatórios de produtos do menu lateral para escolas de gestão mista ou parceira