### PR TITLE
Feature/93529-MI-detalhamento-períodos-devolvidos-para-ajustes-pela-dre-visão-UE

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
@@ -95,7 +95,10 @@ export default ({
   }
 
   const desabilitarBotaoEditar = () => {
-    if (!solicitacaoMedicaoInicial) {
+    if (
+      !solicitacaoMedicaoInicial ||
+      ["Não Preenchido", "MEDICAO_ENVIADA_PELA_UE"].includes(statusPeriodo())
+    ) {
       return true;
     } else if (
       ["MEDICAO_APROVADA_PELA_DRE", "MEDICAO_CORRECAO_SOLICITADA"].includes(
@@ -123,6 +126,8 @@ export default ({
         mesAnoSelecionado: periodoSelecionado,
         tipos_alimentacao: tipos_alimentacao,
         status_periodo: statusPeriodo(),
+        status_solicitacao: solicitacaoMedicaoInicial.status,
+        justificativa_periodo: justificativaPeriodo(),
         ...location.state
       }
     });
@@ -134,8 +139,24 @@ export default ({
     );
     if (obj) {
       return obj.status;
-    } else {
+    } else if (
+      solicitacaoMedicaoInicial.status ===
+      "MEDICAO_EM_ABERTO_PARA_PREENCHIMENTO_UE"
+    ) {
       return solicitacaoMedicaoInicial.status;
+    } else {
+      return "Não Preenchido";
+    }
+  };
+
+  const justificativaPeriodo = () => {
+    const obj = quantidadeAlimentacoesLancadas.find(
+      each => each.nome_periodo_grupo === nomePeriodoGrupo()
+    );
+    if (obj) {
+      return obj.justificativa;
+    } else {
+      return null;
     }
   };
 
@@ -156,9 +177,18 @@ export default ({
               {textoCabecalho}
             </div>
             <div className="col-3 pr-0">
-              <div className="float-right status-card-periodo-grupo">
-                {PERIODO_STATUS_DE_PROGRESSO[statusPeriodo()] &&
-                  PERIODO_STATUS_DE_PROGRESSO[statusPeriodo()].nome}
+              <div
+                className={`float-right status-card-periodo-grupo ${
+                  statusPeriodo() === "MEDICAO_CORRECAO_SOLICITADA"
+                    ? "red"
+                    : statusPeriodo() === "MEDICAO_CORRIGIDA_PELA_UE"
+                    ? "blue"
+                    : ""
+                }`}
+              >
+                {PERIODO_STATUS_DE_PROGRESSO[statusPeriodo()]
+                  ? PERIODO_STATUS_DE_PROGRESSO[statusPeriodo()].nome
+                  : "Não Preenchido"}
               </div>
             </div>
           </div>
@@ -195,7 +225,11 @@ export default ({
                   statusPeriodo() === "MEDICAO_APROVADA_PELA_DRE"
                     ? "Visualizar"
                     : solicitacaoMedicaoInicial.status ===
-                      "MEDICAO_CORRECAO_SOLICITADA"
+                        "MEDICAO_CORRECAO_SOLICITADA" &&
+                      [
+                        "MEDICAO_CORRECAO_SOLICITADA",
+                        "MEDICAO_CORRIGIDA_PELA_UE"
+                      ].includes(statusPeriodo())
                     ? "Corrigir"
                     : "Editar"
                 }

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/styles.scss
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/styles.scss
@@ -78,11 +78,16 @@
     font-size: 14px;
     border-radius: 24px;
     padding: 5px 12px;
-
-    .red {
-      color: $red;
-    }
   }
+
+  .red {
+    color: $red;
+  }
+
+  .blue {
+    color: $blue;
+  }
+
   .col-form-label {
     font-size: 14px;
     span {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/components/ModalSalvarCorrecoes/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/components/ModalSalvarCorrecoes/index.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { Spin } from "antd";
+import { Modal } from "react-bootstrap";
+import Botao from "components/Shareable/Botao";
+import {
+  BUTTON_TYPE,
+  BUTTON_STYLE
+} from "components/Shareable/Botao/constants";
+
+export default ({ closeModal, showModal, periodoGrupo, onSubmit }) => {
+  const [loadingModal, setLoadingModal] = useState(false);
+
+  const onClickSim = async () => {
+    setLoadingModal(true);
+    await onSubmit();
+    closeModal();
+  };
+
+  return (
+    <Modal dialogClassName="modal-50w" show={showModal} onHide={closeModal}>
+      <Spin tip="Carregando..." spinning={loadingModal}>
+        <Modal.Header closeButton>
+          <Modal.Title>Salvar Correções</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p className="col-12 my-3 p-0">
+            {`Deseja salvar as correções realizadas no Período ${periodoGrupo}?`}
+          </p>
+        </Modal.Body>
+        <Modal.Footer className="float-right">
+          <Botao
+            className="ml-3"
+            texto="Não"
+            type={BUTTON_TYPE.BUTTON}
+            onClick={closeModal}
+            style={BUTTON_STYLE.GREEN_OUTLINE}
+          />
+          <Botao
+            className="ml-3 mr-3"
+            texto="Sim"
+            type={BUTTON_TYPE.BUTTON}
+            style={BUTTON_STYLE.GREEN}
+            onClick={() => onClickSim()}
+          />
+        </Modal.Footer>
+      </Spin>
+    </Modal>
+  );
+};

--- a/src/services/medicaoInicial/solicitacaoMedicaoInicial.service.js
+++ b/src/services/medicaoInicial/solicitacaoMedicaoInicial.service.js
@@ -89,6 +89,15 @@ export const drePedeCorrecaMedicao = async (uuid, params) => {
   }
 };
 
+export const escolaCorrigeMedicao = async (uuid, params) => {
+  const url = `medicao-inicial/medicao/${uuid}/escola-corrige-medicao/`;
+  const response = await axios.patch(url, params).catch(ErrorHandlerFunction);
+  if (response) {
+    const data = { data: response.data, status: response.status };
+    return data;
+  }
+};
+
 export const getQuantidadeAlimentacoesLancadasPeriodoGrupo = async params => {
   const url = `medicao-inicial/solicitacao-medicao-inicial/quantidades-alimentacoes-lancadas-periodo-grupo/`;
   const response = await axios.get(url, { params }).catch(ErrorHandlerFunction);


### PR DESCRIPTION
**### Este PR visa:**

- ajustar campos habilitados para correção da ue, bloco de justificativa DRE e botão de Salvar Correções
- ajustar exibição botão "Corrigir" e "Editar" para os cards de períodos/grupos
- criar ModalSalvarCorrecoes

**Referência:**
93529