### PR TITLE
Feature/65442-GA-inclusão-alimentação-retirar-campo-obs-para-sol-não-contínua

### DIFF
--- a/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
@@ -259,17 +259,19 @@ export class CorpoRelatorio extends Component {
         {ehInclusaoCei(tipoSolicitacao) && (
           <TabelaFaixaEtaria faixas={quantidade_alunos_por_faixas_etarias} />
         )}
-        <div className="row">
-          <div className="col-12 report-label-value">
-            <p>Observações</p>
-            <p
-              className="value"
-              dangerouslySetInnerHTML={{
-                __html: observacao
-              }}
-            />
+        {ehInclusaoContinua(tipoSolicitacao) && (
+          <div className="row">
+            <div className="col-12 report-label-value">
+              <p>Observações</p>
+              <p
+                className="value"
+                dangerouslySetInnerHTML={{
+                  __html: observacao
+                }}
+              />
+            </div>
           </div>
-        </div>
+        )}
         {justificativaNegacao && (
           <div className="row">
             <div className="col-12 report-label-value">


### PR DESCRIPTION
# Proposta

Este PR visa incluir validação de inclusão contínua para exibir campo Observações

# Referência do Azure

- 65442

# Tarefas para concluir

- [x] incluir validação de inclusão contínua para exibir campo Observações