### PR TITLE
Feature/57651-PD-botão-cancelar-solicitações-aguardando-análise-sensorial

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -121,6 +121,7 @@ export const tipoDeStatus = status => {
     case "CODAE homologou":
       return "prosseguiu";
     case "CODAE não homologou":
+    case "CODAE cancelou análise sensorial":
       return "cancelado";
     case "CODAE pediu correção":
     case "Terceirizada respondeu questionamento":

--- a/src/components/Shareable/FluxoDeStatus/index.jsx
+++ b/src/components/Shareable/FluxoDeStatus/index.jsx
@@ -13,8 +13,24 @@ export const FluxoDeStatus = props => {
   cloneListaDeStatus = formatarLogs(cloneListaDeStatus);
   const fluxoNaoFinalizado =
     cloneListaDeStatus && existeAlgumStatusFimDeFluxo(cloneListaDeStatus);
-  const fluxoUtilizado =
+  let fluxoUtilizado =
     fluxo.length > cloneListaDeStatus.length ? fluxo : cloneListaDeStatus;
+  let ultimoStatus = cloneListaDeStatus.slice(-1)[0];
+  let temStatusDeAnaliseSensorialCancelada = false;
+
+  if (
+    cloneListaDeStatus.length > fluxo.length &&
+    ultimoStatus.status_evento_explicacao === "Solicitação Realizada"
+  ) {
+    fluxoUtilizado.push({
+      status_evento_explicacao: "CODAE",
+      status: "",
+      criado_em: "",
+      usuario: null
+    });
+    temStatusDeAnaliseSensorialCancelada = true;
+  }
+
   const fluxoUtilizadoEFormatado = fluxoUtilizado.map(log => {
     let logFormatado = log;
     if (log.status_evento_explicacao === "Escola solicitou inativação") {
@@ -25,6 +41,7 @@ export const FluxoDeStatus = props => {
     }
     return logFormatado;
   });
+
   const getTitulo = log => {
     if (log) {
       if (
@@ -43,6 +60,7 @@ export const FluxoDeStatus = props => {
       }
     }
   };
+
   return (
     <div className="w-100">
       <div className="row">
@@ -67,7 +85,8 @@ export const FluxoDeStatus = props => {
                   className={`${
                     tipoDeStatusClasse(novoStatus) !== "pending"
                       ? tipoDeStatusClasse(novoStatus)
-                      : fluxoNaoFinalizado
+                      : fluxoNaoFinalizado ||
+                        temStatusDeAnaliseSensorialCancelada
                       ? "pending"
                       : ""
                   }`}

--- a/src/components/Shareable/ModalCodaeCancelaAnaliseSensorial/index.jsx
+++ b/src/components/Shareable/ModalCodaeCancelaAnaliseSensorial/index.jsx
@@ -1,0 +1,164 @@
+import HTTP_STATUS from "http-status-codes";
+import React, { Component } from "react";
+import { Spin } from "antd";
+import { withRouter } from "react-router-dom";
+import { Modal } from "react-bootstrap";
+import { Field, Form } from "react-final-form";
+import { Field as FieldReduxForm } from "redux-form";
+import { OnChange } from "react-final-form-listeners";
+import Botao from "../Botao";
+import { BUTTON_STYLE, BUTTON_TYPE } from "../Botao/constants";
+import {
+  maxLengthProduto,
+  textAreaRequiredAndAtLeastOneCharacter
+} from "helpers/fieldValidators";
+import { TextAreaWYSIWYG } from "../TextArea/TextAreaWYSIWYG";
+import { toastError, toastSuccess, toastWarn } from "../Toast/dialogs";
+import { MENSAGEM_VAZIA } from "../TextArea/constants";
+import { composeValidators } from "helpers/utilities";
+import { InputText } from "components/Shareable/Input/InputText";
+
+import "./styles.scss";
+import { CODAECancelaAnaliseSensorialProduto } from "services/produto.service";
+
+const maxLength1500 = maxLengthProduto(1500);
+
+class ModalCodaeCancelaAnaliseSensorial extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      desabilitarSubmit: true,
+      loading: false
+    };
+
+    this.setDesabilitarSubmit = this.setDesabilitarSubmit.bind(this);
+  }
+
+  setDesabilitarSubmit(value) {
+    this.setState({
+      desabilitarSubmit:
+        [undefined, null, "", "<p></p>\n"].includes(value) ||
+        maxLength1500(value)
+    });
+  }
+
+  async autorizarSolicitacao(uuid, values) {
+    const { closeModal, loadSolicitacao, setDisableBotaoCancelar } = this.props;
+    if (values.justificativa_autorizacao === MENSAGEM_VAZIA) {
+      toastWarn("Justificativa é obrigatória.");
+    } else {
+      this.setState({
+        loading: true
+      });
+      const resp = await CODAECancelaAnaliseSensorialProduto(
+        uuid,
+        values.justificativa_autorizacao
+      );
+      if (resp.status === HTTP_STATUS.OK) {
+        this.setState({
+          loading: false
+        });
+        setDisableBotaoCancelar();
+        closeModal();
+        loadSolicitacao(uuid);
+        toastSuccess("Solicitação cancelada com sucesso");
+      } else {
+        toastError(resp.data.detail);
+      }
+    }
+  }
+
+  render() {
+    const { showModal, closeModal, produto, uuid } = this.props;
+    return (
+      <Modal dialogClassName="modal-90w" show={showModal} onHide={closeModal}>
+        <Spin spinning={this.state.loading} tip="Carregando...">
+          <Form
+            onSubmit={() => {}}
+            initialValues={{}}
+            render={({ handleSubmit, values }) => (
+              <form onSubmit={handleSubmit}>
+                <Modal.Header closeButton>
+                  <Modal.Title>
+                    Deseja cancelar a solicitação de análise sensorial do
+                    produto?
+                  </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                  <section className="informacoes-do-produto">
+                    <div className="">
+                      <label className="label-formulario-produto">
+                        <nav>*</nav>Nome do produto
+                      </label>
+                      <FieldReduxForm
+                        component={InputText}
+                        name="nome_produto"
+                        placeholder={produto.nome}
+                        disabled={true}
+                      />
+                    </div>
+                    <div className="">
+                      <label className="label-formulario-produto">
+                        <nav>*</nav>Marca
+                      </label>
+                      <FieldReduxForm
+                        component={InputText}
+                        name="marca_produto"
+                        placeholder={produto.marca && produto.marca.nome}
+                        disabled={true}
+                      />
+                    </div>
+                  </section>
+                  <div className="form-row">
+                    <div className="form-group col-12">
+                      <Field
+                        component={TextAreaWYSIWYG}
+                        label="Justificativa"
+                        name="justificativa_autorizacao"
+                        required
+                        validate={composeValidators(
+                          textAreaRequiredAndAtLeastOneCharacter,
+                          maxLength1500
+                        )}
+                      />
+                      <OnChange name="justificativa_autorizacao">
+                        {value => {
+                          this.setDesabilitarSubmit(value);
+                        }}
+                      </OnChange>
+                    </div>
+                  </div>
+                </Modal.Body>
+                <Modal.Footer>
+                  <div className="row mt-4">
+                    <div className="col-12">
+                      <Botao
+                        texto="Voltar"
+                        type={BUTTON_TYPE.BUTTON}
+                        onClick={closeModal}
+                        style={BUTTON_STYLE.BLUE_OUTLINE}
+                        className="ml-3"
+                      />
+                      <Botao
+                        texto="Enviar Cancelamento"
+                        type={BUTTON_TYPE.BUTTON}
+                        onClick={() => {
+                          this.autorizarSolicitacao(uuid, values);
+                        }}
+                        style={BUTTON_STYLE.BLUE}
+                        className="ml-3"
+                        disabled={this.state.desabilitarSubmit}
+                      />
+                    </div>
+                  </div>
+                </Modal.Footer>
+              </form>
+            )}
+          />
+        </Spin>
+      </Modal>
+    );
+  }
+}
+
+export default withRouter(ModalCodaeCancelaAnaliseSensorial);

--- a/src/components/Shareable/ModalCodaeCancelaAnaliseSensorial/styles.scss
+++ b/src/components/Shareable/ModalCodaeCancelaAnaliseSensorial/styles.scss
@@ -1,0 +1,11 @@
+@import "../../../styles/variables.scss";
+
+.informacoes-do-produto {
+  display: grid;
+  grid-template-columns: 50% 30%;
+  column-gap: 3%;
+
+  .input ::placeholder {
+    color: $blackSubtle;
+  }
+}

--- a/src/components/screens/Produto/Homologacao/index.jsx
+++ b/src/components/screens/Produto/Homologacao/index.jsx
@@ -44,6 +44,7 @@ import { FluxoDeStatus } from "components/Shareable/FluxoDeStatus";
 import { fluxoPartindoTerceirizada } from "components/Shareable/FluxoDeStatus/helper";
 import { ENDPOINT_HOMOLOGACOES_PRODUTO_STATUS } from "constants/shared";
 import TabelaEspecificacoesProduto from "components/Shareable/TabelaEspecificacoesProduto";
+import ModalCodaeCancelaAnaliseSensorial from "components/Shareable/ModalCodaeCancelaAnaliseSensorial";
 
 const {
   CODAE_HOMOLOGADO,
@@ -67,9 +68,15 @@ class HomologacaoProduto extends Component {
       ativo: false,
       acao: null,
       mostraModalCancelar: false,
-      terceirizadas: null
+      terceirizadas: null,
+      showCancelarAnaliseSensorialModal: false,
+      disableBotaoCancelar: false
     };
     this.closeModal = this.closeModal.bind(this);
+    this.closeCancelarAnaliseSensorialModal = this.closeCancelarAnaliseSensorialModal.bind(
+      this
+    );
+    this.setDisableBotaoCancelar = this.setDisableBotaoCancelar.bind(this);
   }
 
   closeModal = () => {
@@ -142,7 +149,8 @@ class HomologacaoProduto extends Component {
         status: response.data.status,
         logs: response.data.logs,
         ativo: this.checaStatus(response.data),
-        acao: null
+        acao: null,
+        disableBotaoCancelar: false
       });
     });
   };
@@ -222,6 +230,18 @@ class HomologacaoProduto extends Component {
     return this.state.logs;
   };
 
+  showCancelarAnaliseSensorialModal() {
+    this.setState({ showCancelarAnaliseSensorialModal: true });
+  }
+
+  closeCancelarAnaliseSensorialModal() {
+    this.setState({ showCancelarAnaliseSensorialModal: false });
+  }
+
+  setDisableBotaoCancelar() {
+    this.setState({ disableBotaoCancelar: true });
+  }
+
   render() {
     const tipoPerfil = localStorage.getItem("tipo_perfil");
     const {
@@ -236,7 +256,9 @@ class HomologacaoProduto extends Component {
       logs,
       ativo,
       acao,
-      terceirizadas
+      terceirizadas,
+      showCancelarAnaliseSensorialModal,
+      disableBotaoCancelar
     } = this.state;
     const {
       necessita_analise_sensorial,
@@ -246,8 +268,21 @@ class HomologacaoProduto extends Component {
     const { ultima_homologacao } = produto !== null && produto;
     const logAnaliseSensorial =
       ultima_homologacao && ultima_homologacao.ultimo_log;
+
+    const handleClickBotaoCancela = () => {
+      this.showCancelarAnaliseSensorialModal();
+    };
+
     return (
       <div className="card">
+        <ModalCodaeCancelaAnaliseSensorial
+          showModal={showCancelarAnaliseSensorialModal}
+          produto={produto}
+          closeModal={this.closeCancelarAnaliseSensorialModal}
+          uuid={uuid}
+          loadSolicitacao={this.loadHomologacao}
+          setDisableBotaoCancelar={this.setDisableBotaoCancelar}
+        />
         <div className="card-body">
           {!produto ? (
             <div>Carregando...</div>
@@ -801,6 +836,21 @@ class HomologacaoProduto extends Component {
                           })
                         }
                         style={BUTTON_STYLE.GREEN}
+                      />
+                    </div>
+                  </div>
+                )}
+              {tipoPerfil === TIPO_PERFIL.GESTAO_PRODUTO &&
+                status === "CODAE_PEDIU_ANALISE_SENSORIAL" && (
+                  <div className="row">
+                    <div className="col-12 text-right pt-3">
+                      <Botao
+                        texto={"Cancelar"}
+                        className="mr-3"
+                        type={BUTTON_TYPE.BUTTON}
+                        onClick={() => handleClickBotaoCancela()}
+                        style={BUTTON_STYLE.GREEN}
+                        disabled={disableBotaoCancelar}
                       />
                     </div>
                   </div>

--- a/src/services/produto.service.js
+++ b/src/services/produto.service.js
@@ -377,6 +377,26 @@ export const CODAEPedeAnaliseSensorialProduto = (
     });
 };
 
+export const CODAECancelaAnaliseSensorialProduto = (uuid, justificativa) => {
+  const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-cancela-analise-sensorial/`;
+  let status = 0;
+  return fetch(url, {
+    method: "PATCH",
+    headers: authToken,
+    body: JSON.stringify({ justificativa })
+  })
+    .then(res => {
+      status = res.status;
+      return res.json();
+    })
+    .then(data => {
+      return { data: data, status: status };
+    })
+    .catch(error => {
+      return error;
+    });
+};
+
 export const CODAENaoHomologaProduto = (uuid, justificativa) => {
   const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-nao-homologa/`;
   let status = 0;


### PR DESCRIPTION
# Proposta

Este PR visa criar modal e botão de cancelar solicitações que estejam no status de aguardando análise sensorial

# Referência do Azure

- 57651

# Tarefas para concluir

- [x] criar botão de Cancelar no relatório de solicitação de análise sensorial
- [x] incluir status de CODAE cancelou análise sensorial no fluxo de status
- [x] criar service para CODAE cancelar análise sensorial
- [x] criar modal de CODAE cancelar análise sensorial