### PR TITLE
Feature/109638 restricao arquivo laudo documentos recebimento

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Corrigir/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Corrigir/index.tsx
@@ -381,6 +381,9 @@ export default () => {
                     <InserirDocumento
                       setFiles={setFilesLaudo}
                       removeFile={removeFileLaudo}
+                      formatosAceitos="PDF"
+                      multiplosArquivos={false}
+                      concatenarNovosArquivos={false}
                       arquivosIniciais={arquivosLaudoForm.arquivosForm}
                     />
                   </div>


### PR DESCRIPTION
# Este PR:

- Restringe campo laudo também na tela de correção.

### Referência Azure:

- 109638