### PR TITLE
Feature: desabilitar edição dos campos 'nome' e 'produto é para dieta especial'

### DIFF
--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
@@ -301,6 +301,7 @@ class WizardFormPrimeiraPagina extends React.Component {
                     onClick={() => {
                       this.dietaEspecialCheck("1");
                     }}
+                    disabled={true}
                     required
                   />
                   <span className="checkmark" />
@@ -315,6 +316,7 @@ class WizardFormPrimeiraPagina extends React.Component {
                     onClick={() => {
                       this.dietaEspecialCheck("0");
                     }}
+                    disabled={true}
                   />
                   <span className="checkmark" />
                 </label>
@@ -333,6 +335,7 @@ class WizardFormPrimeiraPagina extends React.Component {
               name="nome"
               onSelect={this.addNome}
               validate={required}
+              disabled={true}
             >
               {nomeDeProdutosEditalArray}
             </Field>


### PR DESCRIPTION
# Proposta

Este PR visa bloquear a edição dos campos 'nome' e 'produto é para dieta especial'.

# Referência do Azure

- 56232

# Tarefas para concluir

- [x] Desabilitar campos no componente de edição de produto