### PR TITLE
Hotfix/97055 correcao relatorio inclusao cemei

### DIFF
--- a/src/components/Shareable/SolicitacoesSimilaresKitLanche/index.jsx
+++ b/src/components/Shareable/SolicitacoesSimilaresKitLanche/index.jsx
@@ -304,7 +304,8 @@ export const SolicitacoesSimilaresKitLanche = ({ ...props }) => {
                   dangerouslySetInnerHTML={{
                     __html:
                       solicitacao.observacao ||
-                      solicitacao.solicitacao_kit_lanche.descricao
+                      (solicitacao.solicitacao_kit_lanche &&
+                        solicitacao.solicitacao_kit_lanche.descricao)
                   }}
                 />
               </div>


### PR DESCRIPTION
# Este PR:
- corrige regra que faz tela de solicitacao kit lanche cemei quebrar


### Referência azure:
- 97055