### PR TITLE
Bugfix/56554 erro ao salvar justificativa

### DIFF
--- a/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -1,6 +1,10 @@
 import React, { Fragment } from "react";
 import { FluxoDeStatus } from "../../../Shareable/FluxoDeStatus";
-import { corDaMensagem, ehInclusaoCei } from "../../../../helpers/utilities";
+import {
+  corDaMensagem,
+  ehInclusaoCei,
+  justificativaAoNegarSolicitacao
+} from "../../../../helpers/utilities";
 import Botao from "../../../Shareable/Botao";
 import {
   BUTTON_STYLE,
@@ -13,6 +17,11 @@ import TabelaFaixaEtaria from "../../../Shareable/TabelaFaixaEtaria";
 
 export const CorpoRelatorio = props => {
   const { alteracaoDeCardapio, prazoDoPedidoMensagem, tipoSolicitacao } = props;
+
+  const justificativaNegacao = justificativaAoNegarSolicitacao(
+    alteracaoDeCardapio.logs
+  );
+
   return (
     <div>
       <div className="row">
@@ -181,6 +190,23 @@ export const CorpoRelatorio = props => {
           </td>
         </tr>
       </table>
+      {justificativaNegacao && (
+        <table className="table-periods">
+          <tr>
+            <th>Justificativa da rejeição</th>
+          </tr>
+          <tr>
+            <td>
+              <p
+                className="value"
+                dangerouslySetInnerHTML={{
+                  __html: justificativaNegacao
+                }}
+              />
+            </td>
+          </tr>
+        </table>
+      )}
     </div>
   );
 };

--- a/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
@@ -4,7 +4,8 @@ import {
   corDaMensagem,
   stringSeparadaPorVirgulas,
   ehInclusaoContinua,
-  ehInclusaoCei
+  ehInclusaoCei,
+  justificativaAoNegarSolicitacao
 } from "helpers/utilities";
 import Botao from "../../../Shareable/Botao";
 import {
@@ -97,6 +98,10 @@ export class CorpoRelatorio extends Component {
         observacao
       }
     } = this.props;
+
+    const justificativaNegacao = justificativaAoNegarSolicitacao(
+      this.props.inclusaoDeAlimentacao.logs
+    );
     return (
       <div>
         <div className="row">
@@ -219,6 +224,19 @@ export class CorpoRelatorio extends Component {
             />
           </div>
         </div>
+        {justificativaNegacao && (
+          <div className="row">
+            <div className="col-12 report-label-value">
+              <p>Justificativa da rejeição</p>
+              <p
+                className="value"
+                dangerouslySetInnerHTML={{
+                  __html: justificativaNegacao
+                }}
+              />
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -1,6 +1,9 @@
 import React from "react";
 import { FluxoDeStatus } from "../../../Shareable/FluxoDeStatus";
-import { corDaMensagem } from "../../../../helpers/utilities";
+import {
+  corDaMensagem,
+  justificativaAoNegarSolicitacao
+} from "../../../../helpers/utilities";
 import Botao from "../../../Shareable/Botao";
 import {
   BUTTON_TYPE,
@@ -18,6 +21,10 @@ export const CorpoRelatorio = props => {
     prazoDoPedidoMensagem,
     escolaDaInversao
   } = props;
+
+  const justificativaNegacao = justificativaAoNegarSolicitacao(
+    inversaoDiaCardapio.logs
+  );
   return (
     <div>
       <div className="row">
@@ -163,6 +170,19 @@ export const CorpoRelatorio = props => {
             </div>
           </div>
         )}
+      {justificativaNegacao && (
+        <div className="row">
+          <div className="col-12 report-label-value">
+            <p>Justificativa da rejeição</p>
+            <p
+              className="value"
+              dangerouslySetInnerHTML={{
+                __html: justificativaNegacao
+              }}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/SolicitacaoDeKitLanche/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Relatorio/componentes/CorpoRelatorio.jsx
@@ -204,7 +204,7 @@ export const CorpoRelatorio = props => {
       {justificativaNegacao && (
         <div className="row">
           <div className="col-12 report-label-value">
-            <p>Justificativa do cancelamento da solicitação</p>
+            <p>Justificativa da rejeição</p>
             <p
               className="value"
               dangerouslySetInnerHTML={{

--- a/src/components/SolicitacaoUnificada/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/SolicitacaoUnificada/Relatorio/componentes/CorpoRelatorio.jsx
@@ -149,9 +149,7 @@ export const CorpoRelatorio = props => {
           </div>
           {justificativaNegacao && (
             <div>
-              <div className="descricao-titulo">
-                Justificativa do cancelamento da solicitação
-              </div>
+              <div className="descricao-titulo">Justificativa da rejeição</div>
               <div
                 className="descricao-texto"
                 dangerouslySetInnerHTML={{

--- a/src/services/inclusaoDeAlimentacao/dre.service.js
+++ b/src/services/inclusaoDeAlimentacao/dre.service.js
@@ -46,7 +46,8 @@ export const dreValidarSolicitacaoDeInclusaoDeAlimentacao = (
   let status = 0;
   return fetch(url, {
     method: "PATCH",
-    headers: AUTH_TOKEN
+    headers: AUTH_TOKEN,
+    body: JSON.stringify({ justificativa })
   })
     .then(res => {
       status = res.status;
@@ -69,7 +70,8 @@ export const dreReprovarSolicitacaoDeInclusaoDeAlimentacao = (
   let status = 0;
   return fetch(url, {
     method: "PATCH",
-    headers: AUTH_TOKEN
+    headers: AUTH_TOKEN,
+    body: JSON.stringify({ justificativa })
   })
     .then(res => {
       status = res.status;


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o envio da justificativa no payload da rejeição da validação de inclusão de alimentação

# Referência do Azure

- 56554

# Tarefas para concluir

- [x]  Enviar justificativa no service de Inclusão de alimentação.
- [x] Corrigir título do label.
- [x]  Adicionar bloco justificativa nos relatórios de Inclusão de Alimentação, Inversão de Cardápio e Alteração de Dia da Alimentação.