### PR TITLE
feature/101752 detalhar documentos codae

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Analisar/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Analisar/index.tsx
@@ -234,9 +234,9 @@ export default () => {
   const geraInitialValues = (doc: DocumentosRecebimentoParaAnalise): void => {
     let newPrazos = [];
     let iniciais = {
-      laboratorio: doc.laboratorio,
+      laboratorio: doc.laboratorio.uuid,
       quantidade_laudo: doc.quantidade_laudo?.toString(),
-      unidade_medida: doc.unidade_medida,
+      unidade_medida: doc.unidade_medida.uuid,
       data_fabricacao_lote: doc.data_fabricacao_lote
         ? doc.data_fabricacao_lote
         : undefined,

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Analisar/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Analisar/styles.scss
@@ -51,10 +51,4 @@
     font-weight: bold;
     margin: 12px 0px;
   }
-
-  .secao-tipo-documento {
-    ::marker {
-      color: $greenDark;
-    }
-  }
 }

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Detalhar/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Detalhar/styles.scss
@@ -22,10 +22,4 @@
     font-weight: bold;
     margin: 12px 0px;
   }
-
-  .secao-tipo-documento {
-    ::marker {
-      color: $greenDark;
-    }
-  }
 }

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/index.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useState } from "react";
+import { Spin } from "antd";
+import "./styles.scss";
+import {
+  PAINEL_DOCUMENTOS_RECEBIMENTO,
+  PRE_RECEBIMENTO,
+} from "configs/constants";
+import { useHistory } from "react-router-dom";
+import BotaoVoltar from "components/Shareable/Page/BotaoVoltar";
+import { detalharDocumentoParaAnalise } from "services/documentosRecebimento.service";
+import InputText from "components/Shareable/Input/InputText";
+import {
+  DocumentosRecebimentoParaAnalise,
+  TiposDocumentos,
+} from "interfaces/pre_recebimento.interface";
+import ArquivosTipoRecebimento from "../ArquivosTipoDocumento";
+import OutrosDocumentos from "../OutrosDocumentos";
+
+export default () => {
+  const history = useHistory();
+
+  const [carregando, setCarregando] = useState(true);
+  const [objeto, setObjeto] = useState<DocumentosRecebimentoParaAnalise>(
+    {} as DocumentosRecebimentoParaAnalise
+  );
+  const [laudo, setLaudo] = useState<TiposDocumentos>();
+
+  const voltarPaginaPainel = () =>
+    history.push(`/${PRE_RECEBIMENTO}/${PAINEL_DOCUMENTOS_RECEBIMENTO}`);
+
+  const carregarDados = async (): Promise<void> => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const uuid = urlParams.get("uuid");
+    const response = await detalharDocumentoParaAnalise(uuid);
+
+    const objeto = response.data;
+
+    const laudoIndex = objeto.tipos_de_documentos.findIndex(
+      (tipo) => tipo.tipo_documento === "LAUDO"
+    );
+    const laudo = objeto.tipos_de_documentos.splice(laudoIndex, 1)[0];
+
+    setLaudo(laudo);
+    setObjeto(objeto);
+  };
+
+  useEffect(() => {
+    (async () => {
+      setCarregando(true);
+      await carregarDados();
+      setCarregando(false);
+    })();
+  }, []);
+
+  return (
+    <Spin tip="Carregando..." spinning={carregando}>
+      <div className="card mt-3 card-detalhar-documentos-recebimento-codae">
+        <div className="card-body">
+          <div className="flex-header">
+            <div className="subtitulo">Dados Gerais</div>
+            <div className="status">
+              <i className="fas fa-check-circle" />
+              Documentos aprovados em {objeto.log_mais_recente}
+            </div>
+          </div>
+
+          <div className="row">
+            <div className="col-12">
+              <InputText
+                label="Fornecedor"
+                valorInicial={objeto.fornecedor}
+                disabled={true}
+              />
+            </div>
+            <div className="col-6">
+              <InputText
+                label="Nº do Cronograma"
+                valorInicial={objeto.numero_cronograma}
+                disabled={true}
+              />
+            </div>
+            <div className="col-6">
+              <InputText
+                label="Nº do Pregão/Chamada Pública"
+                valorInicial={objeto.pregao_chamada_publica}
+                disabled={true}
+              />
+            </div>
+            <div className="col-6">
+              <InputText
+                label="Nome do Produto"
+                valorInicial={objeto.nome_produto}
+                disabled={true}
+              />
+            </div>
+            <div className="col-6">
+              <InputText
+                label="Nº do Processo SEI"
+                valorInicial={objeto.numero_sei}
+                disabled={true}
+              />
+            </div>
+            <div className="col-6">
+              <InputText
+                label="Nº do Laudo"
+                valorInicial={objeto.numero_laudo}
+                disabled={true}
+              />
+            </div>
+          </div>
+          <div className="subtitulo-documento">
+            Laudo enviado pelo Fornecedor:
+          </div>
+          <ArquivosTipoRecebimento lista={laudo} />
+
+          <hr />
+
+          <div className="subtitulo">Dados do Laudo</div>
+
+          <div className="row">
+            <div className="col-6">
+              <InputText
+                label="Nome do Laboratório"
+                valorInicial={objeto.laboratorio?.nome}
+                disabled={true}
+              />
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-4">
+              <InputText
+                label="Quantidade do Laudo"
+                valorInicial={objeto.quantidade_laudo}
+                disabled={true}
+              />
+            </div>
+            <div className="col-4">
+              <InputText
+                label="Unidade de Medida"
+                valorInicial={objeto.unidade_medida?.nome}
+                disabled={true}
+              />
+            </div>
+            <div className="col-4">
+              <InputText
+                label="Data Fabricação do Lote"
+                valorInicial={objeto.data_fabricacao_lote}
+                disabled={true}
+              />
+            </div>
+            <div className="col-4">
+              <InputText
+                label="Validade do Produto"
+                valorInicial={objeto.validade_produto}
+                disabled={true}
+              />
+            </div>
+            <div className="col-4">
+              <InputText
+                label="Data Final do Laudo"
+                valorInicial={objeto.data_final_lote}
+                disabled={true}
+              />
+            </div>
+            <div className="col-4">
+              <InputText
+                label="Saldo do Laudo"
+                valorInicial={objeto.saldo_laudo}
+                disabled={true}
+              />
+            </div>
+
+            {objeto.datas_fabricacao_e_prazos?.map((prazo) => (
+              <>
+                <div className="col-4">
+                  <InputText
+                    label="Data de Fabricação"
+                    valorInicial={prazo.data_fabricacao}
+                    disabled={true}
+                  />
+                </div>
+                <div className="col-4">
+                  <InputText
+                    label="Prazo Máximo para Recebimento"
+                    valorInicial={prazo.prazo_maximo_recebimento}
+                    disabled={true}
+                  />
+                </div>
+
+                {prazo.prazo_maximo_recebimento !== "OUTRO" && (
+                  <div className="col-4">
+                    <InputText
+                      label="Saldo do Laudo"
+                      valorInicial={prazo.data_maxima_recebimento}
+                      disabled={true}
+                    />
+                  </div>
+                )}
+
+                {prazo.prazo_maximo_recebimento === "OUTRO" && (
+                  <div className="col-12">
+                    <InputText
+                      label="Justifique Outro prazo máximo para Recebimento"
+                      valorInicial={prazo.justificativa}
+                      disabled={true}
+                    />
+                  </div>
+                )}
+              </>
+            ))}
+          </div>
+
+          <hr />
+
+          <OutrosDocumentos documento={objeto} />
+
+          <hr />
+
+          <BotaoVoltar onClick={voltarPaginaPainel} />
+        </div>
+      </div>
+    </Spin>
+  );
+};

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/index.tsx
@@ -190,7 +190,7 @@ export default () => {
                 {prazo.prazo_maximo_recebimento !== "OUTRO" && (
                   <div className="col-4">
                     <InputText
-                      label="Saldo do Laudo"
+                      label="Data Máxima de Recebimento"
                       valorInicial={prazo.data_maxima_recebimento}
                       disabled={true}
                     />

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/styles.scss
@@ -39,7 +39,6 @@
     font-size: 13px;
     font-style: normal;
     font-weight: 700;
-    line-height: 128%;
 
     i {
       margin-right: 8px;

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae/styles.scss
@@ -1,0 +1,48 @@
+@import "../../../../../../styles/variables.scss";
+
+.card-detalhar-documentos-recebimento-codae {
+  color: $blackInput;
+  font-size: 14px;
+
+  .green-bold {
+    color: $greenDark;
+    font-weight: bold;
+  }
+
+  .subtitulo {
+    color: $greenDark;
+    font-size: 16px;
+    font-weight: bold;
+    margin: 8px 0px;
+  }
+
+  .subtitulo-documento {
+    color: $greenDark;
+    font-size: 15px;
+    font-weight: bold;
+    margin: 12px 0px;
+  }
+
+  .flex-header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .status {
+    background-color: $green;
+    border-radius: 50px;
+    border: 1px solid $greenDark;
+    color: white;
+    padding: 2px 8px;
+    height: 10%;
+    margin: auto 0;
+    font-size: 13px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 128%;
+
+    i {
+      margin-right: 8px;
+    }
+  }
+}

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/OutrosDocumentos/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/OutrosDocumentos/index.tsx
@@ -6,6 +6,7 @@ import {
 import InputText from "components/Shareable/Input/InputText";
 import ArquivosTipoRecebimento from "../ArquivosTipoDocumento";
 import { OUTROS_DOCUMENTOS_OPTIONS } from "../../constants";
+import "./styles.scss";
 
 export interface Props {
   documento: DocumentosRecebimentoDetalhado;

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/OutrosDocumentos/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/OutrosDocumentos/styles.scss
@@ -1,0 +1,7 @@
+@import "../../../../../../styles/variables.scss";
+
+.secao-tipo-documento {
+  ::marker {
+    color: $greenDark;
+  }
+}

--- a/src/components/screens/PreRecebimento/PainelDocumentosRecebimento/index.tsx
+++ b/src/components/screens/PreRecebimento/PainelDocumentosRecebimento/index.tsx
@@ -4,6 +4,7 @@ import CardCronograma from "components/Shareable/CardCronograma/CardCronograma";
 import { cardsAprovacao } from "./constants";
 import {
   ANALISAR_DOCUMENTO_RECEBIMENTO,
+  DETALHAR_DOCUMENTO_RECEBIMENTO,
   PRE_RECEBIMENTO,
 } from "configs/constants";
 import {
@@ -55,9 +56,17 @@ export default () => {
     return items.sort(ordenarPorLogMaisRecente).map((item) => ({
       text: gerarTextoCardDocumento(item),
       date: item.log_mais_recente.slice(0, 10),
-      link: `/${PRE_RECEBIMENTO}/${ANALISAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`,
+      link: gerarLinkDocumento(item),
       status: item.status,
     }));
+  };
+
+  const gerarLinkDocumento = (item: DocumentosRecebimentoDashboard): string => {
+    return item.status === "Aprovado"
+      ? `/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`
+      : item.status === "Enviado para Análise"
+      ? `/${PRE_RECEBIMENTO}/${ANALISAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`
+      : ``;
   };
 
   const agruparCardsPorStatus = (

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1998,7 +1998,8 @@ const routesConfig = [
     path: `/${constants.PRE_RECEBIMENTO}/${constants.DETALHAR_DOCUMENTO_RECEBIMENTO}`,
     component: DetalharDocumentosRecebimentoPage,
     exact: true,
-    tipoUsuario: usuarioEhEmpresaFornecedor(),
+    tipoUsuario:
+      usuarioEhEmpresaFornecedor() || usuarioComAcessoAoPainelEmbalagens(),
   },
   {
     path: `/${constants.PRE_RECEBIMENTO}/${constants.PAINEL_DOCUMENTOS_RECEBIMENTO}`,

--- a/src/interfaces/pre_recebimento.interface.ts
+++ b/src/interfaces/pre_recebimento.interface.ts
@@ -23,8 +23,9 @@ export interface DocumentosRecebimentoParaAnalise
   validade_produto: string;
   numero_sei: string;
   fornecedor: string;
-  unidade_medida: string;
-  laboratorio: string;
+  unidade_medida: UnidadeMedidaSimples;
+  laboratorio: LaboratorioSimples;
+  log_mais_recente: string;
 }
 
 export interface DatasFabricacaoPrazos {

--- a/src/pages/PreRecebimento/DetalharDocumentosRecebimentoPage.tsx
+++ b/src/pages/PreRecebimento/DetalharDocumentosRecebimentoPage.tsx
@@ -14,7 +14,7 @@ import { usuarioEhEmpresaFornecedor } from "helpers/utilities";
 
 const atual = {
   href: `/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}`,
-  titulo: "Detalhar Documento de Recebimento",
+  titulo: "Detalhar Documentos de Recebimento",
 };
 
 const link = usuarioEhEmpresaFornecedor()

--- a/src/pages/PreRecebimento/DetalharDocumentosRecebimentoPage.tsx
+++ b/src/pages/PreRecebimento/DetalharDocumentosRecebimentoPage.tsx
@@ -4,15 +4,22 @@ import Breadcrumb from "components/Shareable/Breadcrumb";
 import Page from "components/Shareable/Page/Page";
 import {
   DETALHAR_DOCUMENTO_RECEBIMENTO,
+  PAINEL_DOCUMENTOS_RECEBIMENTO,
   DOCUMENTOS_RECEBIMENTO,
   PRE_RECEBIMENTO,
 } from "configs/constants";
 import Detalhar from "components/screens/PreRecebimento/DocumentosRecebimento/components/Detalhar";
+import DetalharCodae from "components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae";
+import { usuarioEhEmpresaFornecedor } from "helpers/utilities";
 
 const atual = {
   href: `/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}`,
   titulo: "Detalhar Documento de Recebimento",
 };
+
+const link = usuarioEhEmpresaFornecedor()
+  ? `/${PRE_RECEBIMENTO}/${DOCUMENTOS_RECEBIMENTO}`
+  : `/${PRE_RECEBIMENTO}/${PAINEL_DOCUMENTOS_RECEBIMENTO}`;
 
 const anteriores = [
   {
@@ -20,19 +27,14 @@ const anteriores = [
     titulo: "Pré-Recebimento",
   },
   {
-    href: `/${PRE_RECEBIMENTO}/${DOCUMENTOS_RECEBIMENTO}`,
+    href: link,
     titulo: "Documentos de Recebimento",
   },
 ];
 
 export default () => (
-  <Page
-    botaoVoltar
-    voltarPara={`/${PRE_RECEBIMENTO}/${DOCUMENTOS_RECEBIMENTO}`}
-    titulo={atual.titulo}
-  >
+  <Page botaoVoltar voltarPara={link} titulo={atual.titulo}>
     <Breadcrumb home={HOME} atual={atual} anteriores={anteriores} />
-
-    <Detalhar />
+    {usuarioEhEmpresaFornecedor() ? <Detalhar /> : <DetalharCodae />}
   </Page>
 );


### PR DESCRIPTION
Este PR:
- cria a screen de detalhar documentos pra codae
- reutiliza pages e rotas da pag de detalhar do fornecedor
- refatora css do componente de visualizar outros documentos
- adiciona/altera atributos nas interfaces de documento de recebimento