### PR TITLE
Feature/96840-GA-relatório-solicitações-alimentação-dias-com-cancelamento-inclusão-normal-contínua

### DIFF
--- a/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/index.jsx
@@ -12,7 +12,7 @@ import { CODAE, TERCEIRIZADA } from "configs/constants";
 import { statusEnum, TIPO_PERFIL, TIPO_SOLICITACAO } from "constants/shared";
 import {
   prazoDoPedidoMensagem,
-  usuarioEhEscolaTerceirizada,
+  usuarioEhEscolaTerceirizadaQualquerPerfil,
   visualizaBotoesDoFluxo
 } from "helpers/utilities";
 import HTTP_STATUS from "http-status-codes";
@@ -230,7 +230,7 @@ class Relatorio extends Component {
 
     const renderModalCancelamentoContinuo = inclusao => {
       return (
-        usuarioEhEscolaTerceirizada() &&
+        usuarioEhEscolaTerceirizadaQualquerPerfil() &&
         inclusao &&
         inclusao.motivo &&
         !inclusao.motivo.nome.includes("ETEC") &&

--- a/src/components/Shareable/Weekly/style.scss
+++ b/src/components/Shareable/Weekly/style.scss
@@ -33,3 +33,27 @@
     }
   }
 }
+
+.cancelado {
+  .weekly {
+    .week-circle {
+      text-decoration: line-through;
+    }
+
+    .week-circle-clicked.green {
+      background-color: $gray;
+      text-decoration: line-through;
+    }
+  }
+
+  .nome-periodo-escolar-relatorio-sol-alim,
+  .tipos-alimentacao-relatorio-sol-alim,
+  .numero-alunos-relatorio-sol-alim,
+  .observacao-relatorio-sol-alim {
+    p {
+      color: $grayLight;
+      font-weight: bold;
+      text-decoration: line-through;
+    }
+  }
+}

--- a/src/components/Shareable/style.scss
+++ b/src/components/Shareable/style.scss
@@ -583,8 +583,12 @@ table.table-report {
     tr.cancelado {
       td {
         p:not(.justificativa-cancelamento) {
-          color: $grayDisabled;
+          color: $grayLight;
+          font-weight: bold;
           text-decoration: line-through;
+        }
+        p:is(.justificativa-cancelamento) {
+          word-break: break-word;
         }
       }
 

--- a/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/InclusaoBody/index.jsx
+++ b/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/InclusaoBody/index.jsx
@@ -5,6 +5,12 @@ export const InclusaoBody = ({ ...props }) => {
   const log = solicitacao.logs[solicitacao.logs.length - 1];
   const [showDetail, setShowDetail] = useState(false);
 
+  const ehDiaCancelado = inclusao => {
+    return inclusao.cancelado || solicitacao.status === "ESCOLA_CANCELOU"
+      ? "dia-cancelado"
+      : "";
+  };
+
   return [
     <tr className="table-body-items" key={index}>
       <td>
@@ -59,12 +65,16 @@ export const InclusaoBody = ({ ...props }) => {
                   )}
                   <div className="col-3">
                     <p>
-                      <b>{inclusao.motivo.nome}</b>
+                      <b className={`${ehDiaCancelado(inclusao)}`}>
+                        {inclusao.motivo.nome}
+                      </b>
                     </p>
                   </div>
                   <div className="col-3">
                     <p>
-                      <b>{inclusao.data}</b>
+                      <b className={`${ehDiaCancelado(inclusao)}`}>
+                        {inclusao.data}
+                      </b>
                     </p>
                   </div>
                   {idx === 0 ? (
@@ -114,6 +124,27 @@ export const InclusaoBody = ({ ...props }) => {
                 </div>
               );
             })}
+            {solicitacao.inclusoes.find(
+              inclusao => inclusao.cancelado_justificativa
+            ) && (
+              <>
+                <hr />
+                <p>
+                  <strong>Histórico de cancelamento</strong>
+                  {solicitacao.inclusoes
+                    .filter(inclusao => inclusao.cancelado_justificativa)
+                    .map((inclusao, key) => {
+                      return (
+                        <div className="cancelado_justificativa" key={key}>
+                          {inclusao.data}
+                          {" - "}
+                          justificativa: {inclusao.cancelado_justificativa}
+                        </div>
+                      );
+                    })}
+                </p>
+              </>
+            )}
           </div>
         </td>
       </tr>

--- a/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/InclusaoContinuaBody/index.jsx
+++ b/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/InclusaoContinuaBody/index.jsx
@@ -1,7 +1,7 @@
 import { WEEK } from "configs/constants";
 import React, { useState } from "react";
 
-export const InclusaoContiniuaBody = ({ ...props }) => {
+export const InclusaoContinuaBody = ({ ...props }) => {
   const { solicitacao, item, index, filtros, labelData } = props;
   const log = solicitacao.logs[solicitacao.logs.length - 1];
   const [showDetail, setShowDetail] = useState(false);
@@ -81,7 +81,15 @@ export const InclusaoContiniuaBody = ({ ...props }) => {
                 .map(tipo_alimentacao => tipo_alimentacao.nome)
                 .join(", ");
               return (
-                <div className="row" key={idx}>
+                <div
+                  className={`row ${
+                    quantidade_periodo.cancelado ||
+                    solicitacao.status === "ESCOLA_CANCELOU"
+                      ? "cancelado"
+                      : ""
+                  }`}
+                  key={idx}
+                >
                   <div className="col-3 weekly">
                     {WEEK.map((day, key) => {
                       return (
@@ -102,23 +110,23 @@ export const InclusaoContiniuaBody = ({ ...props }) => {
                       );
                     })}
                   </div>
-                  <div className="col-3">
+                  <div className="col-3 nome-periodo-escolar-relatorio-sol-alim">
                     <p>
                       <b>{quantidade_periodo.periodo_escolar.nome}</b>
                     </p>
                   </div>
-                  <div className="col-3">
+                  <div className="col-3 tipos-alimentacao-relatorio-sol-alim">
                     <p>
                       <b>{tiposAlimentacao}</b>
                     </p>
                   </div>
-                  <div className="col-3">
+                  <div className="col-3 numero-alunos-relatorio-sol-alim">
                     <p>
                       <b>{quantidade_periodo.numero_alunos}</b>
                     </p>
                   </div>
                   {quantidade_periodo.observacao !== "<p></p>" && (
-                    <div className="col-12">
+                    <div className="col-12 observacao-relatorio-sol-alim">
                       <p>Observação:</p>
                       <b>
                         <p
@@ -133,6 +141,38 @@ export const InclusaoContiniuaBody = ({ ...props }) => {
                 </div>
               );
             })}
+            {solicitacao.quantidades_periodo.find(
+              quantidades_periodo => quantidades_periodo.cancelado_justificativa
+            ) && (
+              <>
+                <hr />
+                <p>
+                  <strong>Histórico de cancelamento</strong>
+                  {solicitacao.quantidades_periodo
+                    .filter(
+                      quantidades_periodo =>
+                        quantidades_periodo.cancelado_justificativa
+                    )
+                    .map((quantidades_periodo, key) => {
+                      return (
+                        <div className="cancelado_justificativa" key={key}>
+                          {quantidades_periodo.data ||
+                            `${
+                              quantidades_periodo.periodo_escolar.nome
+                            } - ${quantidades_periodo.tipos_alimentacao
+                              .map(ta => ta.nome)
+                              .join(", ")} - ${
+                              quantidades_periodo.numero_alunos
+                            }`}
+                          {" - "}
+                          justificativa:{" "}
+                          {quantidades_periodo.cancelado_justificativa}
+                        </div>
+                      );
+                    })}
+                </p>
+              </>
+            )}
           </div>
         </td>
       </tr>

--- a/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/TabelaResultado/index.jsx
+++ b/src/components/screens/Relatorios/SolicitacoesAlimentacao/componentes/TabelaResultado/index.jsx
@@ -5,7 +5,7 @@ import { AlteracaoCEMEIBody } from "../AlteracaoCEMEIBody";
 import { InclusaoBody } from "../InclusaoBody";
 import { InclusaoCEIBody } from "../InclusaoCEIBody";
 import { InclusaoCEMEIBody } from "../InclusaoCEMEIBody";
-import { InclusaoContiniuaBody } from "../InclusaoContinuaBody";
+import { InclusaoContinuaBody } from "../InclusaoContinuaBody";
 import { InversaoCardapioBody } from "../InversaoCardapioBody";
 import { KitLancheAvulsaBody } from "../KitLancheAvulsaBody";
 import { KitLancheAvulsaCEIBody } from "../KitLancheAvulsaCEIBody";
@@ -38,7 +38,7 @@ export const TabelaResultado = ({ ...props }) => {
         );
       case "INC_ALIMENTA_CONTINUA":
         return (
-          <InclusaoContiniuaBody
+          <InclusaoContinuaBody
             solicitacao={solicitacao}
             item={item}
             index={index}


### PR DESCRIPTION
**### Este PR visa:**

- exibir histórico de cancelamento no relatório de solicitações de alimentação de inclusão contínua e normal
- renomear componente InclusaoContinuaBody
- ajustar permissão para exibir modal correto de cancelamento parcial de inclusão contínua
- ajustar color para dias cancelados na tela da solicitação de inclusão contínua

**Referência:**
96840