### PR TITLE
Feature: Adicionar permissões nas rotas dos relatórios e permissão de exibição dos botões da SideBar

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuRelatorios.jsx
@@ -35,7 +35,10 @@ const MenuRelatorios = () => {
     usuarioEhEmpresaTerceirizada() ||
     usuarioEhEscolaTerceirizada() ||
     usuarioEhEscolaTerceirizadaDiretor() ||
-    usuarioEhCODAEDietaEspecial();
+    usuarioEhCODAEDietaEspecial() ||
+    usuarioEhCODAENutriManifestacao() ||
+    usuarioEhCODAEGestaoAlimentacao() ||
+    usuarioEhDRE();
 
   const exibirProdutosSuspensos =
     usuarioEhCODAEGestaoProduto() ||
@@ -45,7 +48,8 @@ const MenuRelatorios = () => {
     usuarioEhEscolaTerceirizada() ||
     usuarioEhEscolaTerceirizadaDiretor() ||
     usuarioEhCODAEDietaEspecial() ||
-    usuarioEhCODAENutriManifestacao();
+    usuarioEhCODAENutriManifestacao() ||
+    usuarioEhCODAEGestaoAlimentacao();
 
   const exibirRelatorioQuantitativoSolicDietaEsp =
     usuarioEhCODAEDietaEspecial() ||

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1109,7 +1109,10 @@ const routesConfig = [
       usuarioEhCODAEDietaEspecial() ||
       usuarioEhNutricionistaSupervisao() ||
       usuarioEhEscolaTerceirizada() ||
-      usuarioEhEscolaTerceirizadaDiretor()
+      usuarioEhEscolaTerceirizadaDiretor() ||
+      usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhDRE() ||
+      usuarioEhCODAENutriManifestacao()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/responder-questionamento-ue`,
@@ -1306,7 +1309,8 @@ const routesConfig = [
       usuarioEhEmpresaTerceirizada() ||
       usuarioEhEscolaTerceirizada() ||
       usuarioEhEscolaTerceirizadaDiretor() ||
-      usuarioEhCODAENutriManifestacao()
+      usuarioEhCODAENutriManifestacao() ||
+      usuarioEhCODAEGestaoAlimentacao()
   },
   {
     path: `/${constants.GESTAO_PRODUTO}/${


### PR DESCRIPTION
# Proposta

Este PR visa liberar acesso aos relatórios de P&D com o perfil de DRE, CODAE, e NUTRIMANIFESTAÇÃO

# Referência do Azure

- 97064

# Tarefas para concluir

- [x] Alterar configurações de permissões das rotas
- [x] Alterar configurações de permissões da sidebar