### PR TITLE
Feature 108380 - Libera modulo medicao inicial para NUTRI MANIFESTACAO E CODAE

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
@@ -12,6 +12,8 @@ import {
   usuarioEhDRE,
   usuarioEhEscolaTerceirizada,
   usuarioEhMedicao,
+  usuarioEhCODAEGestaoAlimentacao,
+  usuarioEhCODAENutriManifestacao,
 } from "helpers/utilities";
 
 export default () => {
@@ -30,7 +32,9 @@ export default () => {
         )}
         {(usuarioEhDRE() ||
           usuarioEhMedicao() ||
-          usuarioEhEscolaTerceirizadaQualquerPerfil()) && (
+          usuarioEhEscolaTerceirizadaQualquerPerfil() ||
+          usuarioEhCODAEGestaoAlimentacao() ||
+          usuarioEhCODAENutriManifestacao()) && (
           <LeafItem to={`/${MEDICAO_INICIAL}/${ACOMPANHAMENTO_DE_LANCAMENTOS}`}>
             Acompanhamento de Lançamentos
           </LeafItem>

--- a/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/index.jsx
@@ -62,7 +62,7 @@ export const AcompanhamentoDeLancamentos = () => {
   const [statusSelecionado, setStatusSelecionado] = useState(null);
   const [resultados, setResultados] = useState(null);
   const [mesesAnos, setMesesAnos] = useState(null);
-  const [lotes, setLotes] = useState(DEFAULT_STATE);
+  const [lotes, setLotes] = useState([]);
   const [tiposUnidades, setTiposUnidades] = useState(DEFAULT_STATE);
   const [nomesEscolas, setNomesEscolas] = useState(DEFAULT_STATE);
   const [diretoriasRegionais, setDiretoriasRegionais] = useState(null);

--- a/src/components/screens/PainelInicial/index.jsx
+++ b/src/components/screens/PainelInicial/index.jsx
@@ -92,7 +92,10 @@ const PainelInicial = ({ history }) => {
               (usuarioEhEscolaTerceirizada() ||
                 usuarioEhEscolaTerceirizadaDiretor()) &&
                 history.push("/lancamento-inicial/lancamento-medicao-inicial");
-              (usuarioEhDRE() || usuarioEhMedicao()) &&
+              (usuarioEhDRE() ||
+                usuarioEhMedicao() ||
+                usuarioEhCODAEGestaoAlimentacao() ||
+                usuarioEhCODAENutriManifestacao()) &&
                 history.push(
                   `/medicao-inicial/${ACOMPANHAMENTO_DE_LANCAMENTOS}`
                 );

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1560,13 +1560,19 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhDRE() ||
       usuarioEhMedicao() ||
-      usuarioEhEscolaTerceirizadaQualquerPerfil(),
+      usuarioEhEscolaTerceirizadaQualquerPerfil() ||
+      usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao(),
   },
   {
     path: `/${constants.MEDICAO_INICIAL}/${constants.CONFERENCIA_DOS_LANCAMENTOS}`,
     component: ConferenciaDosLancamentosPage,
     exact: true,
-    tipoUsuario: usuarioEhDRE() || usuarioEhMedicao(),
+    tipoUsuario:
+      usuarioEhDRE() ||
+      usuarioEhMedicao() ||
+      usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao(),
   },
   {
     path: `/${constants.MEDICAO_INICIAL}/${constants.DETALHAMENTO_DO_LANCAMENTO}`,

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -995,7 +995,8 @@ export const exibirModuloMedicaoInicial = () => {
       return acessoModuloMedicaoInicialDRE();
     case `"medicao"`:
       return true;
-    case `"codae"`:
+    case `"nutricao_manifestacao"`:
+    case `"gestao_alimentacao_terceirizada"`:
       return acessoModuloMedicaoInicialCODAE();
     default:
       return false;

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -700,6 +700,13 @@ export const acessoModuloMedicaoInicialDRE = () => {
   );
 };
 
+export const acessoModuloMedicaoInicialCODAE = () => {
+  return (
+    localStorage.getItem("acesso_modulo_medicao_inicial") === "true" &&
+    (usuarioEhCODAEGestaoAlimentacao() || usuarioEhCODAENutriManifestacao())
+  );
+};
+
 export const converterDDMMYYYYparaYYYYMMDD = (data) => {
   return moment(data, "DD/MM/YYYY").format("YYYY-MM-DD");
 };
@@ -976,7 +983,9 @@ export const exibirModuloMedicaoInicial = () => {
       ((usuarioEhEscolaTerceirizada() ||
         usuarioEhEscolaTerceirizadaDiretor()) &&
         !usuarioEscolaEhGestaoDireta()) ||
-      usuarioEhMedicao()
+      usuarioEhMedicao() ||
+      usuarioEhCODAEGestaoAlimentacao() ||
+      usuarioEhCODAENutriManifestacao()
     );
 
   switch (localStorage.getItem("tipo_perfil")) {
@@ -986,6 +995,8 @@ export const exibirModuloMedicaoInicial = () => {
       return acessoModuloMedicaoInicialDRE();
     case `"medicao"`:
       return true;
+    case `"codae"`:
+      return acessoModuloMedicaoInicialCODAE();
     default:
       return false;
   }


### PR DESCRIPTION
Feature 108380 - Libera modulo medicao inicial para NUTRI MANIFESTACAO E CODAE

# Este PR: 
- Libera o modulo de medicao inicial para os usuarios NUTRI MANIFESTACAO e CODAE GESTAO ALIMENTACAO;
- Nao exibe para eles os botões de Solicitar Correção no Formulário, Aprovar Formulário, Solicitar Correção, Aprovar Período e Aprovar Medição;
- Permite acesso apenas de visualização, podendo extrair os relatórios disponíveis;

### Referência azure:
- AB#108380