### PR TITLE
Feature/57883-PD-criar-permissionamento-nutricionista-manifestação

### DIFF
--- a/src/components/Shareable/Sidebar/SidebarContent.jsx
+++ b/src/components/Shareable/Sidebar/SidebarContent.jsx
@@ -70,6 +70,7 @@ export const SidebarContent = () => {
     usuarioEhTerceirizada();
   const exibirGestaoProduto =
     usuarioEhCODAEGestaoAlimentacao() ||
+    usuarioEhCODAENutriManifestacao() ||
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhNutricionistaSupervisao() ||

--- a/src/components/screens/PainelInicial/index.jsx
+++ b/src/components/screens/PainelInicial/index.jsx
@@ -57,6 +57,7 @@ const PainelInicial = ({ history }) => {
       )}
 
       {(usuarioEhQualquerCODAE() ||
+        usuarioEhCODAENutriManifestacao() ||
         usuarioEhTerceirizada() ||
         usuarioEhNutricionistaSupervisao() ||
         usuarioEhDRE() ||

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -899,6 +899,7 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
@@ -928,6 +929,7 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
@@ -994,6 +996,7 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
@@ -1010,6 +1013,7 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
@@ -1022,6 +1026,7 @@ const routesConfig = [
     exact: true,
     tipoUsuario:
       usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||


### PR DESCRIPTION
# Proposta

Este PR visa criar permissionamento nutricionista manifestação ao módulo de P&D

# Referência do Azure

- 57883

# Tarefas para concluir

- [x] adicionar permissões nas rotas para usuário nutricionista manifestação P&D
- [x] adicionar menu lateral de P&D para usuário nutricionista manifestação
- [x] adicionar painel inicial de P&D para usuário nutricionista manifestação