### PR TITLE
feature/67915-aumentar-fontes-icones-breadcrumb

### DIFF
--- a/src/components/Shareable/Breadcrumb/index.jsx
+++ b/src/components/Shareable/Breadcrumb/index.jsx
@@ -7,11 +7,12 @@ export default class Breadcrumb extends Component {
     const { home, anteriores, atual } = this.props;
     return (
       <div className="breadcrumb-row row">
-        <div className="col-9">
+        <div className="col-10">
           <ul className="br-breadcrumb">
             <li>
               <Link className={`home ${!atual && "is-active"}`} to={home}>
-                <i className="fas fa-home" />
+                <i className="fas fa-home home" />
+                Início
               </Link>
             </li>
             {anteriores &&
@@ -32,7 +33,7 @@ export default class Breadcrumb extends Component {
             )}
           </ul>
         </div>
-        <div className="col-3 text-right contrast">
+        <div className="col-2 text-right contrast">
           <i className="fas fa-adjust" /> Contraste
         </div>
       </div>

--- a/src/components/Shareable/Breadcrumb/style.scss
+++ b/src/components/Shareable/Breadcrumb/style.scss
@@ -20,7 +20,7 @@
     li {
       color: $blackSubtle;
       display: inline;
-      font-size: 10px;
+      font-size: 13px;
       font-weight: 500;
       a {
         color: $blackSubtle;
@@ -30,6 +30,9 @@
           color: inherit;
           text-decoration: underline;
         }
+      }
+      .home {
+        padding-right: 10px;
       }
     }
     .is-active {
@@ -54,7 +57,7 @@
 
   .contrast {
     cursor: pointer;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: bold;
     color: $blackSubtle;
   }

--- a/src/components/Shareable/Page/style.scss
+++ b/src/components/Shareable/Page/style.scss
@@ -8,7 +8,7 @@
 }
 
 .page-title {
-  padding-top: 1.2rem;
+  padding-top: 1.8rem;
 }
 
 .page-no-sidebar-card {

--- a/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/Filtros/index.jsx
+++ b/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/Filtros/index.jsx
@@ -125,7 +125,7 @@ export default ({
                 />
               </div>
             </div>
-            <div className="row mt-3">
+            <div className="row">
               <div className="col">
                 <Field
                   component={InputText}

--- a/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/styles.scss
+++ b/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/styles.scss
@@ -2,6 +2,7 @@
   .menu-inferior {
     font-size: 14px !important;
   }
+  padding: 1.25rem !important;
 }
 
 .card-consulta-requisicao-entrega {

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -10069,4 +10069,5 @@ a.text-dark:hover, a.text-dark:focus {
   font-size: 24px;
   line-height: normal;
   color: #353535;
+  margin-bottom: 0px;
 }


### PR DESCRIPTION
Este PR:

- Acrescenta a palavra início no breadcrumb
- Aumenta fonte e espaçamento
- Reajusta elementos de estilos do título, card-body e row