### PR TITLE
Feature/109505 botao detalhar doc recebimentos aprovados

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
@@ -49,7 +49,8 @@ const Listagem: React.FC<Props> = ({ objetos }) => {
 
     return (
       <>
-        {objeto.status === "Enviado para Análise" && botaoDetalharVerde}
+        {["Enviado para Análise", "Aprovado"].includes(objeto.status) &&
+          botaoDetalharVerde}
         {objeto.status === "Enviado para Correção" && botaoCorrigirLaranja}
       </>
     );


### PR DESCRIPTION
# Este PR:

- Adiciona botão de Detalhar na listagem para os Documentos de Recebimento com status Aprovado.

### Referência Azure:

- 109505