### PR TITLE
65430-correção-seletor-campo-distribuidor

### DIFF
--- a/src/components/Shareable/MultiSelectDistribuidores/index.jsx
+++ b/src/components/Shareable/MultiSelectDistribuidores/index.jsx
@@ -15,7 +15,7 @@ const MultiSelectDistribuidores = ({ name, label, className }) => {
         const listaDistribuidores = await getNomesDistribuidores();
         let listaRsultados = listaDistribuidores.data.results;
         let listaFormatada = listaRsultados.map(element => {
-          return { value: element.uuid, label: element.nome_fantasia };
+          return { value: element.uuid, label: element.razao_social };
         });
         setDistribuidores(listaFormatada);
       } catch (erro) {


### PR DESCRIPTION
Este PR:

- Modifica de "nome fantasista" para "razão social" os nomes exibidos no seletor de distribuidores.