### PR TITLE
Bugfix/55020-GA-remover-tags-html-histórico-questionamento-justificativa-codae

### DIFF
--- a/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
+++ b/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
@@ -40,11 +40,13 @@ export const RelatorioHistoricoQuestionamento = props => {
                         É possível atender a solicitação com todos os itens
                         previstos no contrato?
                       </div>
-                      <div className="obs">
-                        Observação da CODAE:{" "}
-                        {log.justificativa ||
-                          "Sem observações por parte da CODAE"}
-                      </div>
+                      <div
+                        className="obs"
+                        dangerouslySetInnerHTML={{
+                          __html: `Observação da CODAE: ${log.justificativa ||
+                            "Sem observações por parte da CODAE"}`
+                        }}
+                      />
                     </div>
                   )}
                   {log.status_evento_explicacao ===


### PR DESCRIPTION
# Proposta

Este PR visa remover tags html de observações codae no histórico de questionamento da página de relatório de Inversão de dia de Cardápio

# Referência do Azure

- 55020

# Tarefas para concluir

- [x] Remover tags html de observações codae no histórico de questionamento