### PR TITLE
Feature/106172 botao adicionar obrigatorio dia nao letivo

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1320,7 +1320,6 @@ export default () => {
       );
     };
     semanaSelecionada && formatar();
-
     valoresPeriodosLancamentos.findIndex(
       (valor) => valor.nome_campo !== "observacoes"
     ) !== -1 && setDisableBotaoSalvarLancamentos(false);

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.js
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.js
@@ -1,4 +1,8 @@
-import { deepCopy, ehEscolaTipoCEUGESTAO } from "helpers/utilities";
+import {
+  deepCopy,
+  ehEscolaTipoCEUGESTAO,
+  ehFimDeSemana,
+} from "helpers/utilities";
 
 export const repeticaoSobremesaDoceComValorESemObservacao = (
   values,
@@ -308,6 +312,32 @@ export const camposLancheEmergTabelaEtec = (
   return erro;
 };
 
+export const camposDiaNaoLetivoEmDiaUtilESemObservacao = (
+  location,
+  dia,
+  validacaoDiaLetivo,
+  feriadosNoMes,
+  formValuesAtualizados,
+  categoria
+) => {
+  let erro = false;
+  const mesAnoSelecionado = new Date(location.state.mesAnoSelecionado);
+  const dateObj = new Date(
+    `${mesAnoSelecionado.getFullYear()}-${
+      mesAnoSelecionado.getMonth() + 1
+    }-${dia}`
+  );
+  if (
+    !validacaoDiaLetivo(dia) &&
+    !ehFimDeSemana(dateObj) &&
+    !feriadosNoMes.includes(dia) &&
+    !formValuesAtualizados[`observacoes__dia_${dia}__categoria_${categoria.id}`]
+  ) {
+    erro = true;
+  }
+  return erro;
+};
+
 export const botaoAdicionarObrigatorioTabelaAlimentacao = (
   formValuesAtualizados,
   dia,
@@ -386,6 +416,14 @@ export const botaoAdicionarObrigatorioTabelaAlimentacao = (
         categoria,
         inclusoesEtecAutorizadas,
         ehGrupoETECUrlParam
+      ) ||
+      camposDiaNaoLetivoEmDiaUtilESemObservacao(
+        location,
+        dia,
+        validacaoDiaLetivo,
+        feriadosNoMes,
+        formValuesAtualizados,
+        categoria
       )
     );
   }

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -1099,3 +1099,7 @@ export const formataMesNome = (mes) => {
       return mes;
   }
 };
+
+export const ehFimDeSemana = (dateObj) => {
+  return dateObj.getDay() % 6 === 0;
+};


### PR DESCRIPTION
# Este PR:
- Deixa o botão adicionar obrigatório para dia não letivo e útil para escolas EMEF/EMEI/etc

### Referência azure:
- 106172