### PR TITLE
bugfix/83178-corrige-conferencia-de-guia-e-exibe-msg-erro

### DIFF
--- a/src/components/screens/Logistica/ConferenciaDeGuia/components/ReceberSemOcorrencia/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuia/components/ReceberSemOcorrencia/index.jsx
@@ -54,8 +54,10 @@ export default ({ values, disabled, uuidEdicao }) => {
           setLoading(false);
           goToConferir();
         })
-        .catch(e => {
-          toastError(e.response.data.detail);
+        .catch(() => {
+          toastError(
+            "Erro ao registrar Guia de Remessa, procure o administrador do SIGPAE na sua Unidade!"
+          );
           setShow(false);
           setLoading(false);
         });

--- a/src/components/screens/Logistica/ConferenciaDeGuia/index.jsx
+++ b/src/components/screens/Logistica/ConferenciaDeGuia/index.jsx
@@ -86,7 +86,7 @@ export default () => {
         data_entrega: conferencia.guia.data_entrega,
         hora_recebimento: conferencia.hora_recebimento,
         placa_veiculo: conferencia.placa_veiculo,
-        data_entrega_real: moment(conferencia.data_recebimento, "DD/MM/YYYY"),
+        data_entrega_real: conferencia.data_recebimento,
         nome_motorista: conferencia.nome_motorista
       });
       setHoraRecebimento(conferencia.hora_recebimento);
@@ -113,9 +113,7 @@ export default () => {
 
   const onSubmit = async values => {
     values.hora_recebimento = HoraRecebimento;
-    values.data_recebimento = moment(values.data_entrega_real).format(
-      "DD/MM/YYYY"
-    );
+    values.data_recebimento = values.data_entrega_real;
     values.guia = uuid;
   };
 


### PR DESCRIPTION
### **Este PR:**

- Retira a conversão da lib moment do campo data_recebimento
- Altera mensagem de erro para "Erro ao registrar Guia de Remessa, procure o administrador do SIGPAE na sua Unidade!"

**Referência:**
83178