### PR TITLE
Fix/102411-MI-erro-ao-adicionar-observação-com-repetição-maior-que-frequência

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1295,7 +1295,11 @@ export default () => {
     Object.entries(valuesMesmoDiaDaObservacao).forEach(([key, value]) => {
       if (
         !ehGrupoETECUrlParam &&
-        !(key.includes("observacoes") || key.includes("frequencia")) &&
+        !(
+          key.includes("observacoes") ||
+          key.includes("frequencia") ||
+          key.includes("repeticao")
+        ) &&
         Number(value) >
           Number(
             valuesMesmoDiaDaObservacao[


### PR DESCRIPTION
**### Este PR visa:**

- excluir campos de repetição na validação de valores maiores que frequência ao adicionar observação

**Referência:**
102411