### PR TITLE
Fix/57563-invalid-date-datepicker-component

### DIFF
--- a/src/components/Shareable/DatePicker/index.jsx
+++ b/src/components/Shareable/DatePicker/index.jsx
@@ -56,11 +56,13 @@ export class InputComData extends Component {
 
   handleChange(date) {
     this.props.input.onChange(
-      this.props.writable
-        ? date
-        : moment(date).format(
-            this.props.dateFormat || this.defaultProps.dateFormat
-          )
+      date
+        ? this.props.writable
+          ? date
+          : moment(date).format(
+              this.props.dateFormat || this.defaultProps.dateFormat
+            )
+        : null
     );
   }
 


### PR DESCRIPTION
# Proposta

Este PR visa evitar erro de invalid date quando componente tem prop writable

# Referência do Azure

- 57563

# Tarefas para concluir

- [x] evitar erro de invalid date quando componente tem prop writable