### PR TITLE
bugfix/82188-problema-cancelar-conferencia-reposicao-tela-resumo

### DIFF
--- a/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
@@ -80,7 +80,7 @@ export default () => {
       setInitialValues({
         numero_guia: response.data.numero_guia,
         data_entrega: response.data.data_entrega,
-        hora_recebimento: "00:00"
+        hora_recebimento: "00:00:00"
       });
       setCarregando(false);
     } catch (e) {
@@ -91,7 +91,7 @@ export default () => {
 
   const escolherHora = hora => {
     if (hora) {
-      const horario = moment(hora).format("HH:mm");
+      const horario = moment(hora).format("HH:mm:ss");
       setHoraRecebimento(horario);
       setHoraRecebimentoAlterada(true);
     } else {
@@ -108,11 +108,12 @@ export default () => {
 
     for (let i = 0; i < guia.alimentos.length; i++) {
       let x = {};
-      if (edicao) x.uuid_conferencia = values.uuid_conferencia;
+      //if (edicao) x.uuid_conferencia = values.uuid_conferencia;
+      x.uuid_conferencia = values.uuid_conferencia;
       x.data_entrega = values.data_entrega;
       x.arquivo = values.arquivo[i];
       x.data_entrega_real = values.data_entrega_real;
-      x.hora_recebimento = values.hora_recebimento;
+      x.hora_recebimento = HoraRecebimento;
       x.nome_motorista = values.nome_motorista;
       x.placa_veiculo = values.placa_veiculo;
       x.ocorrencias = values[`ocorrencias_${i}`];
@@ -123,7 +124,6 @@ export default () => {
 
       valoresForm[i] = x;
     }
-
     localStorage.setItem("valoresConferencia", JSON.stringify(valoresForm));
     localStorage.setItem("guiaConferencia", JSON.stringify(guia));
     history.push(
@@ -339,11 +339,12 @@ export default () => {
 
     setArquivoAtual(arquivos);
 
+    values.numero_guia = guiaConf.numero_guia;
     values.data_entrega = ultimoItem.data_entrega;
     values.nome_motorista = ultimoItem.nome_motorista;
     values.hora_recebimento = ultimoItem.hora_recebimento;
     values.placa_veiculo = ultimoItem.placa_veiculo;
-    values.data_entrega_real = moment(ultimoItem.data_entrega_real);
+    values.data_entrega_real = ultimoItem.data_entrega_real;
     values.uuid_conferencia = ultimoItem.uuid_conferencia;
 
     setHoraRecebimento(ultimoItem.hora_recebimento);

--- a/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaComOcorrencia/index.jsx
@@ -108,7 +108,6 @@ export default () => {
 
     for (let i = 0; i < guia.alimentos.length; i++) {
       let x = {};
-      //if (edicao) x.uuid_conferencia = values.uuid_conferencia;
       x.uuid_conferencia = values.uuid_conferencia;
       x.data_entrega = values.data_entrega;
       x.arquivo = values.arquivo[i];

--- a/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
@@ -136,7 +136,7 @@ export default ({ reposicao }) => {
     history.push(
       `/${LOGISTICA}/${
         reposicao ? REPOSICAO_GUIA : CONFERENCIA_GUIA_COM_OCORRENCIA
-      }/?uuid=${uuid}&autofill=true&editar=true`
+      }/?uuid=${uuid}&autofill=true${reposicao ? "&editar=true" : ""}`
     );
   };
 

--- a/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuiaResumoFinal/index.jsx
@@ -136,7 +136,7 @@ export default ({ reposicao }) => {
     history.push(
       `/${LOGISTICA}/${
         reposicao ? REPOSICAO_GUIA : CONFERENCIA_GUIA_COM_OCORRENCIA
-      }/?uuid=${uuid}&autofill=true${reposicao ? "&editar=true" : ""}`
+      }/?uuid=${uuid}&autofill=true`
     );
   };
 

--- a/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
+++ b/src/components/screens/Logistica/ReposicaoDeGuia/index.jsx
@@ -78,7 +78,7 @@ export default () => {
       setInitialValues({
         numero_guia: response.data.numero_guia,
         data_entrega: response.data.data_entrega,
-        hora_recebimento: "00:00"
+        hora_recebimento: "00:00:00"
       });
       setCarregando(false);
     } catch (e) {
@@ -167,10 +167,7 @@ export default () => {
     values.nome_motorista = conferencia.nome_motorista;
     values.hora_recebimento = conferencia.hora_recebimento;
     values.placa_veiculo = conferencia.placa_veiculo;
-    values.data_entrega_real = moment(
-      conferencia.data_recebimento,
-      "DD/MM/YYYY"
-    );
+    values.data_entrega_real = conferencia.data_recebimento;
 
     values.uuid_conferencia = conferencia.uuid;
 
@@ -194,11 +191,11 @@ export default () => {
 
   const escolherHora = hora => {
     if (hora) {
-      const horario = moment(hora).format("HH:mm");
+      const horario = moment(hora).format("HH:mm:ss");
       setHoraRecebimento(horario);
       setHoraRecebimentoAlterada(true);
     } else {
-      setHoraRecebimento("00:00");
+      setHoraRecebimento("00:00:00");
       setHoraRecebimentoAlterada(false);
     }
   };
@@ -434,11 +431,12 @@ export default () => {
 
     setArquivoAtual(arquivos);
 
+    values.numero_guia = guiaConf.numero_guia;
     values.data_entrega = ultimoItem.data_entrega;
     values.nome_motorista = ultimoItem.nome_motorista;
     values.hora_recebimento = ultimoItem.hora_recebimento;
     values.placa_veiculo = ultimoItem.placa_veiculo;
-    values.data_entrega_real = moment(ultimoItem.data_entrega_real);
+    values.data_entrega_real = ultimoItem.data_entrega_real;
 
     setHoraRecebimento(ultimoItem.hora_recebimento);
     setHoraRecebimentoAlterada(true);


### PR DESCRIPTION
**### Este PR:**

- Retira conversão de string em data que quebrava tela.
- Coloca a hora no formato correto para ser exibida pelo componente.
- Adiciona número da guia no local storage.
- Altera link do botão Cancelar

**Referência:**
82188