### PR TITLE
Fix: adicionar bypass para exception de obrigatoriedade de terminar url com /

### DIFF
--- a/src/services/_base.js
+++ b/src/services/_base.js
@@ -8,6 +8,7 @@ const instance = axios.create({
   headers: AUTH_TOKEN
 });
 instance.interceptors.request.use(function(config) {
+  if (config.url.includes("/media/")) return config;
   if (!config.url.endsWith("/")) {
     throw new Error(
       "URLs devem obrigatoriamente terminar em '/': " + config.url


### PR DESCRIPTION
# Proposta

Este PR visa adiciomanar condição bypass para exception onde toda URL deve terminar com '/'.

# Referência do Azure

- 74333

# Tarefas para concluir

- [x] adicionar bypass para arquivos com url '/media/'.
