### PR TITLE
vira dre MP em producao

### DIFF
--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -755,7 +755,8 @@ export const exibirGA = () => {
     "IPIRANGA",
     "PIRITUBA",
     "FREGUESIA/BRASILANDIA",
-    "SAO MATEUS"
+    "SAO MATEUS",
+    "SAO MIGUEL"
   ];
 
   if (["production"].includes(ENVIRONMENT)) {


### PR DESCRIPTION
# Este PR:
- vira a DRE São Miguel (MP) para produção 

### Referência azure:
- 84844