### PR TITLE
Bugfix/66161 alimentos reposicao

### DIFF
--- a/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
+++ b/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
@@ -117,6 +117,13 @@ export default () => {
         });
       });
     }
+
+    guiaResponse.alimentos = guiaResponse.alimentos.filter(alimento => {
+      alimento.embalagens = alimento.embalagens.filter(
+        embalagem => embalagem.qtd_a_receber !== 0
+      );
+      return alimento.embalagens.length !== 0;
+    });
   };
 
   const carregarReposicaoEdicao = async uuid => {


### PR DESCRIPTION
Este PR:
- Corrige o bug que causava alimentos sem conferencia individual (porém totalmente recebidos) a aparecer na tela de reposição de alimentos