### PR TITLE
Fix: corrigir estado do tooltip ao excluir a observação com um valor válido

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/components/ModalObservacaoDiaria/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/components/ModalObservacaoDiaria/index.jsx
@@ -30,7 +30,8 @@ export default ({
   valoresPeriodosLancamentos,
   onSubmit,
   dadosIniciais,
-  setExibirTooltip
+  setExibirTooltip,
+  errors
 }) => {
   const [desabilitarBotaoSalvar, setDesabilitarBotaoSalvar] = useState(true);
   const [showBotaoExcluir, setShowBotaoExcluir] = useState(false);
@@ -62,7 +63,11 @@ export default ({
           ),
           1
         );
-        setExibirTooltip();
+        if (Object.keys(errors).length > 0) {
+          setExibirTooltip(true);
+        } else {
+          setExibirTooltip(false);
+        }
         toastSuccess("Observação excluída com sucesso");
       } else {
         toastError(msgError);

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1748,7 +1748,8 @@ export default () => {
                         )
                       }
                       dadosIniciais={dadosIniciais}
-                      setExibirTooltip={() => setExibirTooltip(true)}
+                      setExibirTooltip={value => setExibirTooltip(value)}
+                      errors={errors}
                     />
                   )}
                   <Botao


### PR DESCRIPTION
# Proposta

Este PR visa corrigir o exibir tooltip.

# Referência do Azure

- 84859

# Tarefas para concluir

- [x] corrigir validações.
