### PR TITLE
Hotfix/63540

### DIFF
--- a/src/components/screens/Cadastros/CadastroLote/components/LotesCadastrados/index.jsx
+++ b/src/components/screens/Cadastros/CadastroLote/components/LotesCadastrados/index.jsx
@@ -147,7 +147,7 @@ class LotesCadastrados extends Component {
                             <tr key={indice} className="relationed-companies">
                               <td className="pt-0 pb-0 link" colSpan="4">
                                 {`${escola.codigo_eol} - ${escola.nome} - ${
-                                  escola.lote
+                                  escola.lote.nome
                                 }`}
                               </td>
                             </tr>

--- a/src/components/screens/Cadastros/CadastroLote/index.jsx
+++ b/src/components/screens/Cadastros/CadastroLote/index.jsx
@@ -41,7 +41,8 @@ class CadastroLote extends Component {
       loading: true,
       uuid: null,
       redirect: false,
-      deactivate: true
+      deactivate: true,
+      escolasParaEdicaoCarregadas: false
     };
     this.exibirModal = this.exibirModal.bind(this);
     this.fecharModal = this.fecharModal.bind(this);
@@ -50,13 +51,16 @@ class CadastroLote extends Component {
   }
 
   componentDidUpdate() {
-    const { loading, loteCarregado } = this.state;
+    const { loading, loteCarregado, escolasParaEdicaoCarregadas } = this.state;
     const {
       meusDados,
       lotes,
       diretoriasRegionais,
       tiposGestao,
-      subprefeituras
+      subprefeituras,
+      location,
+      diretoria_regional,
+      getEscolasPorDre
     } = this.props;
     if (
       lotes !== [] &&
@@ -100,7 +104,7 @@ class CadastroLote extends Component {
           let escolasSelecionadasNomes = [];
           response.data.escolas.forEach(escola => {
             escolasSelecionadasNomes.push(
-              `${escola.codigo_eol} - ${escola.nome} - ${escola.lote}`
+              `${escola.codigo_eol} - ${escola.nome} - ${escola.lote.nome}`
             );
           });
           this.setState({
@@ -121,6 +125,16 @@ class CadastroLote extends Component {
           this.setState({ loteCarregado: true });
         }
       });
+    }
+
+    if (
+      location &&
+      location.state &&
+      diretoria_regional &&
+      !escolasParaEdicaoCarregadas
+    ) {
+      getEscolasPorDre(diretoria_regional);
+      this.setState({ escolasParaEdicaoCarregadas: true });
     }
   }
 


### PR DESCRIPTION
Hotfix requerida pela PO para correção do Cadastro de lotes.

Corrige:

- [x] Permissão de adição/remoção de escolas na edição de lotes 
- [x] label que estava aparecendo [object Object] 