### PR TITLE
Feature/105272-MI-tooltips-inclusão-alteração-suspensão-alimentação-dre-e-medição-conferência-lançamentos

### DIFF
--- a/src/components/Shareable/Input/InputValueMedicao/index.jsx
+++ b/src/components/Shareable/Input/InputValueMedicao/index.jsx
@@ -48,6 +48,10 @@ export const InputText = (props) => {
     exibeTooltipRepeticao,
     exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI,
     exibeTooltipSuspensoesAutorizadasCEI,
+    exibeTooltipInclusaoAlimentacaoAutorizadaDreCodae,
+    exibeTooltipAlteracaoAlimentacaoAutorizadaDreCodae,
+    exibeTooltipSuspensaoAutorizadaFrequenciaDreCodae,
+    exibeTooltipSuspensaoAutorizadaAlimentacaoDreCodae,
   } = props;
 
   let msgTooltip = "";
@@ -270,6 +274,30 @@ export const InputText = (props) => {
           }
         >
           <i className="fas fa-info icone-info-warning" />
+        </Tooltip>
+      )}
+      {exibeTooltipInclusaoAlimentacaoAutorizadaDreCodae && (
+        <Tooltip title={"Foi autorizada inclusão de alimentações neste dia."}>
+          <i className="fas fa-info icone-info-success" />
+        </Tooltip>
+      )}
+      {exibeTooltipAlteracaoAlimentacaoAutorizadaDreCodae && (
+        <Tooltip title={"Há autorização de LPR ou RPL para este dia."}>
+          <i className="fas fa-info icone-info-success" />
+        </Tooltip>
+      )}
+      {exibeTooltipSuspensaoAutorizadaFrequenciaDreCodae && (
+        <Tooltip
+          title={"Há suspensão de alimentações autorizada para este dia."}
+        >
+          <i className="fas fa-info icone-info-success" />
+        </Tooltip>
+      )}
+      {exibeTooltipSuspensaoAutorizadaAlimentacaoDreCodae && (
+        <Tooltip
+          title={"Há suspensão deste tipo de alimentação para este dia."}
+        >
+          <i className="fas fa-info icone-info-success" />
         </Tooltip>
       )}
 

--- a/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
@@ -270,6 +270,8 @@ export const AcompanhamentoDeLancamentos = () => {
         search: `uuid=${uuidSolicitacaoMedicao}`,
         state: {
           escolaUuid: escolaUuid,
+          mes: mes,
+          ano: ano,
         },
       });
     }

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.js
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.js
@@ -457,13 +457,19 @@ export const desabilitarField = (
   } else if (
     `refeicao__dia_${dia}__categoria_${categoria}` in
       dadosValoresInclusoesAutorizadasState &&
-    rowName === "repeticao_refeicao"
+    rowName === "repeticao_refeicao" &&
+    !["Mês anterior", "Mês posterior"].includes(
+      values[`${rowName}__dia_${dia}__categoria_${categoria}`]
+    )
   ) {
     return false;
   } else if (
     `sobremesa__dia_${dia}__categoria_${categoria}` in
       dadosValoresInclusoesAutorizadasState &&
-    rowName === "repeticao_sobremesa"
+    rowName === "repeticao_sobremesa" &&
+    !["Mês anterior", "Mês posterior"].includes(
+      values[`${rowName}__dia_${dia}__categoria_${categoria}`]
+    )
   ) {
     return false;
   } else if (
@@ -499,7 +505,7 @@ export const getSolicitacoesInclusaoAutorizadasAsync = async (
   mes,
   ano,
   periodos_escolares,
-  location
+  location = null
 ) => {
   const params = {};
   params["escola_uuid"] = escolaUuuid;
@@ -508,6 +514,7 @@ export const getSolicitacoesInclusaoAutorizadasAsync = async (
   params["ano"] = ano;
   params["periodos_escolares"] = periodos_escolares;
   if (
+    location &&
     location.state.grupo &&
     location.state.grupo.includes("Programas e Projetos")
   ) {
@@ -616,7 +623,8 @@ export const getSolicitacoesKitLanchesAutorizadasAsync = async (
 export const formatarLinhasTabelaAlimentacao = (
   tipos_alimentacao,
   periodoGrupo,
-  solicitacao
+  solicitacao,
+  eh_periodo_especifico = false
 ) => {
   const tiposAlimentacaoFormatadas = tipos_alimentacao
     .filter((alimentacao) => alimentacao.nome !== "Lanche Emergencial")
@@ -656,7 +664,8 @@ export const formatarLinhasTabelaAlimentacao = (
 
   const matriculadosOuNumeroDeAlunos = () => {
     return periodoGrupo.grupo === "Programas e Projetos" ||
-      ehEscolaTipoCEUGESTAO(solicitacao.escola)
+      ehEscolaTipoCEUGESTAO(solicitacao.escola) ||
+      eh_periodo_especifico
       ? {
           nome: "Número de Alunos",
           name: "numero_de_alunos",

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.js
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.js
@@ -1368,3 +1368,118 @@ export const exibirTooltipRepeticaoDiasSobremesaDoceDreCodae = (
     )
   );
 };
+
+export const exibirTooltipInclusaoAlimentacaoAutorizadaDreCodae = (
+  semanaSelecionada,
+  inclusoesAutorizadas,
+  column,
+  row,
+  categoria
+) => {
+  return (
+    categoria.nome === "ALIMENTAÇÃO" &&
+    !(Number(semanaSelecionada) === 1 && Number(column.dia) > 20) &&
+    !(
+      [4, 5, 6].includes(Number(semanaSelecionada)) && Number(column.dia) < 10
+    ) &&
+    row.name === "frequencia" &&
+    inclusoesAutorizadas.filter((inclusao) => inclusao.dia === column.dia)
+      .length > 0
+  );
+};
+
+export const exibirTooltipAlteracaoAlimentacaoAutorizadaDreCodae = (
+  semanaSelecionada,
+  alteracoesAlimentacaoAutorizadas,
+  column,
+  row,
+  categoria
+) => {
+  return (
+    categoria.nome === "ALIMENTAÇÃO" &&
+    !(Number(semanaSelecionada) === 1 && Number(column.dia) > 20) &&
+    !(
+      [4, 5, 6].includes(Number(semanaSelecionada)) && Number(column.dia) < 10
+    ) &&
+    ((row.name === "lanche" &&
+      alteracoesAlimentacaoAutorizadas.filter(
+        (alteracao) =>
+          alteracao.dia === column.dia && alteracao.motivo.includes("LPR")
+      ).length > 0) ||
+      (row.name === "refeicao" &&
+        !row.name.includes("repeticao") &&
+        alteracoesAlimentacaoAutorizadas.filter(
+          (alteracao) =>
+            alteracao.dia === column.dia && alteracao.motivo.includes("RPL")
+        ).length > 0))
+  );
+};
+
+const todasAlimentacoesSuspensas = (periodo, suspensoesAutorizadas, column) => {
+  const tiposAlimentacaoPeriodo = periodo.tipos_alimentacao
+    .flatMap((tipo_ali) =>
+      tipo_ali.nome
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replaceAll(/ /g, "_")
+    )
+    .filter((tipo_ali) => tipo_ali !== "lanche_emergencial");
+  const tiposAlimentacaoSuspensasDia = [
+    ...new Set(
+      suspensoesAutorizadas
+        .filter((suspensao) => suspensao.dia === column.dia)
+        .flatMap((suspensao) => suspensao.alimentacoes)
+    ),
+  ];
+
+  return tiposAlimentacaoPeriodo.every((tipo_ali) =>
+    tiposAlimentacaoSuspensasDia.includes(tipo_ali)
+  );
+};
+
+export const exibirTooltipSuspensaoAutorizadaFrequenciaDreCodae = (
+  semanaSelecionada,
+  suspensoesAutorizadas,
+  column,
+  row,
+  categoria,
+  periodo
+) => {
+  return (
+    categoria.nome === "ALIMENTAÇÃO" &&
+    !(Number(semanaSelecionada) === 1 && Number(column.dia) > 20) &&
+    !(
+      [4, 5, 6].includes(Number(semanaSelecionada)) && Number(column.dia) < 10
+    ) &&
+    row.name === "frequencia" &&
+    suspensoesAutorizadas.filter((suspensao) => suspensao.dia === column.dia)
+      .length > 0 &&
+    todasAlimentacoesSuspensas(periodo, suspensoesAutorizadas, column)
+  );
+};
+
+export const exibirTooltipSuspensaoAutorizadaAlimentacaoDreCodae = (
+  semanaSelecionada,
+  suspensoesAutorizadas,
+  column,
+  row,
+  categoria,
+  periodo
+) => {
+  return (
+    categoria.nome === "ALIMENTAÇÃO" &&
+    !(Number(semanaSelecionada) === 1 && Number(column.dia) > 20) &&
+    !(
+      [4, 5, 6].includes(Number(semanaSelecionada)) && Number(column.dia) < 10
+    ) &&
+    [
+      ...new Set(
+        suspensoesAutorizadas
+          .filter((suspensao) => suspensao.dia === column.dia)
+          .flatMap((suspensao) => suspensao.alimentacoes)
+      ),
+    ].includes(row.name) &&
+    !todasAlimentacoesSuspensas(periodo, suspensoesAutorizadas, column)
+  );
+};

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1540,10 +1540,7 @@ const routesConfig = [
     path: `/${constants.MEDICAO_INICIAL}/${constants.CONFERENCIA_DOS_LANCAMENTOS}`,
     component: ConferenciaDosLancamentosPage,
     exact: true,
-    tipoUsuario:
-      usuarioEhDRE() ||
-      usuarioEhMedicao() ||
-      usuarioEhEscolaTerceirizadaQualquerPerfil(),
+    tipoUsuario: usuarioEhDRE() || usuarioEhMedicao(),
   },
   {
     path: `/${constants.MEDICAO_INICIAL}/${constants.DETALHAMENTO_DO_LANCAMENTO}`,


### PR DESCRIPTION
**### Este PR visa:**

- exibir tooltips dre e codae caso existam soliictações (alimentação, alteração, suspensão)
- ajustar períodos simples para comtemplar períodos que tenham solicitação de evento específico
- criar validações tooltips para dre e codae tela de Conferência dos Lançamentos
- remover permissão usuarioEhEscolaTerceirizadaQualquerPerfil para tela de Conferência dos Lançamentos

**Referência:**
105272