### PR TITLE
Feature/93459-MI-envio-solicitação-de-correção-pela-codae

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/helper.js
+++ b/src/components/Shareable/FluxoDeStatus/helper.js
@@ -124,7 +124,7 @@ export const tipoDeStatus = status => {
     case "Em aberto para preenchimento pela UE":
     case "Enviado pela UE":
     case "Aprovado pela DRE":
-    case "Aprovado por CODAE":
+    case "Aprovado pela CODAE":
     case "CODAE homologou":
     case "CODAE Atualizou o protocolo":
     case "Corrigido para DRE":
@@ -138,6 +138,7 @@ export const tipoDeStatus = status => {
     case "Ativo em alguns editais":
     case "Vínculo do Edital ao Produto":
     case "Correção solicitada":
+    case "Correção solicitada pela CODAE":
       return "questionado";
 
     case "Escola cancelou":

--- a/src/components/Shareable/FluxoDeStatus/index.jsx
+++ b/src/components/Shareable/FluxoDeStatus/index.jsx
@@ -74,6 +74,9 @@ export const FluxoDeStatus = props => {
         if (log.status_evento_explicacao === "Correção solicitada") {
           return "Devolvido para ajustes pela DRE";
         }
+        if (log.status_evento_explicacao === "Correção solicitada pela CODAE") {
+          return "Devolvido para ajustes pela CODAE";
+        }
         return log.status_evento_explicacao;
       }
     }

--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/TabelaLancamentosPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/TabelaLancamentosPeriodo/index.jsx
@@ -511,7 +511,12 @@ export const TabelaLancamentosPeriodo = ({ ...props }) => {
         <div className="content-section-acompanhamento-lancamento-right">
           <div
             className={`acompanhamento-status-lancamento mr-3 ${
-              periodoGrupo.status === "MEDICAO_CORRECAO_SOLICITADA" ? "red" : ""
+              [
+                "MEDICAO_CORRECAO_SOLICITADA",
+                "MEDICAO_CORRECAO_SOLICITADA_CODAE"
+              ].includes(periodoGrupo.status)
+                ? "red"
+                : ""
             }`}
           >
             {PERIODO_STATUS_DE_PROGRESSO[periodoGrupo.status] &&
@@ -776,9 +781,10 @@ export const TabelaLancamentosPeriodo = ({ ...props }) => {
                 className={`col-${
                   modoCorrecao
                     ? 6
-                    : ["MEDICAO_APROVADA_PELA_CODAE"].includes(
-                        solicitacao.status
-                      )
+                    : [
+                        "MEDICAO_APROVADA_PELA_CODAE",
+                        "MEDICAO_CORRECAO_SOLICITADA_CODAE"
+                      ].includes(solicitacao.status)
                     ? 12
                     : 8
                 } pl-0 pr-4`}
@@ -812,9 +818,10 @@ export const TabelaLancamentosPeriodo = ({ ...props }) => {
                   />
                 </div>
               ) : (
-                !["MEDICAO_APROVADA_PELA_CODAE"].includes(
-                  solicitacao.status
-                ) && (
+                ![
+                  "MEDICAO_APROVADA_PELA_CODAE",
+                  "MEDICAO_CORRECAO_SOLICITADA_CODAE"
+                ].includes(solicitacao.status) && (
                   <div className="botoes col-4 px-0">
                     <Botao
                       texto="Solicitar Correção"

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
@@ -176,7 +176,10 @@ export default ({
             <div className="col-3 pr-0">
               <div
                 className={`float-right status-card-periodo-grupo ${
-                  statusPeriodo() === "MEDICAO_CORRECAO_SOLICITADA"
+                  [
+                    "MEDICAO_CORRECAO_SOLICITADA",
+                    "MEDICAO_CORRECAO_SOLICITADA_CODAE"
+                  ].includes(statusPeriodo())
                     ? "red"
                     : statusPeriodo() === "MEDICAO_CORRIGIDA_PELA_UE"
                     ? "blue"

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/Ocorrencias/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/Ocorrencias/index.jsx
@@ -55,8 +55,12 @@ export default ({
                     <span className="status-ocorrencia text-center mr-3">
                       <b
                         className={
-                          solicitacaoMedicaoInicial.ocorrencia.status ===
-                          "MEDICAO_CORRECAO_SOLICITADA"
+                          [
+                            "MEDICAO_CORRECAO_SOLICITADA",
+                            "MEDICAO_CORRECAO_SOLICITADA_CODAE"
+                          ].includes(
+                            solicitacaoMedicaoInicial.ocorrencia.status
+                          )
                             ? "red"
                             : ""
                         }
@@ -113,7 +117,7 @@ export default ({
                           className="ml-3"
                           onClick={visualizarModalHistorico}
                         />
-                        {solicitacaoMedicaoInicial.status ===
+                        {solicitacaoMedicaoInicial.ocorrencia.status ===
                           "MEDICAO_CORRECAO_SOLICITADA" && (
                           <Botao
                             className="float-right ml-3"

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1848,7 +1848,7 @@ export default () => {
                       </div>
                     </div>
                     {location.state && location.state.justificativa_periodo && (
-                      <div className="row py-2">
+                      <div className="row pt-4 pb-2 mt-legenda">
                         <div className="col">
                           <b className="pb-2 mb-2">
                             Correções solicitadas pela DRE:
@@ -1861,7 +1861,11 @@ export default () => {
                         </div>
                       </div>
                     )}
-                    <div className="row pb-2 pt-4 title-semanas">
+                    <div
+                      className={`row pb-2 pt-4 ${!(
+                        location.state && location.state.justificativa_periodo
+                      ) && "mt-legenda"}`}
+                    >
                       <div className="col">
                         <b className="section-title">
                           Semanas do Período para Lançamento da Medição Inicial

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/styles.scss
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/styles.scss
@@ -269,6 +269,6 @@
   }
 }
 
-.title-semanas {
+.mt-legenda {
   margin-top: 50px !important;
 }

--- a/src/services/medicaoInicial/solicitacaoMedicaoInicial.service.js
+++ b/src/services/medicaoInicial/solicitacaoMedicaoInicial.service.js
@@ -152,6 +152,15 @@ export const codaeAprovaSolicitacaoMedicao = async uuid => {
   }
 };
 
+export const codaeSolicitaCorrecaoUE = async uuid => {
+  const url = `medicao-inicial/solicitacao-medicao-inicial/${uuid}/codae-solicita-correcao-medicao/`;
+  const response = await axios.patch(url).catch(ErrorHandlerFunction);
+  if (response) {
+    const data = { data: response.data, status: response.status };
+    return data;
+  }
+};
+
 export const escolaEnviaCorrecaoMedicaoInicialDRE = async uuid => {
   const url = `medicao-inicial/solicitacao-medicao-inicial/${uuid}/escola-corrige-medicao-para-dre/`;
   const response = await axios.patch(url).catch(ErrorHandlerFunction);


### PR DESCRIPTION
**### Este PR visa:**

- criar service codaeSolicitaCorrecaoUE
- ajustar endpoint solicitarCorrecaoMedicao e exibição de botões
- ajustar css do status MEDICAO_CORRECAO_SOLICITADA_CODAE nas tags / pílulas
- não exibir botões para os períodos após solicitação ser enviada para correção pela codae
- ajustar fluxo de status para log "Devolvido para ajustes pela CODAE"
- ajustar bloco de legenda na tela de lançamento ue

**Referência:**
93459