### PR TITLE
Hom - Atualizado até 14/01 as 17:00

### DIFF
--- a/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
+++ b/src/components/Shareable/RelatorioHistoricoQuestionamento/index.jsx
@@ -40,11 +40,13 @@ export const RelatorioHistoricoQuestionamento = props => {
                         É possível atender a solicitação com todos os itens
                         previstos no contrato?
                       </div>
-                      <div className="obs">
-                        Observação da CODAE:{" "}
-                        {log.justificativa ||
-                          "Sem observações por parte da CODAE"}
-                      </div>
+                      <div
+                        className="obs"
+                        dangerouslySetInnerHTML={{
+                          __html: `Observação da CODAE: ${log.justificativa ||
+                            "Sem observações por parte da CODAE"}`
+                        }}
+                      />
                     </div>
                   )}
                   {log.status_evento_explicacao ===

--- a/src/components/screens/Notificacoes/components/CardNotificacao/index.jsx
+++ b/src/components/screens/Notificacoes/components/CardNotificacao/index.jsx
@@ -93,19 +93,21 @@ export default ({
           </div>
           <div className="row acoes-notificacoes">
             <div className="checkbox-container">
-              <Checkbox
-                defaultChecked={notificacao.lido}
-                style={{
-                  fontSize: "16px",
-                  paddingTop: "10px",
-                  paddingLeft: "12px"
-                }}
-                onChange={() => {
-                  handleChangeMarcarComoLida(notificacao, index);
-                }}
-              >
-                Marcar como lida
-              </Checkbox>
+              {notificacao.tipo !== "Pendência" && (
+                <Checkbox
+                  defaultChecked={notificacao.lido}
+                  style={{
+                    fontSize: "16px",
+                    paddingTop: "10px",
+                    paddingLeft: "12px"
+                  }}
+                  onChange={() => {
+                    handleChangeMarcarComoLida(notificacao, index);
+                  }}
+                >
+                  Marcar como lida
+                </Checkbox>
+              )}
             </div>
             {notificacao.link && (
               <Link to={notificacao.link}>


### PR DESCRIPTION
# Proposta

Este PR visa remover tags html de observações codae no histórico de questionamento da página de relatório de Inversão de dia de Cardápio

# Referência do Azure

- 55020

# Tarefas para concluir

- [x] Remover tags html de observações codae no histórico de questionamento