### PR TITLE
Feature: usar tipos de alimentação em alteração de cardápio

### DIFF
--- a/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -148,19 +148,28 @@ export const CorpoRelatorio = props => {
           (
             {
               periodo_escolar,
-              tipo_alimentacao_de,
+              tipos_alimentacao_de,
               tipo_alimentacao_para,
               qtd_alunos,
               faixas_etarias
             },
             key
           ) => {
+            let alimentos = tipos_alimentacao_de.map(alimento => alimento.nome);
+            let tipos_alimentos_formatados = "";
+            for (let i = 0; i < alimentos.length; i++) {
+              tipos_alimentos_formatados =
+                tipos_alimentos_formatados + alimentos[i];
+              if (i + 1 !== alimentos.length) {
+                tipos_alimentos_formatados = tipos_alimentos_formatados + ", ";
+              }
+            }
             return (
               <Fragment key={key}>
                 <tr>
                   <td>{periodo_escolar && periodo_escolar.nome}</td>
-                  <td>{tipo_alimentacao_de.label}</td>
-                  <td>{tipo_alimentacao_para.label}</td>
+                  <td>{tipos_alimentos_formatados}</td>
+                  <td>{tipo_alimentacao_para.nome}</td>
                   <td>{qtd_alunos}</td>
                 </tr>
                 {ehInclusaoCei(tipoSolicitacao) && (

--- a/src/components/AlteracaoDeCardapio/helper.js
+++ b/src/components/AlteracaoDeCardapio/helper.js
@@ -21,7 +21,14 @@ export const construirPeriodosECombos = periodos => {
         return {
           nome: alimento.nome,
           uuid: alimento.uuid,
-          substituicoes: []
+          substituicoes: periodo.tipos_alimentacao
+            .filter(substituto => substituto.uuid !== alimento.uuid)
+            .map(substituto => {
+              return {
+                nome: substituto.nome,
+                uuid: substituto.uuid
+              };
+            })
         };
       })
     };

--- a/src/components/AlteracaoDeCardapio/helper.js
+++ b/src/components/AlteracaoDeCardapio/helper.js
@@ -17,16 +17,11 @@ export const construirPeriodosECombos = periodos => {
       nome: periodo.periodo_escolar.nome,
       uuid: periodo.periodo_escolar.uuid,
       style: backgroundLabelPeriodo(periodo.periodo_escolar.nome),
-      tipos_alimentacao: periodo.combos.map(combo => {
+      tipos_alimentacao: periodo.tipos_alimentacao.map(alimento => {
         return {
-          nome: combo.label,
-          uuid: combo.uuid,
-          substituicoes: combo.substituicoes.map(substituicao => {
-            return {
-              nome: substituicao.label,
-              uuid: substituicao.uuid
-            };
-          })
+          nome: alimento.nome,
+          uuid: alimento.uuid,
+          substituicoes: []
         };
       })
     };

--- a/src/components/AlteracaoDeCardapio/validacao.js
+++ b/src/components/AlteracaoDeCardapio/validacao.js
@@ -8,7 +8,7 @@ export const validateSubmit = (values, meusDados) => {
     totalAlunos += parseInt(values.substituicoes_MANHA.numero_de_alunos);
     values["substituicoes"].push({
       periodo_escolar: values.substituicoes_MANHA.periodo,
-      tipo_alimentacao_de: values.substituicoes_MANHA.tipo_alimentacao_de,
+      tipos_alimentacao_de: values.substituicoes_MANHA.tipos_alimentacao_de,
       tipo_alimentacao_para: values.substituicoes_MANHA.tipo_alimentacao_para,
       qtd_alunos: values.substituicoes_MANHA.numero_de_alunos
     });
@@ -18,7 +18,7 @@ export const validateSubmit = (values, meusDados) => {
     totalAlunos += parseInt(values.substituicoes_TARDE.numero_de_alunos);
     values["substituicoes"].push({
       periodo_escolar: values.substituicoes_TARDE.periodo,
-      tipo_alimentacao_de: values.substituicoes_TARDE.tipo_alimentacao_de,
+      tipos_alimentacao_de: values.substituicoes_TARDE.tipos_alimentacao_de,
       tipo_alimentacao_para: values.substituicoes_TARDE.tipo_alimentacao_para,
       qtd_alunos: values.substituicoes_TARDE.numero_de_alunos
     });
@@ -28,7 +28,7 @@ export const validateSubmit = (values, meusDados) => {
     totalAlunos += parseInt(values.substituicoes_NOITE.numero_de_alunos);
     values["substituicoes"].push({
       periodo_escolar: values.substituicoes_NOITE.periodo,
-      tipo_alimentacao_de: values.substituicoes_NOITE.tipo_alimentacao_de,
+      tipos_alimentacao_de: values.substituicoes_NOITE.tipos_alimentacao_de,
       tipo_alimentacao_para: values.substituicoes_NOITE.tipo_alimentacao_para,
       qtd_alunos: values.substituicoes_NOITE.numero_de_alunos
     });
@@ -38,7 +38,7 @@ export const validateSubmit = (values, meusDados) => {
     totalAlunos += parseInt(values.substituicoes_INTEGRAL.numero_de_alunos);
     values["substituicoes"].push({
       periodo_escolar: values.substituicoes_INTEGRAL.periodo,
-      tipo_alimentacao_de: values.substituicoes_INTEGRAL.tipo_alimentacao_de,
+      tipos_alimentacao_de: values.substituicoes_INTEGRAL.tipos_alimentacao_de,
       tipo_alimentacao_para:
         values.substituicoes_INTEGRAL.tipo_alimentacao_para,
       qtd_alunos: values.substituicoes_INTEGRAL.numero_de_alunos


### PR DESCRIPTION
# Proposta

Este PR visa usar tipos de alimentação nas solictições de alteração de cardápio

# Referência do Azure

- 57922

# Tarefas para concluir na Alteração de cardápio 

- [x] formatação de opções do componente de seleção de alimentos substituídos
- [x] trocar nome do componente de seleção nas validações
- [x] adicionar componente de multipla seleção
- [x] adicionar regra para não permitir que usuário selecione como substituto um alimento incluso na lista de alimentos substituídos
- [x] formatar nome dos alimentos substituídos para exibição na tabela do relatório