### PR TITLE
Bugfix/66154 fix botao repor

### DIFF
--- a/src/components/screens/Logistica/ConferirEntrega/components/ListagemGuias/index.js
+++ b/src/components/screens/Logistica/ConferirEntrega/components/ListagemGuias/index.js
@@ -12,7 +12,9 @@ const ListagemSolicitacoes = ({ guias }) => {
 
   const checaReposicao = guia => {
     let alimentosPendentes = guia.alimentos.filter(
-      alimento => alimento.embalagens[0].qtd_a_receber > 0
+      alimento =>
+        alimento.embalagens[0].qtd_a_receber > 0 ||
+        (alimento.embalagens[1] && alimento.embalagens[1].qtd_a_receber > 0)
     );
     return alimentosPendentes.length > 0;
   };


### PR DESCRIPTION
Este PR:
- Corrige problema em que apenas a primeira embalagem da guia era verificada para decidir se o botão "Repor" apareceria ou não