### PR TITLE
Fix/90458-GA-ajustar-filtros-dinâmicos-de-lote-ue-tela-relatório-alunos-matriculados

### DIFF
--- a/src/components/screens/Relatorios/AlunosMatriculados/componentes/Filtros/index.jsx
+++ b/src/components/screens/Relatorios/AlunosMatriculados/componentes/Filtros/index.jsx
@@ -57,11 +57,8 @@ export const Filtros = ({ ...props }) => {
       );
     }
     if (values.lotes && values.lotes.length) {
-      const dresDosLotesSelecionados = listaOpcoes.lotes
-        .filter(lote => values.lotes.includes(lote.uuid))
-        .map(lote => lote.diretoria_regional.uuid);
       escolas = escolas.filter(escola =>
-        dresDosLotesSelecionados.includes(escola.diretoria_regional.uuid)
+        values.lotes.includes(escola.lote.uuid)
       );
     }
     return formataOpcoes(escolas);


### PR DESCRIPTION
**### Este PR visa:**

- ajustar exibição de escolas no filtro de UE com base na seleção de lotes

**Referência:**
90458