### PR TITLE
Correcoes screen notificar empresa

### DIFF
--- a/src/components/screens/Logistica/GuiasComNotificacoes/components/ListagemNotificacoes/index.jsx
+++ b/src/components/screens/Logistica/GuiasComNotificacoes/components/ListagemNotificacoes/index.jsx
@@ -85,6 +85,7 @@ const ListagemNotificacoes = ({ notificacoes, fiscal }) => {
             {botaoNotificarEmpresaDesabilitado}
           </>
         ) : (
+          ["RASCUNHO", "NOTIFICACAO_CRIADA"].includes(status) &&
           botaoNotificarEmpresaHabilitado
         )}
       </>

--- a/src/components/screens/Logistica/NotificarEmpresa/index.jsx
+++ b/src/components/screens/Logistica/NotificarEmpresa/index.jsx
@@ -328,7 +328,7 @@ export default ({ naoEditavel = false, botaoVoltar, voltarPara, fiscal }) => {
                       label="Empresa"
                       name="nome_empresa"
                       className="input-busca-produto"
-                      disabled={naoEditavel}
+                      disabled
                     />
                   </div>
                 </div>


### PR DESCRIPTION
# Este PR:

- Desabilita campo Empresa
- Restringe exibição do botão Notificar Empresa (ícone de sino) às notificações com status RASCUNHO e NOTIFICAÇÃO CRIADA