### PR TITLE
bugfix 79666 imagem insucesso

### DIFF
--- a/src/components/Shareable/Input/InputFile/index.jsx
+++ b/src/components/Shareable/Input/InputFile/index.jsx
@@ -58,7 +58,7 @@ export class InputFile extends Component {
     if (accept) {
       let nova_lista_extensoes = [];
       lista_extensoes.forEach(ext => {
-        if (accept.includes(ext)) {
+        if (accept.toLowerCase().includes(ext)) {
           nova_lista_extensoes.push(ext);
         }
       });


### PR DESCRIPTION
Este PR:
- corrige problema no componente de imagens que não permitia a inserção de arquivos no formato PNG