### PR TITLE
Feature/61312-GA-PeD-retirar-acesso-aos-módulos-escola-tipo-gestão-direta

### DIFF
--- a/src/components/Shareable/Sidebar/SidebarContent.jsx
+++ b/src/components/Shareable/Sidebar/SidebarContent.jsx
@@ -17,6 +17,7 @@ import {
   usuarioEhDistribuidora,
   usuarioComAcessoTelaEntregasDilog,
   usuarioEhCoordenadorNutriSupervisao,
+  usuarioEscolaEhGestaoDireta,
   usuarioEscolaEhGestaoMistaParceira,
   exibirGA
 } from "helpers/utilities";
@@ -57,7 +58,9 @@ export const SidebarContent = () => {
     (usuarioEhCODAEGestaoAlimentacao() ||
       usuarioEhCODAENutriManifestacao() ||
       usuarioEhDRE() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta()) ||
       usuarioEhTerceirizada() ||
       usuarioEhNutricionistaSupervisao());
   const exibirDietaEspecial =
@@ -74,11 +77,15 @@ export const SidebarContent = () => {
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhNutricionistaSupervisao() ||
-    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    (usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()) ||
     usuarioEhDRE() ||
     usuarioEhTerceirizada();
   const exibirLancamentoInicial =
-    exibeMenuValidandoAmbiente && usuarioEhEscola();
+    exibeMenuValidandoAmbiente &&
+    usuarioEhEscola() &&
+    !usuarioEscolaEhGestaoDireta();
   const exibirCadastros =
     usuarioEhLogistica() ||
     (!exibeMenuValidandoAmbiente && usuarioEhCODAEGestaoAlimentacao()) ||
@@ -89,7 +96,8 @@ export const SidebarContent = () => {
     !usuarioEhEscolaAbastecimento() &&
     !usuarioComAcessoTelaEntregasDilog() &&
     !usuarioEhLogistica() &&
-    !usuarioEhDistribuidora();
+    !usuarioEhDistribuidora() &&
+    !usuarioEscolaEhGestaoDireta();
 
   const exibirConfiguracoes =
     !usuarioEhEscola() &&

--- a/src/components/Shareable/Sidebar/menus/MenuGestaoDeAlimentacao.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuGestaoDeAlimentacao.jsx
@@ -26,14 +26,18 @@ import {
   usuarioEhCODAENutriManifestacao,
   usuarioEhDRE,
   usuarioEhEscola,
+  usuarioEscolaEhGestaoDireta,
   usuarioEscolaEhGestaoMistaParceira,
   usuarioEhNutricionistaSupervisao
 } from "helpers/utilities";
 
 const MenuGestaoDeAlimentacao = ({ activeMenu, onSubmenuClick }) => {
   const exibeMenuNovasSolicitacoes =
-    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    (usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()) ||
     usuarioEhDRE();
+  const exibeMenuConsultaDeSolicitacoes = !usuarioEscolaEhGestaoDireta();
   const PERFIL = usuarioEhEscola()
     ? ESCOLA
     : usuarioEhDRE()
@@ -88,38 +92,41 @@ const MenuGestaoDeAlimentacao = ({ activeMenu, onSubmenuClick }) => {
           )}
         </SubMenu>
       )}
-      <SubMenu
-        icon="fa-chevron-down"
-        path="consulta-solicitacoes"
-        onClick={onSubmenuClick}
-        title="Consulta de Solicitações"
-        activeMenu={activeMenu}
-      >
-        {PERFIL === "nutrisupervisao" && (
-          <LeafItem to={`/${PERFIL}/${SOLICITACOES_COM_QUESTIONAMENTO}`}>
-            Aguardando resposta da empresa
-          </LeafItem>
-        )}
-        {PERFIL === "terceirizada" ? (
-          <LeafItem to={`/${PERFIL}/${SOLICITACOES_COM_QUESTIONAMENTO}`}>
-            Questionamentos da CODAE
-          </LeafItem>
-        ) : (
-          !usuarioEhCODAENutriManifestacao() && (
-            <LeafItem to={`/${PERFIL}/${SOLICITACOES_PENDENTES}`}>
-              Aguardando autorização
+      {exibeMenuConsultaDeSolicitacoes && (
+        <SubMenu
+          icon="fa-chevron-down"
+          path="consulta-solicitacoes"
+          onClick={onSubmenuClick}
+          title="Consulta de Solicitações"
+          activeMenu={activeMenu}
+        >
+          {PERFIL === "nutrisupervisao" && (
+            <LeafItem to={`/${PERFIL}/${SOLICITACOES_COM_QUESTIONAMENTO}`}>
+              Aguardando resposta da empresa
             </LeafItem>
-          )
-        )}
+          )}
+          {PERFIL === "terceirizada" ? (
+            <LeafItem to={`/${PERFIL}/${SOLICITACOES_COM_QUESTIONAMENTO}`}>
+              Questionamentos da CODAE
+            </LeafItem>
+          ) : (
+            !usuarioEhCODAENutriManifestacao() &&
+            !usuarioEscolaEhGestaoDireta() && (
+              <LeafItem to={`/${PERFIL}/${SOLICITACOES_PENDENTES}`}>
+                Aguardando autorização
+              </LeafItem>
+            )
+          )}
 
-        <LeafItem to={`/${PERFIL}/${SOLICITACOES_AUTORIZADAS}`}>
-          Autorizadas
-        </LeafItem>
-        <LeafItem to={`/${PERFIL}/${SOLICITACOES_NEGADAS}`}>Negadas</LeafItem>
-        <LeafItem to={`/${PERFIL}/${SOLICITACOES_CANCELADAS}`}>
-          Canceladas
-        </LeafItem>
-      </SubMenu>
+          <LeafItem to={`/${PERFIL}/${SOLICITACOES_AUTORIZADAS}`}>
+            Autorizadas
+          </LeafItem>
+          <LeafItem to={`/${PERFIL}/${SOLICITACOES_NEGADAS}`}>Negadas</LeafItem>
+          <LeafItem to={`/${PERFIL}/${SOLICITACOES_CANCELADAS}`}>
+            Canceladas
+          </LeafItem>
+        </SubMenu>
+      )}
       {usuarioEhCODAEGestaoAlimentacao() && (
         <SubMenu
           icon="fa-chevron-down"

--- a/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
@@ -4,10 +4,14 @@ import {
   LANCAMENTO_INICIAL,
   LANCAMENTO_MEDICAO_INICIAL
 } from "configs/constants";
-import { usuarioEhEscola } from "helpers/utilities";
+import {
+  usuarioEhEscola,
+  usuarioEscolaEhGestaoDireta
+} from "helpers/utilities";
 
 export default () => {
-  const exibirLancamentoMedicaoInicial = usuarioEhEscola();
+  const exibirLancamentoMedicaoInicial =
+    usuarioEhEscola() && !usuarioEscolaEhGestaoDireta();
 
   return (
     <Menu

--- a/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
@@ -9,6 +9,7 @@ import {
   usuarioEhTerceirizada,
   usuarioEhEscola,
   usuarioEhDRE,
+  usuarioEscolaEhGestaoDireta,
   usuarioEscolaEhGestaoMistaParceira
 } from "helpers/utilities";
 import * as constants from "configs/constants";
@@ -18,7 +19,9 @@ const MenuRelatorios = () => {
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhCODAEGestaoAlimentacao() ||
     usuarioEhCODAEGestaoProduto() ||
-    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    (usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()) ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhTerceirizada() ||
     usuarioEhCODAENutriManifestacao();
@@ -31,14 +34,18 @@ const MenuRelatorios = () => {
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhTerceirizada() ||
-    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    (usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()) ||
     usuarioEhCODAEDietaEspecial();
 
   const exibirProdutosSuspensos =
     usuarioEhCODAEGestaoProduto() ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhTerceirizada() ||
-    (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+    (usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()) ||
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhCODAENutriManifestacao();
 
@@ -46,7 +53,7 @@ const MenuRelatorios = () => {
     usuarioEhCODAEDietaEspecial() ||
     usuarioEhNutricionistaSupervisao() ||
     usuarioEhDRE() ||
-    usuarioEhEscola();
+    (usuarioEhEscola() && !usuarioEscolaEhGestaoDireta());
 
   return (
     <Menu id="Relatorios" icon="fa-file-alt" title={"Relatórios"}>

--- a/src/components/screens/PainelInicial/index.jsx
+++ b/src/components/screens/PainelInicial/index.jsx
@@ -14,6 +14,7 @@ import {
   usuarioEhCODAEDietaEspecial,
   usuarioEhDRE,
   usuarioEhNutricionistaSupervisao,
+  usuarioEscolaEhGestaoDireta,
   usuarioEscolaEhGestaoMistaParceira,
   exibirGA
 } from "helpers/utilities";
@@ -29,7 +30,9 @@ const PainelInicial = ({ history }) => {
           usuarioEhTerceirizada() ||
           usuarioEhDRE() ||
           usuarioEhNutricionistaSupervisao() ||
-          (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())) && (
+          (usuarioEhEscola() &&
+            !usuarioEscolaEhGestaoMistaParceira() &&
+            !usuarioEscolaEhGestaoDireta())) && (
           <Col xs={24} sm={24} md={24} lg={8} xl={8}>
             <CardLogo
               titulo={"Gestão de Alimentação"}
@@ -61,7 +64,9 @@ const PainelInicial = ({ history }) => {
         usuarioEhTerceirizada() ||
         usuarioEhNutricionistaSupervisao() ||
         usuarioEhDRE() ||
-        (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())) && (
+        (usuarioEhEscola() &&
+          !usuarioEscolaEhGestaoMistaParceira() &&
+          !usuarioEscolaEhGestaoDireta())) && (
         <Col xs={24} sm={24} md={24} lg={8} xl={8}>
           <CardLogo
             titulo={"Gestão de Produto"}

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -107,6 +107,7 @@ import {
   usuarioEhDistribuidora,
   usuarioComAcessoTelaEntregasDilog,
   usuarioEhCoordenadorNutriSupervisao,
+  usuarioEscolaEhGestaoDireta,
   usuarioEscolaEhGestaoMistaParceira,
   validaPerfilEscolaMistaParceira
 } from "../helpers/utilities";
@@ -180,7 +181,9 @@ const routesConfig = [
     component: painelGestaoAlimentacao(),
     exact: true,
     tipoUsuario:
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta()) ||
       usuarioEhDRE() ||
       usuarioEhCODAEGestaoAlimentacao() ||
       usuarioEhCODAENutriManifestacao() ||
@@ -228,25 +231,37 @@ const routesConfig = [
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_AUTORIZADAS}`,
     component: StatusSolicitacoesAutorizadasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_PENDENTES}`,
     component: StatusSolicitacoesPendentesEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_CANCELADAS}`,
     component: StatusSolicitacoesCanceladasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACOES_NEGADAS}`,
     component: StatusSolicitacoesRecusadasEscolaPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/status-solicitacoes`,
@@ -258,32 +273,46 @@ const routesConfig = [
     path: `/${constants.ESCOLA}/${constants.INCLUSAO_ALIMENTACAO}`,
     component: inclusaoCardapio(),
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.ALTERACAO_TIPO_ALIMENTACAO}`,
     component: alteracaoCardapio(),
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SOLICITACAO_KIT_LANCHE}`,
-    //AQUI POW
     component: PainelPageKitLanche.PainelPedidosEscola,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.INVERSAO_CARDAPIO}`,
     component: RelatorioPageInversaoDiaCardapio.InversaoDeDiaDeCardapioPage,
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.ESCOLA}/${constants.SUSPENSAO_ALIMENTACAO}`,
     component: suspensaoAlimentacao(),
     exact: false,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.DRE}/${constants.SOLICITACOES}`,
@@ -808,7 +837,8 @@ const routesConfig = [
     path: `/${constants.PESQUISA_DESENVOLVIMENTO}/${constants.BUSCA_PRODUTO}`,
     component: BuscaAvancadaProdutoPage,
     exact: true,
-    tipoUsuario: validaPerfilEscolaMistaParceira()
+    tipoUsuario:
+      validaPerfilEscolaMistaParceira() && !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -856,7 +886,8 @@ const routesConfig = [
     }`,
     component: RelatorioSituacaoProduto,
     exact: true,
-    tipoUsuario: validaPerfilEscolaMistaParceira()
+    tipoUsuario:
+      validaPerfilEscolaMistaParceira() && !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -869,13 +900,18 @@ const routesConfig = [
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/responder-questionamento-ue`,
     component: ResponderQuestionamentoUEPage,
     exact: true,
-    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()
+    tipoUsuario:
+      usuarioEhEscola() &&
+      !usuarioEscolaEhGestaoMistaParceira() &&
+      !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${
@@ -919,7 +955,9 @@ const routesConfig = [
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -935,7 +973,9 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhDRE() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -956,7 +996,9 @@ const routesConfig = [
       usuarioEhTerceirizada() ||
       usuarioEhCODAEGestaoProduto() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -968,7 +1010,9 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhTerceirizada() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -1002,7 +1046,9 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${
@@ -1019,7 +1065,9 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhDRE() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: "/painel-gestao-produto",
@@ -1032,7 +1080,9 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhTerceirizada() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta()) ||
       usuarioEhDRE()
   },
   {
@@ -1042,7 +1092,9 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira())
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${constants.SUSPENSAO_DE_PRODUTO}`,
@@ -1053,7 +1105,9 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhTerceirizada() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta()) ||
       usuarioEhCODAENutriManifestacao()
   },
   {
@@ -1079,7 +1133,9 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhQualquerCODAE() ||
       usuarioEhTerceirizada() ||
-      (usuarioEhEscola() && !usuarioEscolaEhGestaoMistaParceira()) ||
+      (usuarioEhEscola() &&
+        !usuarioEscolaEhGestaoMistaParceira() &&
+        !usuarioEscolaEhGestaoDireta()) ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhCODAENutriManifestacao()
   },
@@ -1157,7 +1213,7 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhDRE() ||
-      usuarioEhEscola()
+      (usuarioEhEscola() && !usuarioEscolaEhGestaoDireta())
   },
   {
     path: `/${constants.DIETA_ESPECIAL}/${constants.PROTOCOLO_PADRAO_DIETA}`,
@@ -1191,7 +1247,7 @@ const routesConfig = [
     }`,
     component: LancamentoMedicaoInicialPage,
     exact: true,
-    tipoUsuario: usuarioEhEscola()
+    tipoUsuario: usuarioEhEscola() && !usuarioEscolaEhGestaoDireta()
   },
   {
     path: `/${constants.LOGISTICA}/${

--- a/src/helpers/permissions.js
+++ b/src/helpers/permissions.js
@@ -2,11 +2,12 @@ import {
   usuarioEhCODAEDietaEspecial,
   usuarioEhNutricionistaSupervisao,
   usuarioEhDRE,
-  usuarioEhEscola
+  usuarioEhEscola,
+  usuarioEscolaEhGestaoDireta
 } from "./utilities";
 
 export const podeAcessarRelatorioQuantSolicDietaEsp =
   usuarioEhCODAEDietaEspecial() ||
   usuarioEhNutricionistaSupervisao() ||
   usuarioEhDRE() ||
-  usuarioEhEscola();
+  (usuarioEhEscola() && !usuarioEscolaEhGestaoDireta());

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -354,6 +354,10 @@ export const validaPerfilEscolaMistaParceira = () => {
   }
 };
 
+export const usuarioEscolaEhGestaoDireta = () => {
+  return [TIPO_GESTAO.DIRETA].includes(localStorage.getItem("tipo_gestao"));
+};
+
 export const usuarioEhEscolaAbastecimento = () => {
   return [
     PERFIL.ADMINISTRADOR_ESCOLA_ABASTECIMENTO,


### PR DESCRIPTION
# Proposta

Este PR visa remover acessos de GA, PeD, Lançamento e Relatórios para escola tipo gestão direta

# Referência do Azure

- 61312

# Tarefas para concluir

- [x] criar validação para escola tipo gestão direta
- [x] incluir escola tipo gestão direta na validação de acesso de relatórios quantitativos dieta especial
- [x] remover submenus de Relatórios para escola tipo gestão direta no menu lateral
- [x] remover submenu de Lançamento Inicial para escola tipo gestão direta no menu lateral
- [x] remover submenus de Gestão de Alimentação para escola tipo gestão direta no menu lateral
- [x] remover menus de GA, PeD, Lançamento e Relatórios da barra lateral para escola tipo gestão direta
- [x] bloquear rotas de GA, PeD, Lançamento e Relatórios para escola tipo gestão direta
- [x] remover menus de GA e PeD para escola tipo gestão direta