### PR TITLE
feature/93265-PeD-Cancelamento-correcao-produtos-gpcodae-terceirizadas

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -142,6 +142,7 @@ export const tipoDeStatus = status => {
     case "Cancelamento por alteração de unidade educacional":
     case "Cancelamento para aluno não matriculado na rede municipal":
     case "CODAE cancelou análise sensorial":
+    case "GPCODAE cancelou solicitação de correção":
       return "cancelado";
 
     case "DRE não validou":

--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -142,7 +142,8 @@ export const tipoDeStatus = status => {
     case "Cancelamento por alteração de unidade educacional":
     case "Cancelamento para aluno não matriculado na rede municipal":
     case "CODAE cancelou análise sensorial":
-    case "GPCODAE cancelou solicitação de correção":
+    case "CODAE cancelou solicitação de correção":
+    case "Terceirizada cancelou solicitação de correção":
       return "cancelado";
 
     case "DRE não validou":

--- a/src/components/Shareable/ModalHistorico/index.jsx
+++ b/src/components/Shareable/ModalHistorico/index.jsx
@@ -167,7 +167,6 @@ export default class ModalHistorico extends Component {
                                   __html: logSelecionado.justificativa
                                 }}
                               />
-                              {console.log(logSelecionado, "logSelecionado")}
                             </>
                           )}
                         </article>

--- a/src/components/Shareable/ModalHistorico/index.jsx
+++ b/src/components/Shareable/ModalHistorico/index.jsx
@@ -153,15 +153,21 @@ export default class ModalHistorico extends Component {
                         <article>
                           {logSelecionado.justificativa !== "" && (
                             <>
-                              {logSelecionado.status_evento_explicacao !==
-                              "Vínculo do Edital ao Produto" ? (
-                                <div>Justificativa:</div>
+                              {logSelecionado.status_evento_explicacao ===
+                                "CODAE cancelou solicitação de correção" ||
+                              logSelecionado.status_evento_explicacao ===
+                                "Terceirizada cancelou solicitação de correção" ? (
+                                <div>Nome do Produto: </div>
+                              ) : logSelecionado.status_evento_explicacao !==
+                                "Vínculo do Edital ao Produto" ? (
+                                <div>Justificativa: </div>
                               ) : null}
                               <div
                                 dangerouslySetInnerHTML={{
                                   __html: logSelecionado.justificativa
                                 }}
                               />
+                              {console.log(logSelecionado, "logSelecionado")}
                             </>
                           )}
                         </article>

--- a/src/components/Shareable/ModalPadrao/index.jsx
+++ b/src/components/Shareable/ModalPadrao/index.jsx
@@ -11,6 +11,8 @@ import { toastError, toastSuccess } from "../Toast/dialogs";
 import { textAreaRequiredAndAtLeastOneCharacter } from "../../../helpers/fieldValidators";
 import "./style.scss";
 import InputText from "../Input/InputText";
+import { PAINEL_GESTAO_PRODUTO } from "configs/constants";
+import { useHistory } from "react-router-dom";
 
 export const ModalPadrao = ({ ...props }) => {
   const {
@@ -33,6 +35,9 @@ export const ModalPadrao = ({ ...props }) => {
     ...textAreaProps
   } = props;
 
+  const history = useHistory();
+  const painelProdutos = history => history.push(`/${PAINEL_GESTAO_PRODUTO}`);
+
   const enviarJustificativa = async formValues => {
     const { justificativa } = formValues;
     let resp = undefined;
@@ -46,7 +51,11 @@ export const ModalPadrao = ({ ...props }) => {
     }
     if (resp.status === HTTP_STATUS.OK) {
       closeModal();
-      loadSolicitacao(uuid);
+      if (loadSolicitacao) {
+        loadSolicitacao(uuid);
+      } else {
+        painelProdutos(history);
+      }
       toastSuccess(toastSuccessMessage);
     } else {
       toastError(resp.data.detail);

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
@@ -24,6 +24,7 @@ import {
   STATUS_ESCOLA_OU_NUTRICIONISTA_RECLAMOU,
   STATUS_TERCEIRIZADA_RESPONDEU_RECLAMACAO
 } from "configs/constants";
+import { meusDados } from "services/perfil.service";
 
 const maxLength5000 = maxLengthProduto(5000);
 const { Option } = Select;
@@ -32,6 +33,7 @@ class WizardFormPrimeiraPagina extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      meusDados: null,
       retificou: false,
       checkDieta: false,
       produtoForm: null,
@@ -52,6 +54,12 @@ class WizardFormPrimeiraPagina extends React.Component {
   }
 
   componentDidMount() {
+    meusDados().then(response => {
+      this.setState({
+        meusDados: response
+      });
+    });
+
     const { produto } = this.props;
     const tipoPerfil = localStorage.getItem("tipo_perfil");
 
@@ -312,7 +320,8 @@ class WizardFormPrimeiraPagina extends React.Component {
       fabricantesArray,
       desabilitarNomeDoProdutoField,
       desabilitarEhParaAlunosComDietaField,
-      status_codae_questionado
+      status_codae_questionado,
+      meusDados
     } = this.state;
 
     return (
@@ -552,17 +561,20 @@ class WizardFormPrimeiraPagina extends React.Component {
         </section>
 
         <section className="rodape-botoes-acao">
-          {status_codae_questionado && (
-            <Botao
-              texto={"Cancelar"}
-              type={BUTTON_TYPE.BUTTON}
-              className="ml-3"
-              style={BUTTON_STYLE.GREEN_OUTLINE}
-              onClick={() => {
-                this.props.showModal(true);
-              }}
-            />
-          )}
+          {status_codae_questionado &&
+            (meusDados &&
+              meusDados.vinculo_atual.instituicao.uuid ===
+                this.props.produto.homologacao.rastro_terceirizada.uuid) && (
+              <Botao
+                texto={"Cancelar"}
+                type={BUTTON_TYPE.BUTTON}
+                className="ml-3"
+                style={BUTTON_STYLE.GREEN_OUTLINE}
+                onClick={() => {
+                  this.props.showModal(true);
+                }}
+              />
+            )}
           <Botao
             texto={"Próximo"}
             type={BUTTON_TYPE.SUBMIT}

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormPrimeiraPagina.jsx
@@ -46,7 +46,8 @@ class WizardFormPrimeiraPagina extends React.Component {
       completo: false,
       showModalCadastrarItem: false,
       desabilitarNomeDoProdutoField: true,
-      desabilitarEhParaAlunosComDietaField: true
+      desabilitarEhParaAlunosComDietaField: true,
+      status_codae_questionado: false
     };
   }
 
@@ -57,7 +58,8 @@ class WizardFormPrimeiraPagina extends React.Component {
     if (tipoPerfil === TIPO_PERFIL.TERCEIRIZADA) {
       if (produto.homologacao.status === STATUS_CODAE_QUESTIONADO) {
         this.setState({
-          desabilitarNomeDoProdutoField: false
+          desabilitarNomeDoProdutoField: false,
+          status_codae_questionado: true
         });
       }
       if (
@@ -309,7 +311,8 @@ class WizardFormPrimeiraPagina extends React.Component {
       marcasArray,
       fabricantesArray,
       desabilitarNomeDoProdutoField,
-      desabilitarEhParaAlunosComDietaField
+      desabilitarEhParaAlunosComDietaField,
+      status_codae_questionado
     } = this.state;
 
     return (
@@ -549,9 +552,21 @@ class WizardFormPrimeiraPagina extends React.Component {
         </section>
 
         <section className="rodape-botoes-acao">
+          {status_codae_questionado && (
+            <Botao
+              texto={"Cancelar"}
+              type={BUTTON_TYPE.BUTTON}
+              className="ml-3"
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              onClick={() => {
+                this.props.showModal(true);
+              }}
+            />
+          )}
           <Botao
             texto={"Próximo"}
             type={BUTTON_TYPE.SUBMIT}
+            className="ml-3"
             style={BUTTON_STYLE.GREEN_OUTLINE}
             onClick={() => {
               this.props.passouPrimeiroStep(valuesForm, produtoForm);

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormSegundaPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormSegundaPagina.jsx
@@ -10,11 +10,13 @@ import {
 } from "components/Shareable/Botao/constants";
 import { ToggleExpandir } from "components/Shareable/ToggleExpandir";
 import { STATUS_CODAE_QUESTIONADO } from "configs/constants";
+import { meusDados } from "services/perfil.service";
 
 class WizardFormSegundaPagina extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      meusDados: null,
       informacoes: [],
       valuesForm: {},
       verificado: false,
@@ -48,6 +50,12 @@ class WizardFormSegundaPagina extends React.Component {
   };
 
   componentDidMount() {
+    meusDados().then(response => {
+      this.setState({
+        meusDados: response
+      });
+    });
+
     let { informacoes, valuesForm } = this.state;
     const { produto, change, segundoStep, valoresSegundoForm } = this.props;
 
@@ -262,7 +270,8 @@ class WizardFormSegundaPagina extends React.Component {
     const {
       informacoes,
       temCamposPreenchidos,
-      status_codae_questionado
+      status_codae_questionado,
+      meusDados
     } = this.state;
     return (
       <form onSubmit={handleSubmit} className="segundo-formulario">
@@ -365,17 +374,20 @@ class WizardFormSegundaPagina extends React.Component {
               previousPage();
             }}
           />
-          {status_codae_questionado && (
-            <Botao
-              texto={"Cancelar"}
-              type={BUTTON_TYPE.BUTTON}
-              className="ml-3"
-              style={BUTTON_STYLE.GREEN_OUTLINE}
-              onClick={() => {
-                this.props.showModal(true);
-              }}
-            />
-          )}
+          {status_codae_questionado &&
+            (meusDados &&
+              meusDados.vinculo_atual.instituicao.uuid ===
+                this.props.produto.homologacao.rastro_terceirizada.uuid) && (
+              <Botao
+                texto={"Cancelar"}
+                type={BUTTON_TYPE.BUTTON}
+                className="ml-3"
+                style={BUTTON_STYLE.GREEN_OUTLINE}
+                onClick={() => {
+                  this.props.showModal(true);
+                }}
+              />
+            )}
           {temCamposPreenchidos && (
             <Botao
               texto={"Próximo"}

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormSegundaPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormSegundaPagina.jsx
@@ -9,6 +9,7 @@ import {
   BUTTON_STYLE
 } from "components/Shareable/Botao/constants";
 import { ToggleExpandir } from "components/Shareable/ToggleExpandir";
+import { STATUS_CODAE_QUESTIONADO } from "configs/constants";
 
 class WizardFormSegundaPagina extends React.Component {
   constructor(props) {
@@ -17,7 +18,8 @@ class WizardFormSegundaPagina extends React.Component {
       informacoes: [],
       valuesForm: {},
       verificado: false,
-      temCamposPreenchidos: false
+      temCamposPreenchidos: false,
+      status_codae_questionado: false
     };
   }
 
@@ -48,6 +50,13 @@ class WizardFormSegundaPagina extends React.Component {
   componentDidMount() {
     let { informacoes, valuesForm } = this.state;
     const { produto, change, segundoStep, valoresSegundoForm } = this.props;
+
+    if (produto.homologacao.status === STATUS_CODAE_QUESTIONADO) {
+      this.setState({
+        status_codae_questionado: true
+      });
+    }
+
     const { verificado } = this.state;
     if (
       this.props.informacoes !== this.state.informacoes &&
@@ -250,7 +259,11 @@ class WizardFormSegundaPagina extends React.Component {
 
   render() {
     const { handleSubmit, previousPage, valuesForm } = this.props;
-    const { informacoes, temCamposPreenchidos } = this.state;
+    const {
+      informacoes,
+      temCamposPreenchidos,
+      status_codae_questionado
+    } = this.state;
     return (
       <form onSubmit={handleSubmit} className="segundo-formulario">
         <header>Informações Nutricionais</header>
@@ -352,6 +365,17 @@ class WizardFormSegundaPagina extends React.Component {
               previousPage();
             }}
           />
+          {status_codae_questionado && (
+            <Botao
+              texto={"Cancelar"}
+              type={BUTTON_TYPE.BUTTON}
+              className="ml-3"
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              onClick={() => {
+                this.props.showModal(true);
+              }}
+            />
+          )}
           {temCamposPreenchidos && (
             <Botao
               texto={"Próximo"}

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
@@ -37,7 +37,8 @@ class WizardFormTerceiraPagina extends Component {
       embalagens: null,
       mostraModalConfimacao: false,
       formValues: undefined,
-      especificacoesIniciais: this.props.produto.especificacoes
+      especificacoesIniciais: this.props.produto.especificacoes,
+      status_codae_questionado: false
     };
     this.setFiles = this.setFiles.bind(this);
     this.removeFile = this.removeFile.bind(this);
@@ -56,7 +57,11 @@ class WizardFormTerceiraPagina extends Component {
     if (this.props.produto !== this.state.produto) {
       this.setState({ produto: this.props.produto });
     }
-
+    if (this.props.produto.homologacao.status === STATUS_CODAE_QUESTIONADO) {
+      this.setState({
+        status_codae_questionado: true
+      });
+    }
     await this.updateOpcoesItensCadastrados();
 
     const { change, produto, terceiroStep, valoresterceiroForm } = this.props;
@@ -322,6 +327,17 @@ class WizardFormTerceiraPagina extends Component {
               this.props.passouTerceiroStep(valuesForm);
             }}
           />
+          {this.state.status_codae_questionado && (
+            <Botao
+              texto={"Cancelar"}
+              type={BUTTON_TYPE.BUTTON}
+              className="ml-3"
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              onClick={() => {
+                this.props.showModal(true);
+              }}
+            />
+          )}
           <Botao
             texto={"Enviar"}
             className="ml-3"

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/components/WizardFormTerceiraPagina.jsx
@@ -26,11 +26,13 @@ import {
   getUnidadesDeMedidaProduto,
   getEmbalagensProduto
 } from "services/produto.service";
+import { meusDados } from "services/perfil.service";
 
 class WizardFormTerceiraPagina extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      meusDados: null,
       produto: null,
       arquivos: [],
       unidades_de_medida: null,
@@ -54,6 +56,12 @@ class WizardFormTerceiraPagina extends Component {
   };
 
   componentDidMount = async () => {
+    meusDados().then(response => {
+      this.setState({
+        meusDados: response
+      });
+    });
+
     if (this.props.produto !== this.state.produto) {
       this.setState({ produto: this.props.produto });
     }
@@ -207,7 +215,7 @@ class WizardFormTerceiraPagina extends Component {
       submitting,
       valuesForm
     } = this.props;
-    const { mostraModalConfimacao } = this.state;
+    const { mostraModalConfimacao, meusDados } = this.state;
     return (
       <form onSubmit={handleSubmit} className="cadastro-produto-step3">
         <ModalConfirmacaoSimNao
@@ -327,17 +335,20 @@ class WizardFormTerceiraPagina extends Component {
               this.props.passouTerceiroStep(valuesForm);
             }}
           />
-          {this.state.status_codae_questionado && (
-            <Botao
-              texto={"Cancelar"}
-              type={BUTTON_TYPE.BUTTON}
-              className="ml-3"
-              style={BUTTON_STYLE.GREEN_OUTLINE}
-              onClick={() => {
-                this.props.showModal(true);
-              }}
-            />
-          )}
+          {this.state.status_codae_questionado &&
+            (meusDados &&
+              meusDados.vinculo_atual.instituicao.uuid ===
+                this.props.produto.homologacao.rastro_terceirizada.uuid) && (
+              <Botao
+                texto={"Cancelar"}
+                type={BUTTON_TYPE.BUTTON}
+                className="ml-3"
+                style={BUTTON_STYLE.GREEN_OUTLINE}
+                onClick={() => {
+                  this.props.showModal(true);
+                }}
+              />
+            )}
           <Botao
             texto={"Enviar"}
             className="ml-3"

--- a/src/components/screens/Produto/AtualizacaoProdutoForm/index.jsx
+++ b/src/components/screens/Produto/AtualizacaoProdutoForm/index.jsx
@@ -23,13 +23,15 @@ import {
   getHomologacao,
   getMarcasProdutos,
   getFabricantesProdutos,
-  getInformacoesGrupo
+  getInformacoesGrupo,
+  TerceirizadaCancelaSoliticaoCorrecao
 } from "../../../../services/produto.service";
 import { connect } from "react-redux";
 import { getFormValues } from "redux-form";
 import MotivoHomologacao from "components/Shareable/MotivoHomologacao";
 import MotivoSuspensao from "components/Shareable/MotivoSuspensao";
 import InformativoReclamacao from "components/Shareable/InformativoReclamacao";
+import { ModalPadrao } from "components/Shareable/ModalPadrao";
 
 const { Option } = Select;
 
@@ -48,6 +50,7 @@ class AtualizacaoProdutoForm extends Component {
       uuid: null,
       loading: true,
       produto: null,
+      homologacao: null,
       logs: [],
       informacoesNutricionais: null,
       erro: false,
@@ -60,6 +63,7 @@ class AtualizacaoProdutoForm extends Component {
       reclamacaoProduto: null,
       verificado: false,
       visible: false,
+      showModal: false,
       wizardSteps: [
         {
           step: {
@@ -138,15 +142,28 @@ class AtualizacaoProdutoForm extends Component {
     });
   };
 
+  showModal = () => {
+    this.setState({
+      showModal: true
+    });
+  };
+
+  closeModal = () => {
+    this.setState({
+      showModal: false
+    });
+  };
+
   componentDidMount = async () => {
-    let { produto, informacoesNutricionais, logs } = this.state;
-    let homologacao = null;
+    let { produto, homologacao, informacoesNutricionais, logs } = this.state;
+    let homologacao_dados = null;
     const urlParams = new URLSearchParams(window.location.search);
     const uuid = urlParams.get("uuid");
     try {
-      homologacao = await getHomologacao(uuid);
-      produto = homologacao.data.produto;
-      logs = homologacao.data.logs;
+      homologacao_dados = await getHomologacao(uuid);
+      produto = homologacao_dados.data.produto;
+      homologacao = homologacao_dados.data;
+      logs = homologacao_dados.data.logs;
     } catch {
       this.setState({
         loading: false,
@@ -166,6 +183,7 @@ class AtualizacaoProdutoForm extends Component {
       arrayMarcas,
       arrayFabricantes,
       produto,
+      homologacao,
       logs,
       informacoesNutricionais
     });
@@ -210,6 +228,7 @@ class AtualizacaoProdutoForm extends Component {
       loading,
       erro,
       produto,
+      homologacao,
       arrayMarcas,
       arrayFabricantes,
       primeiroStep,
@@ -280,6 +299,21 @@ class AtualizacaoProdutoForm extends Component {
                 logs={logs}
                 getHistorico={this.getHistorico}
               />
+              <ModalPadrao
+                showModal={this.state.showModal}
+                closeModal={this.closeModal}
+                toastSuccessMessage="Cancelamento enviado com sucesso."
+                modalTitle="Envio de Cancelamento da Solicitação de Correção"
+                endpoint={TerceirizadaCancelaSoliticaoCorrecao}
+                uuid={produto.homologacao.uuid}
+                justificativa={produto.homologacao.justificativa}
+                labelJustificativa="Justificativa"
+                helpText={undefined}
+                eAnalise={false}
+                status={produto.homologacao.status}
+                terceirizada={produto.homologacao.rastro_terceirizada}
+                cancelaAnaliseSensorial={homologacao}
+              />
               <Wizard
                 arrayOfObjects={wizardSteps}
                 currentStep={page}
@@ -297,6 +331,7 @@ class AtualizacaoProdutoForm extends Component {
                   primeiroStep={primeiroStep}
                   valoresPrimeiroForm={valoresPrimeiroForm}
                   valuesForm={values}
+                  showModal={this.showModal}
                 />
               )}
               {page === 1 && (
@@ -309,6 +344,7 @@ class AtualizacaoProdutoForm extends Component {
                   valoresSegundoForm={valoresSegundoForm}
                   segundoStep={segundoStep}
                   passouSegundoStep={this.passouSegundoStep}
+                  showModal={this.showModal}
                 />
               )}
               {page === 2 && (
@@ -321,6 +357,7 @@ class AtualizacaoProdutoForm extends Component {
                   valoresterceiroForm={valoresterceiroForm}
                   terceiroStep={terceiroStep}
                   passouTerceiroStep={this.passouTerceiroStep}
+                  showModal={this.showModal}
                 />
               )}
             </Fragment>

--- a/src/components/screens/Produto/Homologacao/components/BotoesGPCODAE.jsx
+++ b/src/components/screens/Produto/Homologacao/components/BotoesGPCODAE.jsx
@@ -73,19 +73,18 @@ export const BotoesGPCODAE = ({
         });
         break;
 
-        case "cancelar":
-          setPropsModal({
-            toastSuccessMessage:
-              "Cancelamento enviado com sucesso.",
-            modalTitle: "Envio de Cancelamento da Solicitação de Correção",
-            endpoint: CODAECancelaSoliticaoCorrecao,
-            labelJustificativa: "Justificativa",
-            helpText: undefined,
-            eAnalise: false,
-            tipoModal: tipoModal,
-            cancelaSolicitacao: homologacao
-          });
-          break;  
+      case "cancelar":
+        setPropsModal({
+          toastSuccessMessage: "Cancelamento enviado com sucesso.",
+          modalTitle: "Envio de Cancelamento da Solicitação de Correção",
+          endpoint: CODAECancelaSoliticaoCorrecao,
+          labelJustificativa: "Justificativa",
+          helpText: undefined,
+          eAnalise: false,
+          tipoModal: tipoModal,
+          cancelaSolicitacao: homologacao
+        });
+        break;
 
       default:
         setPropsModal({});
@@ -129,18 +128,17 @@ export const BotoesGPCODAE = ({
         cancelaAnaliseSensorial={propsModal.cancelaSolicitacao}
       />
       <div className="col-12">
-        {homologacao.status === "CODAE_QUESTIONADO" 
-        ? (
-          <>        
+        {homologacao.status === "CODAE_QUESTIONADO" ? (
+          <>
             <Botao
-            texto="Cancelar Solicitação"
-            className="float-right"
-            type={BUTTON_TYPE.BUTTON}
-            onClick={() => setPropsModalPadrao("cancelar")}
-            style={BUTTON_STYLE.GREEN_OUTLINE}
-          />
-        </>
-        ):(
+              texto="Cancelar Solicitação"
+              className="float-right"
+              type={BUTTON_TYPE.BUTTON}
+              onClick={() => setPropsModalPadrao("cancelar")}
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+            />
+          </>
+        ) : (
           <>
             <Botao
               texto="Homologar"

--- a/src/components/screens/Produto/Homologacao/components/BotoesGPCODAE.jsx
+++ b/src/components/screens/Produto/Homologacao/components/BotoesGPCODAE.jsx
@@ -7,6 +7,7 @@ import {
 import { ModalPadrao } from "components/Shareable/ModalPadrao";
 import { ModalVincularEditais } from "./ModelVincularEditais";
 import {
+  CODAECancelaSoliticaoCorrecao,
   CODAENaoHomologaProduto,
   CODAEPedeAnaliseSensorialProduto,
   CODAEPedeCorrecao
@@ -72,6 +73,20 @@ export const BotoesGPCODAE = ({
         });
         break;
 
+        case "cancelar":
+          setPropsModal({
+            toastSuccessMessage:
+              "Cancelamento enviado com sucesso.",
+            modalTitle: "Envio de Cancelamento da Solicitação de Correção",
+            endpoint: CODAECancelaSoliticaoCorrecao,
+            labelJustificativa: "Justificativa",
+            helpText: undefined,
+            eAnalise: false,
+            tipoModal: tipoModal,
+            cancelaSolicitacao: homologacao
+          });
+          break;  
+
       default:
         setPropsModal({});
         break;
@@ -111,40 +126,56 @@ export const BotoesGPCODAE = ({
         status={homologacao.status}
         terceirizada={homologacao.rastro_terceirizada}
         tipoModal={tipoModal}
+        cancelaAnaliseSensorial={propsModal.cancelaSolicitacao}
       />
       <div className="col-12">
-        <Botao
-          texto="Homologar"
-          className="float-right"
-          type={BUTTON_TYPE.BUTTON}
-          onClick={() => setShowModalHomologar(true)}
-          style={BUTTON_STYLE.GREEN_OUTLINE}
-          disabled={values.necessita_analise_sensorial === "1"}
-        />
-        <Botao
-          texto="Não homologar"
-          className="mr-3 float-right"
-          onClick={() => setPropsModalPadrao("nao-homologar")}
-          type={BUTTON_TYPE.BUTTON}
-          style={BUTTON_STYLE.GREEN_OUTLINE}
-          disabled={values.necessita_analise_sensorial === "1"}
-        />
-        <Botao
-          texto="Corrigir"
-          className="mr-3 float-right"
-          type={BUTTON_TYPE.BUTTON}
-          style={BUTTON_STYLE.GREEN_OUTLINE}
-          onClick={() => setPropsModalPadrao("corrigir")}
-          disabled={values.necessita_analise_sensorial === "0"}
-        />
-        <Botao
-          texto="Solicitar análise sensorial"
-          className="mr-3 float-right"
-          type={BUTTON_TYPE.BUTTON}
-          onClick={() => setPropsModalPadrao("analise")}
-          style={BUTTON_STYLE.GREEN}
-          disabled={values.necessita_analise_sensorial === "0"}
-        />
+        {homologacao.status === "CODAE_QUESTIONADO" 
+        ? (
+          <>        
+            <Botao
+            texto="Cancelar Solicitação"
+            className="float-right"
+            type={BUTTON_TYPE.BUTTON}
+            onClick={() => setPropsModalPadrao("cancelar")}
+            style={BUTTON_STYLE.GREEN_OUTLINE}
+          />
+        </>
+        ):(
+          <>
+            <Botao
+              texto="Homologar"
+              className="float-right"
+              type={BUTTON_TYPE.BUTTON}
+              onClick={() => setShowModalHomologar(true)}
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              disabled={values.necessita_analise_sensorial === "1"}
+            />
+            <Botao
+              texto="Não homologar"
+              className="mr-3 float-right"
+              onClick={() => setPropsModalPadrao("nao-homologar")}
+              type={BUTTON_TYPE.BUTTON}
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              disabled={values.necessita_analise_sensorial === "1"}
+            />
+            <Botao
+              texto="Corrigir"
+              className="mr-3 float-right"
+              type={BUTTON_TYPE.BUTTON}
+              style={BUTTON_STYLE.GREEN_OUTLINE}
+              onClick={() => setPropsModalPadrao("corrigir")}
+              disabled={values.necessita_analise_sensorial === "0"}
+            />
+            <Botao
+              texto="Solicitar análise sensorial"
+              className="mr-3 float-right"
+              type={BUTTON_TYPE.BUTTON}
+              onClick={() => setPropsModalPadrao("analise")}
+              style={BUTTON_STYLE.GREEN}
+              disabled={values.necessita_analise_sensorial === "0"}
+            />
+          </>
+        )}
       </div>
       <div className="col-12">
         <hr />

--- a/src/components/screens/Produto/Homologacao/index.jsx
+++ b/src/components/screens/Produto/Homologacao/index.jsx
@@ -96,11 +96,13 @@ export const Homologacao = ({
               <InformacoesProduto homologacao={homologacao} />
               <FotosProduto homologacao={homologacao} />
               <DocumentosProduto homologacao={homologacao} />
-
               {usuarioEhCODAEGestaoProduto() &&
-                homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" && (
+                (homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" || 
+                homologacao.status === "CODAE_QUESTIONADO") && (
                   <>
-                    <AnaliseSensorial />
+                    {homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" && (
+                      <AnaliseSensorial />
+                    )}
                     <BotoesGPCODAE
                       homologacao={homologacao}
                       terceirizadas={terceirizadas}

--- a/src/components/screens/Produto/Homologacao/index.jsx
+++ b/src/components/screens/Produto/Homologacao/index.jsx
@@ -97,8 +97,8 @@ export const Homologacao = ({
               <FotosProduto homologacao={homologacao} />
               <DocumentosProduto homologacao={homologacao} />
               {usuarioEhCODAEGestaoProduto() &&
-                (homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" || 
-                homologacao.status === "CODAE_QUESTIONADO") && (
+                (homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" ||
+                  homologacao.status === "CODAE_QUESTIONADO") && (
                   <>
                     {homologacao.status === "CODAE_PENDENTE_HOMOLOGACAO" && (
                       <AnaliseSensorial />

--- a/src/services/produto.service.js
+++ b/src/services/produto.service.js
@@ -447,7 +447,6 @@ export const CODAECancelaSoliticaoCorrecao = (uuid, justificativa) => {
     });
 };
 
-
 export const CODAEPedeCorrecao = (uuid, justificativa) => {
   const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-questiona-pedido/`;
   let status = 0;

--- a/src/services/produto.service.js
+++ b/src/services/produto.service.js
@@ -427,24 +427,41 @@ export const CODAENaoHomologaProduto = (uuid, justificativa) => {
     });
 };
 
-export const CODAECancelaSoliticaoCorrecao = (uuid, justificativa) => {
+export const CODAECancelaSoliticaoCorrecao = async (uuid, justificativa) => {
   const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-cancela-solicitacao-correcao/`;
   let status = 0;
-  return fetch(url, {
-    method: "PATCH",
-    headers: authToken,
-    body: JSON.stringify({ justificativa })
-  })
-    .then(res => {
-      status = res.status;
-      return res.json();
-    })
-    .then(data => {
-      return { data: data, status: status };
-    })
-    .catch(error => {
-      return error;
+  try {
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: authToken,
+      body: JSON.stringify({ justificativa })
     });
+    status = res.status;
+    const data = await res.json();
+    return { data: data, status: status };
+  } catch (error) {
+    return error;
+  }
+};
+
+export const TerceirizadaCancelaSoliticaoCorrecao = async (
+  uuid,
+  justificativa
+) => {
+  const url = `${API_URL}/homologacoes-produtos/${uuid}/terceirizada-cancela-solicitacao-correcao/`;
+  let status = 0;
+  try {
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers: authToken,
+      body: JSON.stringify({ justificativa })
+    });
+    status = res.status;
+    const data = await res.json();
+    return { data: data, status: status };
+  } catch (error) {
+    return error;
+  }
 };
 
 export const CODAEPedeCorrecao = (uuid, justificativa) => {

--- a/src/services/produto.service.js
+++ b/src/services/produto.service.js
@@ -427,6 +427,27 @@ export const CODAENaoHomologaProduto = (uuid, justificativa) => {
     });
 };
 
+export const CODAECancelaSoliticaoCorrecao = (uuid, justificativa) => {
+  const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-cancela-solicitacao-correcao/`;
+  let status = 0;
+  return fetch(url, {
+    method: "PATCH",
+    headers: authToken,
+    body: JSON.stringify({ justificativa })
+  })
+    .then(res => {
+      status = res.status;
+      return res.json();
+    })
+    .then(data => {
+      return { data: data, status: status };
+    })
+    .catch(error => {
+      return error;
+    });
+};
+
+
 export const CODAEPedeCorrecao = (uuid, justificativa) => {
   const url = `${API_URL}/homologacoes-produtos/${uuid}/codae-questiona-pedido/`;
   let status = 0;


### PR DESCRIPTION
# Proposta

Este PR criar botão de cancelar correção por parte da GPCodae e Terceirizada assim como as autorizações e status de log para tal.

# Referência do Azure

- 93265

# Tarefas para concluir

- [x] Criação do botão de Cancelar Solicitação para página de correção do perfil GPCodae
- [x] Criação do botão de Cancelar em todas páginas de correção do perfil Terceirizada
- [x] Adaptações no modalPadrão para cancelar correção
- [x] Criação das funções de endpoint para cancelamento
- [x] Identificação dos status de log para cancelamentos do motivo de correção
- [x] Adaptação do modal de histórico para exibir o nome do produto
- [x] Alteração nas página de correções para encaminhar ao painel de produtos após o cancelamento
