### PR TITLE
Feature/92113-MI-retirar-lanche-emergencial-de-períodos-grupos-que-n-sejam-solicitações-de-alimentação

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
@@ -64,25 +64,32 @@ export default ({
   };
 
   if (ehGrupoSolicitacoesDeAlimentacao || ehGrupoETEC) {
-    alimentacoesFormatadas = tipos_alimentacao.map((item, key) => (
+    if (ehGrupoETEC) {
+      tipos_alimentacao = tipos_alimentacao.filter(
+        alimentacao => alimentacao !== "Lanche Emergencial"
+      );
+    }
+    alimentacoesFormatadas = tipos_alimentacao.map((alimentacao, key) => (
       <div key={key} className="mb-2">
         <span style={{ color: cor }}>
-          <b>{quantidadeAlimentacao(item)}</b>
+          <b>{quantidadeAlimentacao(alimentacao)}</b>
         </span>
-        <span className="ml-1">- {item}</span>
+        <span className="ml-1">- {alimentacao}</span>
         <br />
       </div>
     ));
   } else {
-    alimentacoesFormatadas = tipos_alimentacao.map((alimentacao, key) => (
-      <div key={key} className="mb-2">
-        <span style={{ color: cor }}>
-          <b>{quantidadeAlimentacao(alimentacao.nome)}</b>
-        </span>
-        <span className="ml-1">- {alimentacao.nome}</span>
-        <br />
-      </div>
-    ));
+    alimentacoesFormatadas = tipos_alimentacao
+      .filter(alimentacao => alimentacao.nome !== "Lanche Emergencial")
+      .map((alimentacao, key) => (
+        <div key={key} className="mb-2">
+          <span style={{ color: cor }}>
+            <b>{quantidadeAlimentacao(alimentacao.nome)}</b>
+          </span>
+          <span className="ml-1">- {alimentacao.nome}</span>
+          <br />
+        </div>
+      ));
   }
 
   const desabilitarBotaoEditar = () => {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.js
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.js
@@ -457,16 +457,18 @@ export const formatarLinhasTabelaAlimentacao = (
   tipos_alimentacao,
   periodoGrupo
 ) => {
-  const tiposAlimentacaoFormatadas = tipos_alimentacao.map(alimentacao => {
-    return {
-      ...alimentacao,
-      name: alimentacao.nome
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .toLowerCase()
-        .replaceAll(/ /g, "_")
-    };
-  });
+  const tiposAlimentacaoFormatadas = tipos_alimentacao
+    .filter(alimentacao => alimentacao.nome !== "Lanche Emergencial")
+    .map(alimentacao => {
+      return {
+        ...alimentacao,
+        name: alimentacao.nome
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .toLowerCase()
+          .replaceAll(/ /g, "_")
+      };
+    });
   const indexRefeicao = tiposAlimentacaoFormatadas.findIndex(
     ali => ali.nome === "Refeição"
   );
@@ -489,14 +491,6 @@ export const formatarLinhasTabelaAlimentacao = (
       name: "repeticao_sobremesa",
       uuid: null
     });
-  }
-
-  const indexLancheEmergencial = tiposAlimentacaoFormatadas.findIndex(
-    ali => ali.nome === "Lanche Emergencial"
-  );
-  if (indexLancheEmergencial !== -1) {
-    tiposAlimentacaoFormatadas[indexLancheEmergencial].nome =
-      "Lanche Emergenc.";
   }
 
   const matriculadosOuNumeroDeAlunos = () => {
@@ -621,8 +615,9 @@ export const formatarLinhasTabelaSolicitacoesAlimentacao = () => {
 
 export const formatarLinhasTabelaEtecAlimentacao = () => {
   const tiposAlimentacaoEtec = tiposAlimentacaoETEC();
-  const tiposAlimentacaoEtecFormatadas = tiposAlimentacaoEtec.map(
-    alimentacao => {
+  const tiposAlimentacaoEtecFormatadas = tiposAlimentacaoEtec
+    .filter(alimentacao => alimentacao !== "Lanche Emergencial")
+    .map(alimentacao => {
       return {
         nome: alimentacao,
         name: alimentacao
@@ -632,8 +627,7 @@ export const formatarLinhasTabelaEtecAlimentacao = () => {
           .replaceAll(/ /g, "_"),
         uuid: null
       };
-    }
-  );
+    });
 
   const indexRefeicaoEtec = tiposAlimentacaoEtecFormatadas.findIndex(
     ali => ali.nome === "Refeição"
@@ -659,14 +653,6 @@ export const formatarLinhasTabelaEtecAlimentacao = () => {
       name: "repeticao_sobremesa",
       uuid: null
     });
-  }
-
-  const indexLancheEmergencialEtec = tiposAlimentacaoEtecFormatadas.findIndex(
-    ali => ali.nome === "Lanche Emergencial"
-  );
-  if (indexLancheEmergencialEtec !== -1) {
-    tiposAlimentacaoEtecFormatadas[indexLancheEmergencialEtec].nome =
-      "Lanche Emergenc.";
   }
 
   tiposAlimentacaoEtecFormatadas.unshift(

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -228,8 +228,9 @@ export default () => {
         ) || periodos_escolares[0];
       const tipos_alimentacao = periodo.tipos_alimentacao;
       const cloneTiposAlimentacao = deepCopy(tipos_alimentacao);
-      const tiposAlimentacaoFormatadas = cloneTiposAlimentacao.map(
-        alimentacao => {
+      const tiposAlimentacaoFormatadas = cloneTiposAlimentacao
+        .filter(alimentacao => alimentacao.nome !== "Lanche Emergencial")
+        .map(alimentacao => {
           return {
             ...alimentacao,
             name: alimentacao.nome
@@ -238,8 +239,7 @@ export default () => {
               .toLowerCase()
               .replaceAll(/ /g, "_")
           };
-        }
-      );
+        });
 
       const indexRefeicao = tiposAlimentacaoFormatadas.findIndex(
         ali => ali.nome === "Refeição"
@@ -263,14 +263,6 @@ export default () => {
           name: "repeticao_sobremesa",
           uuid: null
         });
-      }
-
-      const indexLancheEmergencial = tiposAlimentacaoFormatadas.findIndex(
-        ali => ali.nome === "Lanche Emergencial"
-      );
-      if (indexLancheEmergencial !== -1) {
-        tiposAlimentacaoFormatadas[indexLancheEmergencial].nome =
-          "Lanche Emergenc.";
       }
 
       const tiposAlimentacaoProgramasProjetos = deepCopy(
@@ -405,8 +397,9 @@ export default () => {
 
       const tiposAlimentacaoEtec = tiposAlimentacaoETEC();
       const cloneTiposAlimentacaoEtec = deepCopy(tiposAlimentacaoEtec);
-      const tiposAlimentacaoEtecFormatadas = cloneTiposAlimentacaoEtec.map(
-        alimentacao => {
+      const tiposAlimentacaoEtecFormatadas = cloneTiposAlimentacaoEtec
+        .filter(alimentacao => alimentacao !== "Lanche Emergencial")
+        .map(alimentacao => {
           return {
             nome: alimentacao,
             name: alimentacao
@@ -416,8 +409,7 @@ export default () => {
               .replaceAll(/ /g, "_"),
             uuid: null
           };
-        }
-      );
+        });
 
       const indexRefeicaoEtec = tiposAlimentacaoEtecFormatadas.findIndex(
         ali => ali.nome === "Refeição"
@@ -1619,6 +1611,7 @@ export default () => {
   };
 
   const linhasTabelaAlimentacao = categoria => {
+    //
     if (categoria.nome.includes("SOLICITAÇÕES")) {
       return tabelaSolicitacoesAlimentacaoRows;
     } else if (ehGrupoETECUrlParam) {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1611,7 +1611,6 @@ export default () => {
   };
 
   const linhasTabelaAlimentacao = categoria => {
-    //
     if (categoria.nome.includes("SOLICITAÇÕES")) {
       return tabelaSolicitacoesAlimentacaoRows;
     } else if (ehGrupoETECUrlParam) {


### PR DESCRIPTION
**### Este PR visa:**

- remover Lanche Emergencial exceto para Solicitações de Alimentação nas telas de cards somatórios tela de lançamento, tabelas de lançamento da escola e do helpers utilizado na tela de visualização tabelas de lançamento

**Referência:**
92113