### PR TITLE
Feature: usar tipos_alimentacao ao invés de combos

### DIFF
--- a/src/components/SuspensaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/SuspensaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
@@ -121,7 +121,7 @@ export const CorpoRelatorio = props => {
                 <td>
                   {stringSeparadaPorVirgulas(
                     quantidade_por_periodo.tipos_alimentacao,
-                    "label"
+                    "nome"
                   )}
                 </td>
                 <td>{quantidade_por_periodo.numero_alunos}</td>

--- a/src/components/SuspensaoDeAlimentacao/index.jsx
+++ b/src/components/SuspensaoDeAlimentacao/index.jsx
@@ -234,12 +234,14 @@ class FoodSuspensionEditor extends Component {
         if (periodoProps.nome === periodoResp.periodo_escolar.nome) {
           periodoProps.validador = [];
           periodoProps.checked = false;
-          periodoProps.tipos_alimentacao = periodoResp.combos.map(combo => {
-            return {
-              uuid: combo.uuid,
-              nome: combo.label
-            };
-          });
+          periodoProps.tipos_alimentacao = periodoResp.tipos_alimentacao.map(
+            tipo_alimentacao => {
+              return {
+                uuid: tipo_alimentacao.uuid,
+                nome: tipo_alimentacao.nome
+              };
+            }
+          );
         }
       });
     });
@@ -346,6 +348,7 @@ class FoodSuspensionEditor extends Component {
   }
 
   onSubmit(values) {
+    // Refatorar aqui.
     values.dias_razoes = deepCopy(this.state.dias_razoes);
     values.dias_razoes.forEach(value => {
       const idx = values.dias_razoes.findIndex(


### PR DESCRIPTION
# Proposta

Este PR visa usar tipos de alimentação ao invés de combos para solicitações de suspensão

# Referência do Azure

- 57922

# Tarefas para concluir na Suspensão de Alimentação
 
- [x] usar tipos de alimentação
- [x] trocar label por nome
