### PR TITLE
Fix/60507-GA-alterar-entidade-que-realizou-cancelamento-da-solicitação

### DIFF
--- a/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/AlteracaoDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -108,6 +108,7 @@ export const CorpoRelatorio = props => {
           <FluxoDeStatus
             listaDeStatus={alteracaoDeCardapio.logs}
             fluxo={fluxoPartindoEscola}
+            eh_gestao_alimentacao={true}
           />
         </div>
       )}

--- a/src/components/InclusaoDeAlimentacao/Escola/Relatorio/index.jsx
+++ b/src/components/InclusaoDeAlimentacao/Escola/Relatorio/index.jsx
@@ -249,6 +249,7 @@ class Relatorio extends Component {
                       <FluxoDeStatus
                         listaDeStatus={inclusaoDeAlimentacao.logs}
                         fluxo={fluxoPartindoEscola}
+                        eh_gestao_alimentacao={true}
                       />
                     </div>
                   )}

--- a/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
@@ -196,7 +196,11 @@ export class CorpoRelatorio extends Component {
         <hr />
         {logs && (
           <div className="row">
-            <FluxoDeStatus listaDeStatus={logs} fluxo={fluxoPartindoEscola} />
+            <FluxoDeStatus
+              listaDeStatus={logs}
+              fluxo={fluxoPartindoEscola}
+              eh_gestao_alimentacao={true}
+            />
           </div>
         )}
         <hr />

--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -105,6 +105,7 @@ export const CorpoRelatorio = props => {
           <FluxoDeStatus
             listaDeStatus={inversaoDiaCardapio.logs}
             fluxo={fluxoPartindoEscola}
+            eh_gestao_alimentacao={true}
           />
         </div>
       )}

--- a/src/components/Shareable/FluxoDeStatus/index.jsx
+++ b/src/components/Shareable/FluxoDeStatus/index.jsx
@@ -8,7 +8,12 @@ import "./style.scss";
 import { deepCopy } from "../../../helpers/utilities";
 
 export const FluxoDeStatus = props => {
-  const { listaDeStatus, fluxo, eh_importado = false } = props;
+  const {
+    listaDeStatus,
+    fluxo,
+    eh_importado = false,
+    eh_gestao_alimentacao = false
+  } = props;
   let cloneListaDeStatus = deepCopy(listaDeStatus);
   cloneListaDeStatus = formatarLogs(cloneListaDeStatus);
   const fluxoNaoFinalizado =
@@ -36,7 +41,10 @@ export const FluxoDeStatus = props => {
     if (log.status_evento_explicacao === "Escola solicitou cancelamento") {
       logFormatado = "Escola solicitou cancelamento";
     }
-    if (log.status_evento_explicacao === "Escola cancelou") {
+    if (
+      log.status_evento_explicacao === "Escola cancelou" &&
+      !eh_gestao_alimentacao
+    ) {
       logFormatado = "CODAE autorizou cancelamento";
     }
     return logFormatado;
@@ -53,7 +61,10 @@ export const FluxoDeStatus = props => {
         if (log.status_evento_explicacao === "Escola solicitou cancelamento") {
           return "Escola solicitou cancelamento";
         }
-        if (log.status_evento_explicacao === "Escola cancelou") {
+        if (
+          log.status_evento_explicacao === "Escola cancelou" &&
+          !eh_gestao_alimentacao
+        ) {
           return "CODAE autorizou cancelamento";
         }
         return log.status_evento_explicacao;

--- a/src/components/Shareable/ModalCancelarSolicitacao_/index.jsx
+++ b/src/components/Shareable/ModalCancelarSolicitacao_/index.jsx
@@ -32,7 +32,7 @@ export class ModalCancelarSolicitacao extends Component {
         this.props.loadSolicitacao(uuid, this.props.tipoSolicitacao);
     } else {
       this.props.closeModal();
-      toastError(resp.data.detail);
+      toastError(resp.data ? resp.data.detail : resp.detail);
     }
   }
 

--- a/src/components/SolicitacaoDeKitLanche/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/SolicitacaoDeKitLanche/Relatorio/componentes/CorpoRelatorio.jsx
@@ -112,6 +112,7 @@ export const CorpoRelatorio = props => {
         <FluxoDeStatus
           listaDeStatus={solicitacaoKitLanche.logs}
           fluxo={fluxoPartindoEscola}
+          eh_gestao_alimentacao={true}
         />
       </div>
       <hr />

--- a/src/components/SolicitacaoUnificada/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/SolicitacaoUnificada/Relatorio/componentes/CorpoRelatorio.jsx
@@ -74,6 +74,7 @@ export const CorpoRelatorio = props => {
         <FluxoDeStatus
           fluxo={fluxoPartindoDRE}
           listaDeStatus={solicitacaoUnificada.logs}
+          eh_gestao_alimentacao={true}
         />
         <hr />
 


### PR DESCRIPTION
# Proposta

Este PR visa criar prop para não formatar log de 'Escola cancelou' quando solicitação é de gestão de alimentação

# Referência do Azure

- 60507

# Tarefas para concluir

- [x] criar prop para não formatar log de 'Escola cancelou' quando solicitação é de gestão de alimentação
- [x] evitar erro no toast quando escola cancela solicitação