### PR TITLE
Feature/87382-PeD-incluir-no-histórico-do-produto-datas-de-vínculos-dos-editais

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -133,6 +133,7 @@ export const tipoDeStatus = status => {
     case "CODAE pediu análise sensorial":
     case "Suspenso em alguns editais":
     case "Ativo em alguns editais":
+    case "Vínculo do Edital ao Produto":
       return "questionado";
 
     case "Escola cancelou":

--- a/src/components/Shareable/ModalHistorico/index.jsx
+++ b/src/components/Shareable/ModalHistorico/index.jsx
@@ -149,7 +149,10 @@ export default class ModalHistorico extends Component {
                         <article>
                           {logSelecionado.justificativa !== "" && (
                             <>
-                              <div>Justificativa:</div>
+                              {logSelecionado.status_evento_explicacao !==
+                              "Vínculo do Edital ao Produto" ? (
+                                <div>Justificativa:</div>
+                              ) : null}
                               <div
                                 dangerouslySetInnerHTML={{
                                   __html: logSelecionado.justificativa


### PR DESCRIPTION
**### Este PR visa:**

- incluir log de "Vínculo do Edital ao Produto" para exibir ícone de exclamação no fluxo
- não exibir Justificativa quando for log de "Vínculo do Edital ao Produto" - Modal Histórico

**Referência:**
87382