### PR TITLE
feature/85716-PeD-definicao-edital-produto-suspensao-desabilita-botao-resposta

### DIFF
--- a/src/components/Shareable/ModalJustificativa/index.jsx
+++ b/src/components/Shareable/ModalJustificativa/index.jsx
@@ -31,8 +31,6 @@ const ModalJustificativa = ({
   abreModalSuspensao,
   closeModalSuspensao
 }) => {
-  //const [showModalSuspender, setShowModalSuspender] = useState(false);
-
   return (
     <Modal
       dialogClassName="modal-justificativa-com-anexo modal-90w"

--- a/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
+++ b/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
@@ -80,6 +80,12 @@ const ModalSuspensaoProdutoEdital = ({
     return [];
   };
 
+  const verificaEditaisSelecionados = values => {
+    const editaisSelecionados =
+      values.editais_para_suspensao && values.editais_para_suspensao.length;
+    return editaisSelecionados === opcoesEditais().length;
+  };
+
   return (
     <Modal
       dialogClassName="modal-ativacao-produto modal-90w"
@@ -217,7 +223,12 @@ const ModalSuspensaoProdutoEdital = ({
                     className="ml-3"
                     type={BUTTON_TYPE.BUTTON}
                     onClick={() => {
-                      state.tipo_resposta = "aceitar";
+                      const todosEditaisSelecionados = verificaEditaisSelecionados(
+                        values
+                      );
+                      state.tipo_resposta = todosEditaisSelecionados
+                        ? "aceitar"
+                        : "aceitar_parcialmente";
                       form.submit();
                     }}
                     disabled={

--- a/src/components/screens/Produto/AvaliarReclamacaoProduto/components/TabelaProdutos/index.jsx
+++ b/src/components/screens/Produto/AvaliarReclamacaoProduto/components/TabelaProdutos/index.jsx
@@ -54,11 +54,14 @@ export default class TabelaProdutos extends Component {
       tipo_resposta: undefined,
       protocoloAnalise: null,
       terceirizada: null,
-      escola: null
+      escola: null,
+      uuisdReclamacaoDisabled: [],
+      uuidReclamacaoResposta: undefined
     };
   }
 
   ACEITAR_RECLAMACAO = "aceitar";
+  ACEITAR_RECLAMACAO_PARCIALMENTE = "aceitar_parcialmente";
   RECUSAR_RECLAMACAO = "rejeitar";
   QUESTIONAR_TERCEIRIZADA = "questionar_terceirizada";
   QUESTIONAR_UE = "questionar_ue";
@@ -104,7 +107,10 @@ export default class TabelaProdutos extends Component {
       case this.QUESTIONAR_NUTRISUPERVISOR:
         return CODAEQuestionaNutrisupervisor;
       case this.RESPONDER:
-        if (this.state.tipo_resposta === this.ACEITAR_RECLAMACAO) {
+        if (
+          this.state.tipo_resposta === this.ACEITAR_RECLAMACAO ||
+          this.state.tipo_resposta === this.ACEITAR_RECLAMACAO_PARCIALMENTE
+        ) {
           return CODAEAceitaReclamacao;
         }
         if (this.state.tipo_resposta === this.RECUSAR_RECLAMACAO) {
@@ -222,10 +228,41 @@ export default class TabelaProdutos extends Component {
       this.fechaModalJustificativa();
       this.fechaModalSuspensao();
       this.mostraToastSucesso();
+
+      if (this.state.tipo_resposta === this.RECUSAR_RECLAMACAO) {
+        this.setState({
+          uuisdReclamacaoDisabled: [
+            ...this.state.uuisdReclamacaoDisabled,
+            this.state.uuidReclamacaoResposta
+          ]
+        });
+      } else if (this.state.tipo_resposta === this.ACEITAR_RECLAMACAO) {
+        const uuidsReclamacoes = this.props.listaProdutos
+          .map(produto =>
+            produto.ultima_homologacao.reclamacoes.map(
+              reclamacao => reclamacao.uuid
+            )
+          )
+          .flat();
+        this.setState({ uuisdReclamacaoDisabled: uuidsReclamacoes });
+      } else if (
+        this.state.tipo_resposta === this.ACEITAR_RECLAMACAO_PARCIALMENTE
+      ) {
+        this.setState({
+          uuisdReclamacaoDisabled: [
+            ...this.state.uuisdReclamacaoDisabled,
+            this.state.uuidReclamacaoResposta
+          ]
+        });
+      }
     } else {
       toastError(response.errors);
     }
     this.props.setLoading(false);
+  };
+
+  deveDesabilitarBotao = uuidReclamacao => {
+    return this.state.uuisdReclamacaoDisabled.includes(uuidReclamacao);
   };
 
   render() {
@@ -437,14 +474,20 @@ export default class TabelaProdutos extends Component {
                             className="ml-3 botaoResponder"
                             type={BUTTON_TYPE.BUTTON}
                             style={BUTTON_STYLE.GREEN}
-                            disabled={desabilitaResponder}
-                            onClick={() =>
+                            disabled={
+                              desabilitaResponder ||
+                              this.deveDesabilitarBotao(reclamacao.uuid)
+                            }
+                            onClick={() => {
                               this.abreModalJustificativa(
                                 this.RESPONDER,
                                 reclamacao.uuid,
                                 produto
-                              )
-                            }
+                              );
+                              this.setState({
+                                uuidReclamacaoResposta: reclamacao.uuid
+                              });
+                            }}
                           />
                         </div>,
                         deveMostrarBarraHorizontal && <hr />


### PR DESCRIPTION
# Proposta

Este PR visa criar lógica para desabilitar botão de resposta após responder uma reclamação de produto

# Referência do Azure

- 91846

# Tarefas para concluir

- [x] Cria lógica de desabilitar botão Responder