### PR TITLE
Fix: desabilitar botão quando não houver anexos

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -183,6 +183,10 @@ export default ({
                         style={BUTTON_STYLE.GREEN_OUTLINE}
                         className="float-right mr-2"
                         onClick={() => pdfOcorrenciasMedicaoFinalizada()}
+                        disabled={
+                          !solicitacaoMedicaoInicial.anexos ||
+                          !solicitacaoMedicaoInicial.anexos.lenght
+                        }
                       />
                     </>
                   )}


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição do botão de exportar anexos da medição inicial.

# Referência do Azure

- 74333

# Tarefas para concluir

- [x] desabilitar botão quando não houver anexos.
