### PR TITLE
feature/96651-medicao-inicial-ajustes-cabecalho-medicao-teste-usabilidade

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/InformacoesEscola/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/InformacoesEscola/index.jsx
@@ -16,6 +16,14 @@ export default ({ escolaInstituicao, loteEscolaSimples }) => {
         <Collapse expandIconPosition="end">
           <Panel header="Informações da Unidade Educacional">
             <div className="row">
+              <div className="col-12 info-label">
+                <label>NOME DA UE</label>
+                <p className="value-label">
+                  {escolaInstituicao && escolaInstituicao.nome}
+                </p>
+              </div>
+            </div>
+            <div className="row">
               <div className="col-8 info-label">
                 <label>DRE</label>
                 <p className="value-label">

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/InformacoesMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/InformacoesMedicaoInicial/index.jsx
@@ -42,6 +42,7 @@ export default ({
     }
   ]);
   const [emEdicao, setEmEdicao] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   const { Option } = Select;
   const { Panel } = Collapse;
 
@@ -67,6 +68,12 @@ export default ({
 
   useEffect(() => {
     getDefaultValueSelectTipoContagem();
+  }, []);
+
+  useEffect(() => {
+    if (solicitacaoMedicaoInicial) {
+      setIsOpen(false);
+    }
   }, [solicitacaoMedicaoInicial]);
 
   const opcoesContagem = tiposDeContagem
@@ -231,8 +238,8 @@ export default ({
     <div className="row mt-4 info-med-inicial collapse-adjustments">
       <div className="col-12 panel-med-inicial">
         <div className="pl-0 label-adjustments">
-          <Collapse expandIconPosition="end">
-            <Panel header="Informações Básicas da Medição Inicial">
+          <Collapse expandIconPosition="end" activeKey={isOpen ? ["1"] : []}>
+            <Panel header="Informações Básicas da Medição Inicial" key="1">
               <div className="row">
                 <div className="col-5 info-label select-medicao-inicial">
                   <b className="mb-2">

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -164,7 +164,7 @@ export default ({
     getSolicitacoesAlteracaoLancheEmergencialAutorizadasAsync();
     getSolicitacoesInclusoesEtecAutorizadasAsync();
     getQuantidadeAlimentacoesLancadasPeriodoGrupoAsync();
-  }, [periodoSelecionado]);
+  }, [periodoSelecionado, solicitacaoMedicaoInicial]);
 
   const getPathPlanilhaOcorr = () => {
     if (objSolicitacaoMIFinalizada.anexo)


### PR DESCRIPTION
# Proposta

Este PR visa fazer ajustes no cabeçalho de medições iniciais

# Referência do Azure

- 96651

# Tarefas para concluir

- [x] Adiciona label NOME DA UE e seu valor
- [x] Configura collapse de informações básicas para expandido quando não há ainda medição para aquele mês
- [x] Exibe automaticamente os períodos quando criada a medição