### PR TITLE
Feature/80959 retirar obrigatoriedade modal inversa cardapio

### DIFF
--- a/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InversaoDeDiaDeCardapio/Relatorio/componentes/CorpoRelatorio.jsx
@@ -199,15 +199,20 @@ export const CorpoRelatorio = props => {
                 }{" "}
                 - Informações da CODAE
               </div>
-              <p
-                className="value"
-                dangerouslySetInnerHTML={{
-                  __html:
-                    inversaoDiaCardapio.logs[
-                      inversaoDiaCardapio.logs.length - 1
-                    ].justificativa
-                }}
-              />
+              {inversaoDiaCardapio.logs[inversaoDiaCardapio.logs.length - 1]
+                .justificativa !== "" ? (
+                <p
+                  className="value"
+                  dangerouslySetInnerHTML={{
+                    __html:
+                      inversaoDiaCardapio.logs[
+                        inversaoDiaCardapio.logs.length - 1
+                      ].justificativa
+                  }}
+                />
+              ) : (
+                <p>Sem observações por parte da CODAE</p>
+              )}
             </div>
           </div>
         )}

--- a/src/components/Shareable/ModalCODAEAutoriza/index.jsx
+++ b/src/components/Shareable/ModalCODAEAutoriza/index.jsx
@@ -75,7 +75,6 @@ export class ModalCODAEAutoriza extends Component {
                       component={CKEditorField}
                       label="Informações da CODAE"
                       name="justificativa_autorizacao"
-                      required
                       validate={composeValidators(
                         textAreaRequiredAndAtLeastOneCharacter,
                         maxLength1500
@@ -107,7 +106,6 @@ export class ModalCODAEAutoriza extends Component {
                       }}
                       style={BUTTON_STYLE.GREEN}
                       className="ml-3"
-                      disabled={this.state.desabilitarSubmit}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
# Proposta

Este PR visa possibilitar que Inversões do tipo de alimentação sejam autorizadas sem, obrigatoriamente, adicionar uma informação (Como Codae).

# Referência do Azure

- 80959

# Tarefas para concluir

- [x] Desenvolver lógica para exibição da observação, caso seja inserida
- [x] Remover obrigatoriedade do campo de observação  no Modal de autorização