### PR TITLE
feature/69408-alterar-cadastro-produto-solicitacao-homologacao

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuGestaoDeProduto.jsx
@@ -40,7 +40,7 @@ const MenuGestaoDeProduto = ({ activeMenu, onSubmenuClick }) => {
       </LeafItem>
       {exibirCadastro && (
         <LeafItem to={`/${PESQUISA_DESENVOLVIMENTO}/produto`}>
-          Cadastro de Produto
+          Solicitar Homologação do Produto
         </LeafItem>
       )}
       {exibirBusca && (

--- a/src/components/screens/Produto/Cadastro/BuscaProduto/index.jsx
+++ b/src/components/screens/Produto/Cadastro/BuscaProduto/index.jsx
@@ -288,7 +288,7 @@ export default class BuscaProduto extends Component {
                 }}
               />
               <Botao
-                texto={"Cadastrar Produtos"}
+                texto={"Solicitar Homologação"}
                 type={BUTTON_TYPE.BUTTON}
                 style={BUTTON_STYLE.GREEN}
                 onClick={() => {

--- a/src/components/screens/Produto/Cadastro/index.jsx
+++ b/src/components/screens/Produto/Cadastro/index.jsx
@@ -321,7 +321,7 @@ class cadastroProduto extends Component {
         response.status === HTTP_STATUS.CREATED ||
         response.status === HTTP_STATUS.OK
       ) {
-        toastSuccess("Produto cadastrado com sucesso.");
+        toastSuccess("Solicitação de homologação enviada com sucesso.");
         this.setState({
           payload: retornaPayloadDefault(),
           renderizaFormDietaEspecial: false,


### PR DESCRIPTION
Este PR:

- Renomeia item de menu inicial perfil terceirizada.
- Renomeia botão de tela "Ficha de identificação de Produto".
- Renomeia mensagem de sucesso no envio da homologação.