### PR TITLE
Feature/53994-PD-criar-cards-de-responder-questionamentos-da-codae

### DIFF
--- a/src/components/Shareable/CardStatusDeSolicitacao/CardStatusDeSolicitacao.jsx
+++ b/src/components/Shareable/CardStatusDeSolicitacao/CardStatusDeSolicitacao.jsx
@@ -2,6 +2,11 @@ import React from "react";
 import { useHistory, NavLink } from "react-router-dom";
 import "./style.scss";
 import { conferidaClass } from "helpers/terceirizadas";
+import { GESTAO_PRODUTO_CARDS, TERCEIRIZADA } from "configs/constants";
+import {
+  ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS,
+  TIPO_PERFIL
+} from "constants/shared";
 
 export const CARD_TYPE_ENUM = {
   CANCELADO: "card-cancelled",
@@ -36,7 +41,70 @@ export const CardStatusDeSolicitacao = props => {
     loading,
     hrefCard
   } = props;
+
+  const nomeUsuario = localStorage.getItem("nome");
+  const tipoPerfil = localStorage.getItem("tipo_perfil");
+
   let history = useHistory();
+  let filteredSolicitations = [];
+
+  if (cardTitle === GESTAO_PRODUTO_CARDS.RESPONDER_QUESTIONAMENTOS_DA_CODAE) {
+    if (tipoPerfil === `"${TERCEIRIZADA}"`) {
+      filteredSolicitations = solicitations.filter(
+        solicitation =>
+          ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS.CODAE_PEDIU_ANALISE_RECLAMACAO.toUpperCase() ===
+          solicitation.status
+      );
+    } else if (tipoPerfil === TIPO_PERFIL.SUPERVISAO_NUTRICAO) {
+      filteredSolicitations = solicitations.filter(
+        solicitation =>
+          ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS.CODAE_QUESTIONOU_NUTRISUPERVISOR.toUpperCase() ===
+          solicitation.status
+      );
+    } else {
+      filteredSolicitations = solicitations.filter(
+        solicitation =>
+          nomeUsuario === `"${solicitation.nome_usuario_log_de_reclamacao}"` &&
+          ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS.CODAE_QUESTIONOU_UE.toUpperCase() ===
+            solicitation.status
+      );
+    }
+  }
+
+  const renderSolicitations = solicitations => {
+    return solicitations.slice(0, 5).map((solicitation, key) => {
+      let conferida = conferidaClass(solicitation, cardTitle);
+      return (
+        <NavLink
+          to={solicitation.link}
+          key={key}
+          data-cy={`${cardType}-${key}`}
+        >
+          <p className={`data ${conferida}`}>
+            {solicitation.text}
+            <span className="float-right">{solicitation.date}</span>
+          </p>
+        </NavLink>
+      );
+    });
+  };
+
+  const renderVerMais = solicitations => {
+    return (
+      solicitations.length > 5 && (
+        <div className="container-link">
+          <NavLink
+            to={`${href}`}
+            className="see-more"
+            data-cy={`ver-mais-${cardType}`}
+          >
+            Ver Mais
+          </NavLink>
+        </div>
+      )
+    );
+  };
+
   return (
     <div className={`card card-panel card-colored ${cardType}`}>
       <div
@@ -55,32 +123,12 @@ export const CardStatusDeSolicitacao = props => {
         <span className="float-right my-auto">Data/Hora</span>
       </div>
       <hr />
-      {solicitations.slice(0, 5).map((solicitation, key) => {
-        let conferida = conferidaClass(solicitation, cardTitle);
-        return (
-          <NavLink
-            to={solicitation.link}
-            key={key}
-            data-cy={`${cardType}-${key}`}
-          >
-            <p className={`data ${conferida}`}>
-              {solicitation.text}
-              <span className="float-right">{solicitation.date}</span>
-            </p>
-          </NavLink>
-        );
-      })}
-      {solicitations.length > 5 && (
-        <div className="container-link">
-          <NavLink
-            to={`${href}`}
-            className="see-more"
-            data-cy={`ver-mais-${cardType}`}
-          >
-            Ver Mais
-          </NavLink>
-        </div>
-      )}
+      {cardTitle === GESTAO_PRODUTO_CARDS.RESPONDER_QUESTIONAMENTOS_DA_CODAE
+        ? renderSolicitations(filteredSolicitations)
+        : renderSolicitations(solicitations)}
+      {cardTitle === GESTAO_PRODUTO_CARDS.RESPONDER_QUESTIONAMENTOS_DA_CODAE
+        ? renderVerMais(filteredSolicitations)
+        : renderVerMais(solicitations)}
     </div>
   );
 };

--- a/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
@@ -63,6 +63,8 @@ const MenuGestaoDeProduto = ({ activeMenu, onSubmenuClick }) => {
       {exibirReclamacaoUE && (
         <LeafItem to={`/${GESTAO_PRODUTO}/responder-questionamento-ue`}>
           Responder Questionamento
+          <br />
+          da CODAE
         </LeafItem>
       )}
       {exibirReclamacaoNutrisupervisao && (
@@ -70,6 +72,8 @@ const MenuGestaoDeProduto = ({ activeMenu, onSubmenuClick }) => {
           to={`/${GESTAO_PRODUTO}/responder-questionamento-nutrisupervisor`}
         >
           Responder Questionamento
+          <br />
+          da CODAE
         </LeafItem>
       )}
       {exibirAvaliarReclamacao && (
@@ -84,7 +88,9 @@ const MenuGestaoDeProduto = ({ activeMenu, onSubmenuClick }) => {
       )}
       {exibirResponderReclamacao && (
         <LeafItem to={`/${GESTAO_PRODUTO}/responder-reclamacao/consulta`}>
-          Responder Reclamação
+          Responder Questionamento
+          <br />
+          da CODAE
         </LeafItem>
       )}
       <SubMenu

--- a/src/components/screens/DashboardGestaoProduto/index.jsx
+++ b/src/components/screens/DashboardGestaoProduto/index.jsx
@@ -124,7 +124,8 @@ export default class DashboardGestaoProduto extends Component {
                           cardType={card.style}
                           solicitations={formataCards(
                             card.items,
-                            this.apontaParaFormularioDeAlteracao(card.titulo)
+                            this.apontaParaFormularioDeAlteracao(card.titulo),
+                            card.titulo
                           )}
                           icon={card.icon}
                           href={`/${GESTAO_PRODUTO}/${card.rota}`}
@@ -138,7 +139,10 @@ export default class DashboardGestaoProduto extends Component {
                             cardType={card2.style}
                             solicitations={formataCards(
                               card2.items,
-                              this.apontaParaFormularioDeAlteracao(card2.titulo)
+                              this.apontaParaFormularioDeAlteracao(
+                                card2.titulo
+                              ),
+                              card.titulo
                             )}
                             icon={card2.icon}
                             href={`/${GESTAO_PRODUTO}/${card2.rota}`}

--- a/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/components/Filtros/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/components/Filtros/index.jsx
@@ -32,6 +32,9 @@ const Filtros = ({
   const [opcoesMarcas, setOpcoesMarcas] = useState();
   const [opcoesFabricantes, setOpcoesFabricantes] = useState();
 
+  const parameters = new URLSearchParams(window.location.search);
+  const nome_produto_param = parameters.get("nome_produto");
+
   const fetchData = async () => {
     const responseProdutos = await getNomesProdutosNutrisupervisor();
     if (responseProdutos.status === HTTP_STATUS.OK) {
@@ -45,10 +48,23 @@ const Filtros = ({
     if (responseFabricantes.status === HTTP_STATUS.OK) {
       setOpcoesFabricantes(formataOpcoes(responseFabricantes.data.results));
     }
+    if (nome_produto_param) {
+      const responseProdutosFiltrados = await filtrarReclamacoesNutrisupervisor(
+        `?nome_produto=${nome_produto_param}&page=1&page_size=${PAGE_SIZE}`
+      );
+      if (responseProdutosFiltrados) {
+        setProdutos(responseProdutosFiltrados.results);
+        setTotal(responseProdutosFiltrados.count);
+        setPage(1);
+        setCarregando(false);
+        return;
+      }
+    }
     setCarregando(false);
   };
 
   const onSubmit = async formValues => {
+    window.history.replaceState(null, null, window.location.pathname);
     let params = "";
     setProdutos(undefined);
     setCarregando(true);

--- a/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/components/TabelaProdutos/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/components/TabelaProdutos/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import HTTP_STATUS from "http-status-codes";
 import { toastError, toastSuccess } from "components/Shareable/Toast/dialogs";
 
@@ -27,7 +27,8 @@ const TabelaProdutos = ({
   filtros,
   setTotal,
   setProdutos,
-  setShowBuscaVazia
+  setShowBuscaVazia,
+  filtradoPorParametro
 }) => {
   const [indiceProdutoAtivo, setIndiceProdutoAtivo] = useState();
   const [uuid, setUuid] = useState();
@@ -60,6 +61,12 @@ const TabelaProdutos = ({
     }
     setCarregando(false);
   };
+
+  useEffect(() => {
+    if (filtradoPorParametro) {
+      setIndiceProdutoAtivo(0);
+    }
+  }, [filtradoPorParametro]);
 
   return (
     <>

--- a/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoNutrisupervisor/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Spin, Pagination } from "antd";
 import { toastError } from "components/Shareable/Toast/dialogs";
 
@@ -12,10 +12,20 @@ const ResponderQuestionamentoNutrisupervisor = () => {
   const [produtos, setProdutos] = useState();
   const [carregando, setCarregando] = useState();
   const [showBuscaVazia, setShowBuscaVazia] = useState(false);
+  const [filtradoPorParametro, setFiltradoPorParametro] = useState(false);
   const [filtros, setFiltros] = useState();
   const [total, setTotal] = useState();
   const [page, setPage] = useState();
   const PAGE_SIZE = 10;
+
+  const parameters = new URLSearchParams(window.location.search);
+  const nome_produto = parameters.get("nome_produto");
+
+  useEffect(() => {
+    if (nome_produto) {
+      setFiltradoPorParametro(true);
+    }
+  }, [nome_produto]);
 
   const changePage = async page => {
     try {
@@ -66,6 +76,7 @@ const ResponderQuestionamentoNutrisupervisor = () => {
                 setTotal={setTotal}
                 setProdutos={setProdutos}
                 setShowBuscaVazia={setShowBuscaVazia}
+                filtradoPorParametro={filtradoPorParametro}
               />,
               <Pagination
                 className="mt-3 mb-3"

--- a/src/components/screens/Produto/ResponderQuestionamentoUE/components/Filtros/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoUE/components/Filtros/index.jsx
@@ -32,6 +32,9 @@ const Filtros = ({
   const [opcoesMarcas, setOpcoesMarcas] = useState();
   const [opcoesFabricantes, setOpcoesFabricantes] = useState();
 
+  const parameters = new URLSearchParams(window.location.search);
+  const nome_produto_param = parameters.get("nome_produto");
+
   const fetchData = async () => {
     const responseProdutos = await getNomesProdutos();
     if (responseProdutos.status === HTTP_STATUS.OK) {
@@ -45,10 +48,23 @@ const Filtros = ({
     if (responseFabricantes.status === HTTP_STATUS.OK) {
       setOpcoesFabricantes(formataOpcoes(responseFabricantes.data.results));
     }
+    if (nome_produto_param) {
+      const responseProdutosFiltrados = await filtrarReclamacoesEscola(
+        `?nome_produto=${nome_produto_param}&page=1&page_size=${PAGE_SIZE}`
+      );
+      if (responseProdutosFiltrados) {
+        setProdutos(responseProdutosFiltrados.results);
+        setTotal(responseProdutosFiltrados.count);
+        setPage(1);
+        setCarregando(false);
+        return;
+      }
+    }
     setCarregando(false);
   };
 
   const onSubmit = async formValues => {
+    window.history.replaceState(null, null, window.location.pathname);
     let params = "";
     setProdutos(undefined);
     setCarregando(true);

--- a/src/components/screens/Produto/ResponderQuestionamentoUE/components/TabelaProdutos/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoUE/components/TabelaProdutos/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import HTTP_STATUS from "http-status-codes";
 import { toastError, toastSuccess } from "components/Shareable/Toast/dialogs";
 
@@ -27,7 +27,8 @@ const TabelaProdutos = ({
   filtros,
   setTotal,
   setProdutos,
-  setShowBuscaVazia
+  setShowBuscaVazia,
+  filtradoPorParametro
 }) => {
   const [indiceProdutoAtivo, setIndiceProdutoAtivo] = useState();
   const [uuid, setUuid] = useState();
@@ -57,6 +58,12 @@ const TabelaProdutos = ({
     }
     setCarregando(false);
   };
+
+  useEffect(() => {
+    if (filtradoPorParametro) {
+      setIndiceProdutoAtivo(0);
+    }
+  }, [filtradoPorParametro]);
 
   return (
     <>

--- a/src/components/screens/Produto/ResponderQuestionamentoUE/index.jsx
+++ b/src/components/screens/Produto/ResponderQuestionamentoUE/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Spin, Pagination } from "antd";
 import { toastError } from "components/Shareable/Toast/dialogs";
 
@@ -12,10 +12,20 @@ const ResponderQuestionamentoUE = () => {
   const [produtos, setProdutos] = useState();
   const [carregando, setCarregando] = useState();
   const [showBuscaVazia, setShowBuscaVazia] = useState(false);
+  const [filtradoPorParametro, setFiltradoPorParametro] = useState(false);
   const [filtros, setFiltros] = useState();
   const [total, setTotal] = useState();
   const [page, setPage] = useState();
   const PAGE_SIZE = 10;
+
+  const parameters = new URLSearchParams(window.location.search);
+  const nome_produto = parameters.get("nome_produto");
+
+  useEffect(() => {
+    if (nome_produto) {
+      setFiltradoPorParametro(true);
+    }
+  }, [nome_produto]);
 
   const changePage = async page => {
     try {
@@ -66,6 +76,7 @@ const ResponderQuestionamentoUE = () => {
                 setTotal={setTotal}
                 setProdutos={setProdutos}
                 setShowBuscaVazia={setShowBuscaVazia}
+                filtradoPorParametro={filtradoPorParametro}
               />,
               <Pagination
                 className="mt-3 mb-3"

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -924,6 +924,18 @@ const routesConfig = [
   {
     path: `/${constants.GESTAO_PRODUTO}/${
       constants.ROTAS_SOLICITACOES_HOMOLOGACAO_PRODUTO
+        .RESPONDER_QUESTIONAMENTOS_DA_CODAE
+    }`,
+    component: StatusSolicitacoesGestaoProduto.ResponderQuestionamentoDaCodae,
+    exact: true,
+    tipoUsuario:
+      usuarioEhTerceirizada() ||
+      usuarioEhNutricionistaSupervisao() ||
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+  },
+  {
+    path: `/${constants.GESTAO_PRODUTO}/${
+      constants.ROTAS_SOLICITACOES_HOMOLOGACAO_PRODUTO
         .AGUARDANDO_ANALISE_SENSORIAL
     }`,
     component: StatusSolicitacoesGestaoProduto.AguardandoAnaliseSensorial,

--- a/src/configs/constants.js
+++ b/src/configs/constants.js
@@ -54,7 +54,8 @@ export const ROTAS_SOLICITACOES_HOMOLOGACAO_PRODUTO = {
   AGUARDANDO_ANALISE_SENSORIAL: "aguardando-analise-sensorial",
   SOLICITACOES_PENDENTE_HOMOLOGACAO: "solicitacoes-pendente-homologacao",
   SOLICITACOES_HOMOLOGADAS: "solicitacoes-homologadas",
-  SOLICITACOES_NAO_HOMOLOGADAS: "solicitacoes-nao-homologadas"
+  SOLICITACOES_NAO_HOMOLOGADAS: "solicitacoes-nao-homologadas",
+  RESPONDER_QUESTIONAMENTOS_DA_CODAE: "responder-questionamentos-da-codae"
 };
 
 export const AUTORIZADOS_DIETA = "autorizados-dieta";
@@ -82,7 +83,8 @@ export const GESTAO_PRODUTO_CARDS = {
   AGUARDANDO_ANALISE_SENSORIAL: "Aguardando análise sensoriais",
   PENDENTE_HOMOLOGACAO: "Pendentes de homologação",
   HOMOLOGADOS: "Homologados",
-  NAO_HOMOLOGADOS: "Não homologados"
+  NAO_HOMOLOGADOS: "Não homologados",
+  RESPONDER_QUESTIONAMENTOS_DA_CODAE: "Responder Questionamentos da CODAE"
 };
 
 export const SOLICITACOES_CODAE = "codae-solicitacoes";

--- a/src/helpers/gestaoDeProdutos.js
+++ b/src/helpers/gestaoDeProdutos.js
@@ -89,6 +89,19 @@ const CARD_CORRECAO_DE_PRODUTO = {
   incluir_status: [CODAE_QUESTIONADO]
 };
 
+export const CARD_RESPONDER_QUESTIONAMENTOS_DA_CODAE = {
+  id: CARD_ID.RESPONDER_QUESTIONAMENTOS_DA_CODAE,
+  titulo: "Responder Questionamentos da CODAE",
+  icon: "fa-exclamation-triangle",
+  style: "card-pending",
+  rota: ROTA.RESPONDER_QUESTIONAMENTOS_DA_CODAE,
+  incluir_status: [
+    CODAE_QUESTIONOU_UE,
+    CODAE_PEDIU_ANALISE_RECLAMACAO,
+    CODAE_QUESTIONOU_NUTRISUPERVISOR
+  ]
+};
+
 export const TODOS_OS_CARDS = [
   CARD_PRODUTOS_SUSPENSOS,
   CARD_CORRECAO_DE_PRODUTO,
@@ -96,7 +109,8 @@ export const TODOS_OS_CARDS = [
   CARD_AGUARDANDO_ANALISE_SENSORIAL,
   CARD_PENDENTE_HOMOLOGACAO,
   CARD_HOMOLOGADOS,
-  CARD_NAO_HOMOLOGADOS
+  CARD_NAO_HOMOLOGADOS,
+  CARD_RESPONDER_QUESTIONAMENTOS_DA_CODAE
 ];
 
 export const listarCardsPermitidos = () => {
@@ -146,7 +160,8 @@ export const listarCardsPermitidos = () => {
       CARD_AGUARDANDO_ANALISE_SENSORIAL,
       CARD_PENDENTE_HOMOLOGACAO,
       CARD_HOMOLOGADOS,
-      CARD_NAO_HOMOLOGADOS
+      CARD_NAO_HOMOLOGADOS,
+      CARD_RESPONDER_QUESTIONAMENTOS_DA_CODAE
     ];
   } else if (
     [TIPO_PERFIL.SUPERVISAO_NUTRICAO, TIPO_PERFIL.ESCOLA].includes(perfil)
@@ -170,7 +185,8 @@ export const listarCardsPermitidos = () => {
       cardAguardandoAnaliseReclamacao,
       CARD_PRODUTOS_SUSPENSOS,
       CARD_NAO_HOMOLOGADOS,
-      CARD_HOMOLOGADOS
+      CARD_HOMOLOGADOS,
+      CARD_RESPONDER_QUESTIONAMENTOS_DA_CODAE
     ];
   }
 

--- a/src/pages/Produto/StatusSolicitacoesGestaoProduto.jsx
+++ b/src/pages/Produto/StatusSolicitacoesGestaoProduto.jsx
@@ -109,3 +109,12 @@ export const NaoHomologados = () => (
     titulo={GESTAO_PRODUTO_CARDS.NAO_HOMOLOGADOS}
   />
 );
+
+export const ResponderQuestionamentoDaCodae = () => (
+  <StatusSolicitacoesBase
+    status={ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS.CODAE_PEDIU_ANALISE_RECLAMACAO}
+    tipoCard={CARD_TYPE_ENUM.PENDENTE}
+    icone={ICON_CARD_TYPE_ENUM.PENDENTE}
+    titulo={GESTAO_PRODUTO_CARDS.RESPONDER_QUESTIONAMENTOS_DA_CODAE}
+  />
+);


### PR DESCRIPTION
# Proposta

Este PR visa criar card de responder questionamentos da codae

# Referência do Azure

- 53994

# Tarefas para concluir

- [x] Ajustar tela de responder questionamento nutrisupervisor para filtrar nome do produto da url
- [x] Ajustar tela de responder questionamento UE para filtrar nome do produto da url
- [x] Ajustar dashboard & tela de status das solicitações
- [x] Criar card de responder questionamento da codae no dashboard de gestão de produto
- [x] Ajustar nome menu lateral para responder questionamento da codae
- [x] Ajustar rota para tela de status das solicitações do card de responder questionamento da codae