### PR TITLE
Feature/61720-liberar-relatórios-para-usuário-nutrimanifestação

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
@@ -4,6 +4,7 @@ import {
   usuarioEhCODAEDietaEspecial,
   usuarioEhCODAEGestaoProduto,
   usuarioEhCODAEGestaoAlimentacao,
+  usuarioEhCODAENutriManifestacao,
   usuarioEhNutricionistaSupervisao,
   usuarioEhTerceirizada,
   usuarioEhEscola,
@@ -19,7 +20,8 @@ const MenuRelatorios = () => {
     usuarioEhCODAEGestaoProduto() ||
     (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
     usuarioEhNutricionistaSupervisao() ||
-    usuarioEhTerceirizada();
+    usuarioEhTerceirizada() ||
+    usuarioEhCODAENutriManifestacao();
 
   const exibirQuantitativoPorTerceirizada = usuarioEhCODAEGestaoProduto();
   const exibirRelatorioAnaliseSensorial =
@@ -31,6 +33,14 @@ const MenuRelatorios = () => {
     usuarioEhTerceirizada() ||
     (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
     usuarioEhCODAEDietaEspecial();
+
+  const exibirProdutosSuspensos =
+    usuarioEhCODAEGestaoProduto() ||
+    usuarioEhNutricionistaSupervisao() ||
+    usuarioEhTerceirizada() ||
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    usuarioEhCODAEDietaEspecial() ||
+    usuarioEhCODAENutriManifestacao();
 
   const exibirRelatorioQuantitativoSolicDietaEsp =
     usuarioEhCODAEDietaEspecial() ||
@@ -56,7 +66,7 @@ const MenuRelatorios = () => {
           Quantitativo Por Terceirizada
         </LeafItem>
       )}
-      {exibirMenuTodosPerfis && (
+      {exibirProdutosSuspensos && (
         <LeafItem
           to={`/${constants.GESTAO_PRODUTO}/relatorio-produtos-suspensos`}
         >

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1053,7 +1053,8 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhTerceirizada() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      usuarioEhCODAENutriManifestacao()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -1079,7 +1080,8 @@ const routesConfig = [
       usuarioEhQualquerCODAE() ||
       usuarioEhTerceirizada() ||
       (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
-      usuarioEhNutricionistaSupervisao()
+      usuarioEhNutricionistaSupervisao() ||
+      usuarioEhCODAENutriManifestacao()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/responder-reclamacao/consulta`,


### PR DESCRIPTION
# Proposta

Este PR visa corrigir data de homologação exibida no relatório de produtos homologados

# Referência do Azure

- 61720

# Tarefas para concluir

- [x] exibir relatórios no menu lateral para usuário nutrimanifestação
- [x] liberar rotas de relatórios para usuário nutrimanifestação