### PR TITLE
feature/104724-medicao-inicial-remover-cards-dre-acompanhamento-lancamentos

### DIFF
--- a/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
@@ -91,6 +91,16 @@ export const AcompanhamentoDeLancamentos = () => {
       const dashboardResults = response.data.results;
       if (!usuarioEhMedicao() || diretoriaRegional) {
         let NovoDashboardResults = [...dashboardResults];
+        if (usuarioEhMedicao()) {
+          const statusIndesejados = [
+            "MEDICAO_ENVIADA_PELA_UE",
+            "MEDICAO_CORRECAO_SOLICITADA",
+            "MEDICAO_CORRIGIDA_PELA_UE",
+          ];
+          NovoDashboardResults = NovoDashboardResults.filter(
+            (medicoes) => !statusIndesejados.includes(medicoes.status)
+          );
+        }
         if (usuarioEhEscolaTerceirizadaQualquerPerfil())
           NovoDashboardResults = NovoDashboardResults.filter(
             (medicoes) => medicoes.status !== "TODOS_OS_LANCAMENTOS"


### PR DESCRIPTION
# Proposta

Este PR visa retirar cards iniciais para perfil medição

# Referência do Azure

- 104724

# Tarefas para concluir

- [x] retira os cards com seguintes status para perfil medição: [
            "MEDICAO_ENVIADA_PELA_UE",
            "MEDICAO_CORRECAO_SOLICITADA",
            "MEDICAO_CORRIGIDA_PELA_UE",
          ]