### PR TITLE
feature 69662 melhoria qtd embalagem

### DIFF
--- a/src/components/Logistica/TabelaAlimentoConsolidado/index.jsx
+++ b/src/components/Logistica/TabelaAlimentoConsolidado/index.jsx
@@ -48,32 +48,14 @@ export default ({ alimentosConsolidado, className, mostrarPesoTotal }) => {
             <tr key={index}>
               <td>{item.nome_alimento}</td>
               <td>{fechada ? fechada.qtd_volume : "--"}</td>
-              <td>
-                {fechada ? (
-                  <>
-                    {fechada.descricao_embalagem}.{" "}
-                    {fechada.capacidade_embalagem}
-                    {fechada.unidade_medida}
-                  </>
-                ) : (
-                  "--"
-                )}
-              </td>
+              <td>{fechada ? <>{fechada.capacidade_completa}</> : "--"}</td>
               <td>{fracionada ? fracionada.qtd_volume : "--"}</td>
               <td>
-                {fracionada ? (
-                  <>
-                    {fracionada.descricao_embalagem}.{" "}
-                    {fracionada.capacidade_embalagem}
-                    {fracionada.unidade_medida}
-                  </>
-                ) : (
-                  "--"
-                )}
+                {fracionada ? <>{fracionada.capacidade_completa}</> : "--"}
               </td>
               {mostrarPesoTotal && (
                 <td>
-                  {item.peso_total}
+                  {String(item.peso_total).replace(".", ",")}{" "}
                   {item.total_embalagens[0].unidade_medida}
                 </td>
               )}

--- a/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
@@ -681,9 +681,7 @@ export default () => {
                                                   {fechada.descricao_embalagem}.
                                                 </td>
                                                 <td>
-                                                  {fechada.descricao_embalagem}.{" "}
-                                                  {fechada.capacidade_embalagem}
-                                                  {fechada.unidade_medida}
+                                                  {fechada.capacidade_completa}
                                                 </td>
                                                 <td>
                                                   <div className="form-tabela">
@@ -750,13 +748,8 @@ export default () => {
                                                 </td>
                                                 <td>
                                                   {
-                                                    fracionada.descricao_embalagem
+                                                    fracionada.capacidade_completa
                                                   }
-                                                  .{" "}
-                                                  {
-                                                    fracionada.capacidade_embalagem
-                                                  }
-                                                  {fracionada.unidade_medida}
                                                 </td>
                                                 <td>
                                                   <div className="form-tabela">

--- a/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
@@ -294,11 +294,7 @@ export default ({ reposicao }) => {
                           </td>
                           <td className="embalagem">
                             {fechada ? (
-                              <>
-                                {fechada.descricao_embalagem}.{" "}
-                                {fechada.capacidade_embalagem}
-                                {fechada.unidade_medida}
-                              </>
+                              <>{fechada.capacidade_completa}</>
                             ) : (
                               "--"
                             )}
@@ -320,11 +316,7 @@ export default ({ reposicao }) => {
                           </td>
                           <td className="embalagem">
                             {fracionada ? (
-                              <>
-                                {fracionada.descricao_embalagem}.{" "}
-                                {fracionada.capacidade_embalagem}
-                                {fracionada.unidade_medida}
-                              </>
+                              <>{fracionada.capacidade_completa}</>
                             ) : (
                               "--"
                             )}

--- a/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/ListagemGuias/index.jsx
+++ b/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/components/ListagemGuias/index.jsx
@@ -195,9 +195,7 @@ export default ({ solicitacao, situacao, arquivaDesarquivaGuias }) => {
                             <div>{alimento.embalagens[0].qtd_volume}</div>
                             <div>{alimento.embalagens[0].tipo_embalagem}</div>
                             <div>
-                              {alimento.embalagens[0].descricao_embalagem}{" "}
-                              {alimento.embalagens[0].capacidade_embalagem}{" "}
-                              {alimento.embalagens[0].unidade_medida}
+                              {alimento.embalagens[0].capacidade_completa}
                             </div>
                           </div>
                         </>

--- a/src/components/screens/Logistica/DetalhamentoGuia/components/ConferenciaDetalhe/index.jsx
+++ b/src/components/screens/Logistica/DetalhamentoGuia/components/ConferenciaDetalhe/index.jsx
@@ -109,15 +109,7 @@ export default ({ conferencia, reposicaoFlag }) => {
             const fechada = filtraEmbalagemPorTipo(item.embalagens, "FECHADA");
             let celEmbalagem = embalagem => (
               <td className="embalagem">
-                {embalagem ? (
-                  <>
-                    {embalagem.descricao_embalagem}.{" "}
-                    {embalagem.capacidade_embalagem}
-                    {embalagem.unidade_medida}
-                  </>
-                ) : (
-                  "--"
-                )}
+                {embalagem ? <>{embalagem.capacidade_completa}</> : "--"}
               </td>
             );
             return (

--- a/src/components/screens/Logistica/GestaoRequisicaoEntrega/components/ListagemGuias/index.jsx
+++ b/src/components/screens/Logistica/GestaoRequisicaoEntrega/components/ListagemGuias/index.jsx
@@ -144,9 +144,7 @@ export default ({ solicitacao, confirmaCancelamentoGuias }) => {
                             <div>{alimento.embalagens[0].qtd_volume}</div>
                             <div>{alimento.embalagens[0].tipo_embalagem}</div>
                             <div>
-                              {alimento.embalagens[0].descricao_embalagem}{" "}
-                              {alimento.embalagens[0].capacidade_embalagem}{" "}
-                              {alimento.embalagens[0].unidade_medida}
+                              {alimento.embalagens[0].capacidade_completa}
                             </div>
                           </div>
                         </>

--- a/src/components/screens/Logistica/InsucessoEntrega/components/ListagemGuias/index.js
+++ b/src/components/screens/Logistica/InsucessoEntrega/components/ListagemGuias/index.js
@@ -158,11 +158,7 @@ const ListagemGuias = ({ guias, ativos, setAtivos }) => {
                                   {alimento.embalagens[0].tipo_embalagem}
                                 </b>
                                 <br />
-                                {
-                                  alimento.embalagens[0].descricao_embalagem
-                                }{" "}
-                                {alimento.embalagens[0].capacidade_embalagem}{" "}
-                                {alimento.embalagens[0].unidade_medida}
+                                {alimento.embalagens[0].capacidade_completa}
                               </div>
 
                               {alimento.embalagens.length > 1 && (
@@ -178,14 +174,7 @@ const ListagemGuias = ({ guias, ativos, setAtivos }) => {
                                       {alimento.embalagens[1].tipo_embalagem}
                                     </b>
                                     <br />
-                                    {
-                                      alimento.embalagens[1].descricao_embalagem
-                                    }{" "}
-                                    {
-                                      alimento.embalagens[1]
-                                        .capacidade_embalagem
-                                    }{" "}
-                                    {alimento.embalagens[1].unidade_medida}
+                                    {alimento.embalagens[1].capacidade_completa}
                                   </div>
                                 </>
                               )}

--- a/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
+++ b/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
@@ -724,9 +724,7 @@ export default () => {
                                                   {fechada.descricao_embalagem}.
                                                 </td>
                                                 <td>
-                                                  {fechada.descricao_embalagem}.{" "}
-                                                  {fechada.capacidade_embalagem}
-                                                  {fechada.unidade_medida}
+                                                  {fechada.capacidade_completa}
                                                 </td>
                                                 <td>{fechada.qtd_a_receber}</td>
                                                 <td>
@@ -802,13 +800,8 @@ export default () => {
                                                 </td>
                                                 <td>
                                                   {
-                                                    fracionada.descricao_embalagem
+                                                    fracionada.capacidade_completa
                                                   }
-                                                  .{" "}
-                                                  {
-                                                    fracionada.capacidade_embalagem
-                                                  }
-                                                  {fracionada.unidade_medida}
                                                 </td>
                                                 <td>
                                                   {fracionada.qtd_a_receber}


### PR DESCRIPTION
Este PR:
- padroniza a exibição de quantidade das embalagens nas telas solicitadas na história 69662, utilizando virgula pra decimais e espaço entre o número e a unidade de medida