### PR TITLE
Fix: validar quando não houver log ainda

### DIFF
--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
@@ -100,11 +100,13 @@ export const ConferenciaDosLancamentos = () => {
         );
         setOcorrencia(arquivosOcorrencia);
         setLogCorrecaoOcorrencia(logOcorrencia);
-        setTextoOcorrencia(
-          logOcorrencia.status_evento_explicacao === "Correção solicitada"
-            ? "Solicitação de correção no Formulário de Ocorrências realizada em"
-            : "Formulário de Ocorrências aprovado em"
-        );
+        if (logOcorrencia) {
+          setTextoOcorrencia(
+            logOcorrencia.status_evento_explicacao === "Correção solicitada"
+              ? "Solicitação de correção no Formulário de Ocorrências realizada em"
+              : "Formulário de Ocorrências aprovado em"
+          );
+        }
       }
     } else {
       setErroAPI("Erro ao carregar Medição Inicial.");


### PR DESCRIPTION
# Proposta

Este PR visa verificar quando não há log de ocorrência criado.

# Referência do Azure

- 91846

# Tarefas para concluir

- [x] criar verificação