### PR TITLE
Hotfix/104705 cancela lanche emergencial

### DIFF
--- a/src/components/Shareable/ModalCancelaAlteracaoCardapio/index.jsx
+++ b/src/components/Shareable/ModalCancelaAlteracaoCardapio/index.jsx
@@ -92,7 +92,8 @@ export const ModalCancelarAlteracaoCardapio = ({ ...props }) => {
                             solicitacao.datas_intervalo.find(
                               (i) => i.data === dia.data
                             ).cancelado ||
-                            moment(dia.data, "DD/MM/YYYY") <= moment()
+                            moment(dia.data, "DD/MM/YYYY") <=
+                              moment().subtract("days", 1)
                           }
                           type="checkbox"
                           value={dia.data}


### PR DESCRIPTION
# Este PR:
- permite o cancelamento para o lanche emergencial no mesmo dia da solicitação

### Referência azure:
- 104705