### PR TITLE
Feature/76462-PeD-tela-vincular-produtos-editais-incluir-campo-tipo-produto-edital-origem

### DIFF
--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalAtivarInativar/index.jsx
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalAtivarInativar/index.jsx
@@ -61,7 +61,7 @@ export default ({ closeModal, showModal, item, changePage }) => {
                       texto="Não"
                       type={BUTTON_TYPE.BUTTON}
                       onClick={closeModal}
-                      style={BUTTON_STYLE.DARK_OUTLINE}
+                      style={BUTTON_STYLE.GREEN_OUTLINE}
                       className="ml-3"
                     />
                     <Botao

--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/helper.js
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/helper.js
@@ -44,17 +44,18 @@ export const validatePayload = payload => {
   let keys = Object.keys(payload);
 
   let erros = {
-    editaisOrigem: false,
+    editalOrigem: false,
     editaisDestino: false,
     tipoProduto: false,
-    produtos: false
+    produtos: false,
+    tipoProdutoEditalOrigem: false
   };
 
   if (
-    !keys.includes("editais_origem_selecionados") ||
-    payload["editais_origem_selecionados"].length === 0
+    !keys.includes("edital_origem") ||
+    payload["edital_origem"].length === 0
   ) {
-    erros["editaisOrigem"] = true;
+    erros["editalOrigem"] = true;
   }
   if (
     !keys.includes("editais_destino_selecionados") ||
@@ -70,6 +71,12 @@ export const validatePayload = payload => {
     payload["produtos_editais"].length === 0
   ) {
     erros["produtos"] = true;
+  }
+  if (
+    !keys.includes("tipo_produto_edital_origem") ||
+    payload["tipo_produto_edital_origem"].length === 0
+  ) {
+    erros["tipoProdutoEditalOrigem"] = true;
   }
 
   return erros;

--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { Modal } from "react-bootstrap";
-import { Form, Field } from "react-final-form";
+import { Form, Field, FormSpy } from "react-final-form";
 import { TextArea } from "components/Shareable/TextArea/TextArea";
 import StatefulMultiSelect from "@khanacademy/react-multi-select";
 import { formatarParaMultiselect } from "helpers/utilities";
 import { ASelect } from "components/Shareable/MakeField";
+import { Select as SelectAntd } from "antd";
 import { CaretDownOutlined } from "@ant-design/icons";
 import { TreeSelect, Spin } from "antd";
 import "antd/dist/antd.css";
@@ -19,11 +20,15 @@ import {
 } from "services/produto.service";
 import HTTP_STATUS from "http-status-codes";
 import { toastError, toastSuccess } from "components/Shareable/Toast/dialogs";
-import { formataEditais, formatarOpcoes, validatePayload } from "./helper";
+import { formatarOpcoes, validatePayload } from "./helper";
 import "./style.scss";
 
 export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
   const [carregando, setCarregando] = useState(false);
+  const [desabilitarCampos, setDesabilitarCampos] = useState(true);
+  const [loadingProdutos, setLoadingProdutos] = useState(false);
+  const [editalOrigem, setEditalOrigem] = useState(null);
+  const [tipoProdEditalOrigem, setTipoProdEditalOrigem] = useState(null);
   const [opcoesEditaisOrigem, setOpcoesEditaisOrigem] = useState([]);
   const [opcoesEditaisDestino, setOpcoesEditaisDestino] = useState([]);
   const [opcoesProdutosEditais, setOpcoesProdutosEditais] = useState([]);
@@ -32,13 +37,14 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
     setProdutosEditaisSelecionados
   ] = useState([]);
   const [erros, setErros] = useState({
-    editaisOrigem: false,
+    editalOrigem: false,
     editaisDestino: false,
     tipoProduto: false,
     produtos: false
   });
 
   const { SHOW_PARENT } = TreeSelect;
+  const { Option } = SelectAntd;
 
   const onSubmit = async formValues => {
     let payload = formValues;
@@ -99,13 +105,69 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
   useEffect(() => {
     setCarregando(true);
     if (listaEditais) {
-      let opcoes = listaEditais.map(edital => {
-        return { nome: edital.numero, uuid: edital.uuid };
+      const opcoes = listaEditais.map(edital => {
+        return <Option key={edital.uuid}>{edital.numero}</Option>;
       });
       setOpcoesEditaisOrigem(opcoes);
       setCarregando(false);
     }
   }, [listaEditais]);
+
+  const onChangeEditalDeOrigem = (value, form) => {
+    form.change("edital_origem", value);
+    setErros({
+      ...erros,
+      editalOrigem: value && value.length > 0 ? false : true
+    });
+
+    return;
+  };
+
+  const onChangeFormSpy = async changes => {
+    if (
+      changes.values["edital_origem"] &&
+      changes.values["tipo_produto_edital_origem"] &&
+      (changes.values["tipo_produto_edital_origem"] !== tipoProdEditalOrigem ||
+        changes.values["edital_origem"] !== editalOrigem) &&
+      ["edital_origem", "tipo_produto_edital_origem"].includes(
+        changes.active
+      ) &&
+      !loadingProdutos
+    ) {
+      setOpcoesProdutosEditais([]);
+      setProdutosEditaisSelecionados([]);
+      setDesabilitarCampos(false);
+      setLoadingProdutos(true);
+      setCarregando(true);
+      setEditalOrigem(changes.values["edital_origem"]);
+      setTipoProdEditalOrigem(changes.values["tipo_produto_edital_origem"]);
+      let opcoesDestino = listaEditais
+        .filter(
+          edital => !changes.values["edital_origem"].includes(edital.uuid)
+        )
+        .map(edital => {
+          return { nome: edital.numero, uuid: edital.uuid };
+        });
+      setOpcoesEditaisDestino(opcoesDestino);
+      try {
+        const response = await getListaProdutos({
+          editais: changes.values["edital_origem"],
+          tipo_produto_edital_origem:
+            changes.values["tipo_produto_edital_origem"]
+        });
+        if (response.status === HTTP_STATUS.OK) {
+          let t = formatarOpcoes(response.data);
+          setOpcoesProdutosEditais(t);
+          setLoadingProdutos(false);
+          setCarregando(false);
+        }
+      } catch (e) {
+        toastError("Houve um erro ao carregar opções dos produtos");
+        setLoadingProdutos(false);
+        setCarregando(false);
+      }
+    }
+  };
 
   return (
     <Modal
@@ -127,60 +189,75 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
           render={({ handleSubmit, submitting, values, form }) => (
             <form onSubmit={handleSubmit}>
               <Modal.Body>
-                <div className="row mb-3">
+                <FormSpy
+                  subscription={{ values: true, active: true }}
+                  onChange={changes => onChangeFormSpy(changes)}
+                />
+                <div className="row">
                   <div className="col-4">
                     <span className="required-asterisk">*</span>
                     <label className="col-form-label pb-3">
                       Edital de origem
                     </label>
                     <Field
-                      component={StatefulMultiSelect}
-                      name="editais_origem"
-                      selected={values.editais_origem_selecionados || []}
-                      options={formatarParaMultiselect(opcoesEditaisOrigem)}
-                      onSelectedChanged={async values_ => {
-                        setProdutosEditaisSelecionados([]);
-                        setOpcoesProdutosEditais([]);
-                        form.change(`produtos_editais`, []);
-                        form.change(`editais_origem_selecionados`, values_);
-                        let opcoesDestino = opcoesEditaisOrigem.filter(
-                          opcao => !values_.includes(opcao.uuid)
-                        );
-                        setOpcoesEditaisDestino(opcoesDestino);
-                        setErros({
-                          ...erros,
-                          editaisOrigem: values_.length === 0
-                        });
-                        if (values_.length > 0) {
-                          try {
-                            const editaisString = formataEditais(values_);
-                            const response = await getListaProdutos({
-                              editais: editaisString
-                            });
-                            if (response.status === HTTP_STATUS.OK) {
-                              let t = formatarOpcoes(response.data);
-                              setOpcoesProdutosEditais(t);
-                            }
-                          } catch (e) {
-                            toastError(
-                              "Houve um erro ao carregar opções dos produtos"
-                            );
-                          }
-                        }
-                      }}
-                      disableSearch={true}
-                      overrideStrings={{
-                        selectSomeItems: "Selecione um edital",
-                        allItemsAreSelected:
-                          "Todos os itens estão selecionados",
-                        selectAll: "Todos"
-                      }}
-                    />
-                    {erros.editaisOrigem && (
-                      <div className="ant-form-explain">Campo obrigatório</div>
+                      component={ASelect}
+                      placeholder={"Selecione um edital"}
+                      suffixIcon={<CaretDownOutlined />}
+                      name="edital_origem"
+                      onChange={value =>
+                        onChangeEditalDeOrigem(value, form, values)
+                      }
+                      filterOption={(inputValue, option) =>
+                        option.props.children
+                          .toString()
+                          .toLowerCase()
+                          .includes(inputValue.toLowerCase())
+                      }
+                    >
+                      {opcoesEditaisOrigem}
+                    </Field>
+                    {erros.editalOrigem && (
+                      <div className="ant-form-explain customError">
+                        Campo obrigatório
+                      </div>
                     )}
                   </div>
-                  <div className="col-8">
+                  <div className="col-4">
+                    <span className="required-asterisk">*</span>
+                    <label className="col-form-label pb-3">
+                      Tipo de Produto Edital de Origem
+                    </label>
+                    <Field
+                      component={ASelect}
+                      placeholder={"Selecione o tipo de produto"}
+                      suffixIcon={<CaretDownOutlined />}
+                      name="tipo_produto_edital_origem"
+                      onChange={value => {
+                        form.change("tipo_produto_edital_origem", value);
+                        setErros({
+                          ...erros,
+                          tipoProdutoEditalOrigem:
+                            value && value.length > 0 ? false : true
+                        });
+                      }}
+                      filterOption={(inputValue, option) =>
+                        option.props.children
+                          .toString()
+                          .toLowerCase()
+                          .includes(inputValue.toLowerCase())
+                      }
+                    >
+                      {opcoesTipos}
+                    </Field>
+                    {erros.tipoProdutoEditalOrigem && (
+                      <div className="ant-form-explain customError">
+                        Campo obrigatório
+                      </div>
+                    )}
+                  </div>
+                </div>
+                <div className="row mb-3">
+                  <div className="col">
                     <span className="required-asterisk">*</span>
                     <label className="col-form-label pb-3">Produtos</label>
                     <TreeSelect
@@ -189,9 +266,10 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
                       onChange={onChangeProdutosEditais}
                       treeCheckable={true}
                       showCheckedStrategy={SHOW_PARENT}
-                      searchPlaceholder="Selecione os produtos"
+                      placeholder="Selecione os produtos"
                       treeNodeFilterProp="title"
                       style={{ width: "100%" }}
+                      disabled={desabilitarCampos}
                     />
                     {erros.produtos && (
                       <div className="ant-form-explain">Campo obrigatório</div>
@@ -222,6 +300,7 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
                           .toLowerCase()
                           .includes(inputValue.toLowerCase())
                       }
+                      disabled={desabilitarCampos}
                     >
                       {opcoesTipos}
                     </Field>
@@ -255,6 +334,7 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
                           "Todos os itens estão selecionados",
                         selectAll: "Todos"
                       }}
+                      disabled={desabilitarCampos}
                     />
                     {erros.editaisDestino && (
                       <div className="ant-form-explain">Campo obrigatório</div>
@@ -269,6 +349,7 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
                       placeholder="Descreva mais informações do produto ou edital..."
                       label={"Outras informações"}
                       name="outras_informacoes"
+                      disabled={desabilitarCampos}
                     />
                   </div>
                 </div>
@@ -282,6 +363,7 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
                       onClick={() => {
                         setProdutosEditaisSelecionados([]);
                         setOpcoesProdutosEditais([]);
+                        setDesabilitarCampos(true);
                         closeModal();
                       }}
                       style={BUTTON_STYLE.GREEN_OUTLINE}

--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/Tabela/index.jsx
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/Tabela/index.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useState } from "react";
 import ModalAtivarInativar from "../ModalAtivarInativar";
-import { ReadOutlined } from "@ant-design/icons";
+import { ReloadOutlined } from "@ant-design/icons";
 import "./style.scss";
 
 export default ({ resultado, changePage }) => {
@@ -55,7 +55,7 @@ export default ({ resultado, changePage }) => {
                             className="botaoExcluir ml-2"
                             onClick={() => openModal(item)}
                           >
-                            <ReadOutlined className="mr-1" />
+                            <ReloadOutlined className="mr-1" />
                             {item.ativo ? "Inativar" : "Ativar"}
                           </button>
                         </td>


### PR DESCRIPTION
# Proposta

Este PR visa incluir campo de tipo de produto edital origem, ajustar layout de modal e Spin

# Referência do Azure

- 76462

# Tarefas para concluir

- [x] incluir campo de tipo de produto edital origem, ajustar layout de modal e Spin
- [x] mudança de ícone e cor de botão