### PR TITLE
Feature/65382-GA-limitar-período-merenda-seca-em-5-dias-úteis

### DIFF
--- a/src/reducers/alteracaoCardapioReducer.js
+++ b/src/reducers/alteracaoCardapioReducer.js
@@ -17,6 +17,8 @@ export default function reducer(state = {}, action) {
           action.data.data_inicial = null;
           action.data.data_final = null;
           action.data.motivo = action.data.motivo.uuid;
+        } else if (typeof action.data.motivo === "object") {
+          action.data.motivo = action.data.motivo.uuid;
         }
         action.data.substituicoes.forEach(function(substituicao) {
           action.data[`substituicoes_${substituicao.periodo_escolar.nome}`] = {

--- a/src/services/diasUteis.service.js
+++ b/src/services/diasUteis.service.js
@@ -1,12 +1,11 @@
+import axios from "./_base";
 import { API_URL } from "../constants/config";
 
-export const getDiasUteis = () => {
+export const getDiasUteis = async params => {
   const url = `${API_URL}/dias-uteis/`;
-  return fetch(url)
-    .then(resultado => {
-      return resultado.json();
-    })
-    .catch(error => {
-      console.log(error);
-    });
+  try {
+    return await axios.get(url, { params });
+  } catch (error) {
+    console.log(error);
+  }
 };


### PR DESCRIPTION
# Proposta

Este PR limitar período de merenda seca em 5 dias úteis

# Referência do Azure

- 65382

# Tarefas para concluir

- [x] limitar data máxima campo 'Até' com base na data inserida no campo 'De' - período máximo de 5 dias úteis
- [x] permitir método getDiasUteis receber e enviar parâmetros
- [x] ajustar reducer de alteração de cardápio para rascunho