### PR TITLE
Feature/109638 restricao arquivo laudo documentos recebimento

### DIFF
--- a/src/components/Shareable/Input/InputFile/index.jsx
+++ b/src/components/Shareable/Input/InputFile/index.jsx
@@ -130,13 +130,12 @@ const InputFile = (props) => {
     });
     if (valido) {
       let localFiles = [];
-      let data = [];
       Array.from(event.target.files).forEach((file) => {
         readerFile(file)
           .then((anexo) => {
-            data.push(anexo);
             localFiles.push({
               nome: props.nomeNovoArquivo || file.name,
+              arquivo: anexo.arquivo,
               base64: anexo.arquivo,
             });
           })
@@ -150,7 +149,7 @@ const InputFile = (props) => {
                 props.setFiles(allFiles);
                 setFiles(allFiles);
               } else {
-                props.setFiles(data);
+                props.setFiles(localFiles);
                 setFiles(localFiles);
               }
             }

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
@@ -136,16 +136,16 @@ export default () => {
     try {
       let response = await cadastraDocumentoRecebimento(payload);
       if (response.status === 201 || response.status === 200) {
-        setCarregando(false);
         toastSuccess("Documentos enviados com sucesso!");
-        setShowModal(false);
         voltarPagina();
       } else {
         toastError("Ocorreu um erro ao salvar o Documento de Recebimento");
-        setCarregando(false);
       }
     } catch (error) {
       exibeError(error, "Ocorreu um erro ao salvar o Documento de Recebimento");
+    } finally {
+      setShowModal(false);
+      setCarregando(false);
     }
   };
 
@@ -245,6 +245,9 @@ export default () => {
                   <InserirDocumento
                     setFiles={setFilesLaudo}
                     removeFile={removeFileLaudo}
+                    formatosAceitos="PDF"
+                    multiplosArquivos={false}
+                    concatenarNovosArquivos={false}
                   />
                 </div>
 

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/InserirDocumento/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/InserirDocumento/index.tsx
@@ -7,13 +7,14 @@ import { TextArea } from "components/Shareable/TextArea/TextArea";
 import { textAreaRequired } from "helpers/fieldValidators";
 import { OUTROS_DOCUMENTOS_OPTIONS } from "../../constants";
 
-const FORMATOS_IMAGEM = "PDF, PNG, JPG ou JPEG";
-
 interface Props {
   setFiles(_files: Array<ArquivoForm>): void;
   removeFile: (_index: number) => void;
   tipoDocumento?: string;
   arquivosIniciais?: ArquivoForm[];
+  formatosAceitos?: string;
+  multiplosArquivos?: boolean;
+  concatenarNovosArquivos?: boolean;
 }
 
 const InserirDocumento: React.FC<Props> = ({
@@ -21,6 +22,9 @@ const InserirDocumento: React.FC<Props> = ({
   removeFile,
   tipoDocumento = "",
   arquivosIniciais = [],
+  formatosAceitos = "PDF, PNG, JPG ou JPEG",
+  multiplosArquivos = true,
+  concatenarNovosArquivos = true,
 }) => {
   const titulo = OUTROS_DOCUMENTOS_OPTIONS.find(
     (obj) => obj.value === tipoDocumento
@@ -59,21 +63,25 @@ const InserirDocumento: React.FC<Props> = ({
           className="inputfile"
           texto={titulo ? "Anexar Documentos" : "Anexar Laudo"}
           name={"files"}
-          accept={FORMATOS_IMAGEM}
+          accept={formatosAceitos}
           setFiles={setFiles}
           removeFile={removeFile}
           toastSuccess={"Imagem incluída com sucesso!"}
           alignLeft
-          multiple={true}
+          multiple={multiplosArquivos}
           limiteTamanho={DEZ_MB}
-          concatenarNovosArquivos
+          concatenarNovosArquivos={concatenarNovosArquivos}
         />
 
         <label className="col-12 label-imagem">
           <span className="red">* Campo Obrigatório: &nbsp;</span>
-          {"Envie um arquivo nos formatos: " +
-            FORMATOS_IMAGEM +
-            ", com até 10MB"}
+          {titulo
+            ? "Envie um arquivo nos formatos: " +
+              formatosAceitos +
+              ", com até 10MB"
+            : "Envie um arquivo no formato: " +
+              formatosAceitos +
+              " com até 10MB"}
         </label>
       </div>
     </>


### PR DESCRIPTION
# Este PR:

- Adiciona restrição ao campo Inserir Laudo permitindo que somente um único arquivo no formato PDF seja anexado;
- Refatora componente InputFile para manter compatibilidade com novas interfaces do TypeScript e implementações antigas.

### Referência Azure:

- 109638