### PR TITLE
Fix: desabilitar quando o formulário não é válido

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1069,7 +1069,6 @@ export default () => {
       !["Mês anterior", "Mês posterior"].includes(previous)
     ) {
       setDisableBotaoSalvarLancamentos(false);
-      setExibirTooltip(false);
     } else if (typeof value === "string") {
       value.match(/\d+/g) !== null && valuesInputArray.push(value);
       if (value === null) {
@@ -1097,7 +1096,6 @@ export default () => {
     }
     if (Object.keys(errors).length > 0) {
       setDisableBotaoSalvarLancamentos(true);
-      setExibirTooltip(true);
     }
 
     const valuesFrequencia = Object.fromEntries(
@@ -1124,6 +1122,22 @@ export default () => {
       }
     });
 
+    const erro = validarFormulario(
+      values,
+      diasSobremesaDoce,
+      location,
+      categoriasDeMedicao,
+      dadosValoresInclusoesAutorizadasState,
+      weekColumns
+    );
+
+    if (erro) {
+      setDisableBotaoSalvarLancamentos(true);
+      setExibirTooltip(true);
+    } else {
+      setDisableBotaoSalvarLancamentos(false);
+      setExibirTooltip(false);
+    }
     if (deveExistirObservacao(categoria.id, values, calendarioMesConsiderado)) {
       return;
     }


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o desabilitar do botão salvar manualmente e exibir tooltip.

# Referência do Azure

- 84859

# Tarefas para concluir

- [x] usar mesma verificação do onSubmit.
