### PR TITLE
bugfix/91518-esta-trazendo-identificação-nutricionista-errada

### DIFF
--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
@@ -19,9 +19,6 @@ import InformacoesAdicionaisLeitura from "../FormAutorizaDietaEspecial/component
 import IdentificacaoNutricionista from "../FormAutorizaDietaEspecial/componentes/IdentificacaoNutricionista";
 import PeriodoVigencia from "../FormAutorizaDietaEspecial/componentes/PeriodoVigencia";
 import { formataAlergias } from "../FormAutorizaDietaEspecial/helper";
-
-import { obtemIdentificacaoNutricionistaDieta } from "helpers/utilities";
-
 import { ehCanceladaSegundoStep } from "../../helpers";
 import "./styles.scss";
 import JustificativaNegacao from "./JustificativaNegacao";
@@ -320,10 +317,6 @@ const CorpoRelatorio = ({
   };
 
   const initialValues = () => {
-    let logs = [...dietaEspecial.logs];
-    dietaEspecial.registro_funcional_nutricionista = obtemIdentificacaoNutricionistaDieta(
-      logs.pop().usuario
-    );
     if (![undefined, null].includes(dietaEspecial.alergias_intolerancias)) {
       dietaEspecial.relacao_diagnosticos = formataAlergias(dietaEspecial)
         .map(a => a.nome)

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -641,12 +641,6 @@ export const obtemIdentificacaoNutricionista = () =>
     "registro_funcional"
   )}`.replace(/[^\w\s-]/g, "");
 
-export const obtemIdentificacaoNutricionistaDieta = usuario =>
-  `Elaborado por ${usuario.nome} - RF ${usuario.registro_funcional}`.replace(
-    /[^\w\s-]/g,
-    ""
-  );
-
 export const getKey = obj => {
   return Object.keys(obj)[0];
 };


### PR DESCRIPTION
### **Este PR:**

- Retira a função que pega o nome de nutricionista dos logs permitindo que pegue direto do payload

**Referência:**
91518