### PR TITLE
Bugfix/54139 kit lanche dieta especial

### DIFF
--- a/src/components/SolicitacaoDeKitLanche/Container/base.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Container/base.jsx
@@ -234,6 +234,15 @@ export class SolicitacaoDeKitLanche extends Component {
     if (values.confirmar) {
       solicitacao_kit_lanche.confirmar = values.confirmar;
     }
+    if (
+      solicitacao_kit_lanche.quantidade_alunos <
+      solicitacao_kit_lanche.alunos_com_dieta_especial_participantes.length
+    ) {
+      toastError(
+        "O número de alunos selecionados com Dieta Especial é maior que a quantidade de alunos prevista para o evento."
+      );
+      return;
+    }
     try {
       validateFormKitLanchePasseio(values);
       if (ehCei) {


### PR DESCRIPTION
Este PR: 
- Corrige o bug que deixava um número de alunos com dieta especial maior que o número de alunos do kit lanche ser selecionado