### PR TITLE
feature/105810-GP-relaorio-produto-homologado-alterar-compenente-data

### DIFF
--- a/src/components/Shareable/FormBuscaProduto/index.js
+++ b/src/components/Shareable/FormBuscaProduto/index.js
@@ -242,6 +242,7 @@ export const FormBuscaProduto = ({
                         ? moment(values.data_final, "DD/MM/YYYY")._d
                         : moment()._d
                     }
+                    writable={true}
                     disabled={values.agrupado_por_nome_e_marca}
                   />
                 </div>

--- a/src/components/Shareable/FormBuscaProduto/index.js
+++ b/src/components/Shareable/FormBuscaProduto/index.js
@@ -230,7 +230,7 @@ export const FormBuscaProduto = ({
                     </div>
                   )}
                 </div>
-                <div className="col-4">
+                <div className="col-4 data-prod-hom">
                   <Field
                     component={InputComData}
                     label="Homologados até:"
@@ -243,6 +243,8 @@ export const FormBuscaProduto = ({
                         : moment()._d
                     }
                     writable={true}
+                    showMonthDropdown={true}
+                    showYearDropdown={true}
                     disabled={values.agrupado_por_nome_e_marca}
                   />
                 </div>

--- a/src/components/Shareable/FormBuscaProduto/style.scss
+++ b/src/components/Shareable/FormBuscaProduto/style.scss
@@ -154,4 +154,8 @@
     top: 0px;
     left: 0px;
   }
+
+  .data-prod-hom .datepicker .col-form-label {
+    margin-bottom: 0 !important;
+  }
 }


### PR DESCRIPTION
# Proposta

Este PR visa permitir que o usuário digite data no no componente data-calendário da tela de Produtos Homologados
# Referência do Azure

- 105810

# Tarefas para concluir

- [x] Dar permissão para componente ser editável na tela de produtos homologados
- [x] Adiciona filtro de mês e ano
- [x] Corrige layout