### PR TITLE
bugfix/103810-ajuste-nomenclaturas-historico-correcao

### DIFF
--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/ModalHistoricoCorrecoesPeriodo/HistoricoAprovacao.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/ModalHistoricoCorrecoesPeriodo/HistoricoAprovacao.jsx
@@ -3,7 +3,13 @@ import { formataMesNome } from "helpers/utilities";
 import "./style.scss";
 
 export const HistoricoAprovacao = ({ ...props }) => {
-  const { solicitacao, historico, retornaIniciais, formatarTitulo } = props;
+  const {
+    solicitacao,
+    historico,
+    retornaIniciais,
+    formatarTitulo,
+    instituicao,
+  } = props;
 
   return (
     <Fragment>
@@ -37,7 +43,9 @@ export const HistoricoAprovacao = ({ ...props }) => {
         </div>
         <div className="col-12 mb-3">
           <label className="cor-texo-detalhes">
-            <b>DRE aprovou o lançamento dos períodos</b>
+            <b>
+              {instituicao(historico.acao)} aprovou o lançamento dos períodos
+            </b>
           </label>
         </div>
         <div className="col-12">

--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/ModalHistoricoCorrecoesPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/ModalHistoricoCorrecoesPeriodo/index.jsx
@@ -35,6 +35,17 @@ export const ModalHistoricoCorrecoesPeriodo = ({ ...props }) => {
     }
   };
 
+  const instituicao = (acao) => {
+    switch (acao) {
+      case "MEDICAO_APROVADA_PELA_DRE":
+        return "DRE";
+      case "MEDICAO_APROVADA_PELA_CODAE":
+        return "CODAE";
+      default:
+        return acao;
+    }
+  };
+
   const retornaIniciais = (email) => {
     const nome = email.split(" ");
     let iniciais = "";
@@ -78,6 +89,7 @@ export const ModalHistoricoCorrecoesPeriodo = ({ ...props }) => {
             retornaIniciais={retornaIniciais}
             solicitacao={solicitacao}
             formatarTitulo={(acao) => formatarTitulo(acao)}
+            instituicao={(acao) => instituicao(acao)}
           />
         );
         break;
@@ -142,7 +154,7 @@ export const ModalHistoricoCorrecoesPeriodo = ({ ...props }) => {
                           </span>
                         </Tooltip>
                         <span className="mb-0">
-                          {historico.usuario.nome.substr(0, 20)}
+                          {historico.usuario.nome.substr(0, 21)}
                         </span>
                       </div>
                       <div className="col-3 mb-1">


### PR DESCRIPTION
# Proposta

Este PR visa fazer ajustes de nomenclaturas no histórico de correção de medição inicial

# Referência do Azure

- 103810

# Tarefas para concluir

- [x] Coloca no nome na instituição que aprovou de maneira dinâmica
- [x] Aumenta a quantidade de caracteres exibidos no nome do usuario 