### PR TITLE
Fix: validação do disable

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -185,7 +185,7 @@ export default ({
                         onClick={() => pdfOcorrenciasMedicaoFinalizada()}
                         disabled={
                           !solicitacaoMedicaoInicial.anexos ||
-                          !solicitacaoMedicaoInicial.anexos.lenght
+                          solicitacaoMedicaoInicial.anexos.length === 0
                         }
                       />
                     </>


### PR DESCRIPTION
# Proposta

Este PR visa corrigir a exibição do botão de exportar anexos da medição inicial.

# Referência do Azure

- 74333

# Tarefas para concluir

- [x] desabilitar botão quando não houver anexos.
