### PR TITLE
Feature/POC/66486-DE-mostrar-usuário-com-dieta-em-edição-aberta-em-tempo-real

### DIFF
--- a/src/components/Shareable/CardStatusDeSolicitacao/style.scss
+++ b/src/components/Shareable/CardStatusDeSolicitacao/style.scss
@@ -34,6 +34,10 @@
     span {
       font-weight: normal;
     }
+    .dietas-abertas {
+      font-weight: 900;
+      color: #000;
+    }
   }
   p.conferida {
     color: #198459 !important;

--- a/src/services/websocket.js
+++ b/src/services/websocket.js
@@ -1,0 +1,27 @@
+import { API_URL, ENVIRONMENT } from "constants/config";
+
+export function Websocket(url, onmessage, onclose) {
+  const host = API_URL.slice(API_URL.lastIndexOf("/") + 1);
+  let ws_url = `ws://${host}/ws/${url}`;
+
+  if (ENVIRONMENT === "production")
+    ws_url = `wss://${window.location.host}/ws/${url}`;
+
+  this.socket = new WebSocket(ws_url);
+
+  this.socket.onmessage = function(e) {
+    if (onmessage !== undefined) onmessage(e);
+  };
+
+  this.socket.onclose = function() {
+    console.error(
+      "Error while connecting in websocket! Trying to connect again in 5 seconds"
+    );
+
+    setTimeout(() => {
+      console.info("Reconnecting...");
+
+      if (onclose !== undefined) onclose();
+    }, 5000);
+  };
+}


### PR DESCRIPTION
# Proposta

Este PR visa realizar a viabilidade de trazer em tempo real quando no dashboard de dietas, no card de Recebidas demonstrar para os usuários que existe um outro usuário com a mesma dieta selecionada aberta para edição e autorização/negação da dieta.

# Referência do Azure

- 66486

# Tarefas para concluir

- [x] criar arquivo de service websocket.js
- [x] utilizar conexão ws na tela de relatório e exibir quem está com dieta em edição aberta
- [x] utilizar conexão ws no card de Recebidas e exibir quem está com dieta em edição aberta