### PR TITLE
Feature/95490 libera dre jt

### DIFF
--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -851,7 +851,8 @@ export const exibirGA = () => {
     "FREGUESIA/BRASILANDIA",
     "GUAIANASES",
     "SAO MATEUS",
-    "SAO MIGUEL"
+    "SAO MIGUEL",
+    "JACANA/TREMEMBE"
   ];
 
   if (["development"].includes(ENVIRONMENT)) {


### PR DESCRIPTION
# Este PR:
- libera o módulo de Gestão de Alimentação para a DRE Jacana/Tremembe

### Referência azure:
- 95490