### PR TITLE
Feature: filtro para remover a opção de Merenda seca

### DIFF
--- a/src/components/InclusaoDeAlimentacao/helper.js
+++ b/src/components/InclusaoDeAlimentacao/helper.js
@@ -95,6 +95,9 @@ export const abstraiPeriodosComAlunosMatriculados = (
       periodo.uuid,
       periodosQuantidadeAlunos
     );
+    periodo["tipos_alimentacao"] = periodo.tipos_alimentacao.filter(
+      tipo_alimentacao => tipo_alimentacao.nome !== "Merenda seca"
+    );
   });
   return periodos;
 };


### PR DESCRIPTION
# Proposta

Este PR visa remover a opção de Merenda seca dos tipos de alimentação na solicitação de inclusão de alimento.

# Referência do Azure

- 65538

# Tarefas para concluir na Alteração de cardápio 

- [x] adicionar filtro para remover merenda seca