### PR TITLE
Fix: correção ao definir nome da escola para aluno não matriculado

### DIFF
--- a/src/components/screens/DietaEspecial/Escola/index.jsx
+++ b/src/components/screens/DietaEspecial/Escola/index.jsx
@@ -169,12 +169,12 @@ class solicitacaoDietaEspecial extends Component {
 
     if (!resposta) return;
 
-    if (!resposta.count) {
-      change("aluno_nao_matriculado_data.nome_escola", "");
-      toastError("Código EOL informado inválido");
-    } else {
+    if (resposta && resposta.results.length) {
       const escola = resposta.results[0];
       change("aluno_nao_matriculado_data.nome_escola", escola.nome);
+    } else {
+      change("aluno_nao_matriculado_data.nome_escola", "");
+      toastError("Código EOL informado inválido");
     }
   };
 


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o problema ao digitar código EOL da escola para aluno não matriculado.

# Referência do Azure

- 57594

# Tarefas para concluir

- [x] Definir nome da escola ao digitar codigo eol da escola