### PR TITLE
bugfix/105797-gestao-alimentacao-solicitacao-alteracao-RPL-vaios-dias

### DIFF
--- a/src/components/AlteracaoDeCardapio/index.jsx
+++ b/src/components/AlteracaoDeCardapio/index.jsx
@@ -142,7 +142,7 @@ class AlteracaoCardapio extends Component {
     const escola = meusDados && meusDados.vinculo_atual.instituicao.uuid;
     if (periodos.length > 0 && escola && !loadQuantidadeAlunos) {
       getQuantidaDeAlunosPorPeriodoEEscola(escola).then((response) => {
-        if (periodos !== []) {
+        if (periodos.length > 0) {
           periodos = abstraiPeriodosComAlunosMatriculados(
             periodos,
             response.results,
@@ -786,7 +786,6 @@ class AlteracaoCardapio extends Component {
   };
 
   onChangeMotivo = (uuidMotivo) => {
-    // passar periodos
     const motivo = this.props.motivos.find((d) => d.uuid === uuidMotivo);
     let periodos = this.state.periodos;
     this.setState({ motivo });
@@ -802,6 +801,8 @@ class AlteracaoCardapio extends Component {
       );
     });
     this.props.change("alterar_dia", "");
+    this.props.change("data_inicial", "");
+    this.props.change("data_final", "");
     periodos = periodos.map((periodo) => {
       periodo["substituicoes"] = [];
       return periodo;
@@ -1055,7 +1056,11 @@ class AlteracaoCardapio extends Component {
                     }
                     maxDate={fimDoCalendario()}
                     label="Alterar dia"
-                    disabled={this.props.data_inicial || this.props.data_final}
+                    disabled={
+                      this.props.data_inicial ||
+                      this.props.data_final ||
+                      !(motivo && this.DisabledDataInicial(motivo))
+                    }
                     validate={this.ehDiaUtil}
                     usarDirty={true}
                   />
@@ -1073,7 +1078,8 @@ class AlteracaoCardapio extends Component {
                       maxDate={fimDoCalendario()}
                       disabled={
                         this.props.alterar_dia ||
-                        (motivo && this.DisabledDataInicial(motivo))
+                        (motivo && this.DisabledDataInicial(motivo)) ||
+                        !motivo
                       }
                       onChange={(value) => {
                         this.obtemDataInicial(value);
@@ -1084,7 +1090,9 @@ class AlteracaoCardapio extends Component {
                       component={InputComData}
                       name="data_final"
                       label="Até"
-                      disabled={dataInicial === null || this.props.alterar_dia}
+                      disabled={
+                        !this.props.data_inicial || this.props.alterar_dia
+                      }
                       minDate={dataInicial}
                       maxDate={limiteDataFinal}
                     />

--- a/src/components/AlteracaoDeCardapio/index.jsx
+++ b/src/components/AlteracaoDeCardapio/index.jsx
@@ -1056,11 +1056,7 @@ class AlteracaoCardapio extends Component {
                     }
                     maxDate={fimDoCalendario()}
                     label="Alterar dia"
-                    disabled={
-                      this.props.data_inicial ||
-                      this.props.data_final ||
-                      !(motivo && this.DisabledDataInicial(motivo))
-                    }
+                    disabled={this.props.data_inicial || this.props.data_final}
                     validate={this.ehDiaUtil}
                     usarDirty={true}
                   />


### PR DESCRIPTION
# Proposta

Este PR visa corrigir bug que permitia várias alterações de RPL de uma só vez

# Referência do Azure

- 105797

# Tarefas para concluir

- [x] Refatorar lógica de ativação e desativação dos campos de alterar dia, data inicial e data final