### PR TITLE
Feature/102672 remover cursor de escrita do menu lateral

### DIFF
--- a/src/components/Shareable/Sidebar/menus/shared.js
+++ b/src/components/Shareable/Sidebar/menus/shared.js
@@ -51,6 +51,10 @@ export const Menu = ({ id, title, icon, children }) => (
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
+        const otherElements = document.querySelectorAll(".collapse.show");
+        otherElements.forEach(element => {
+          element.classList.toggle("show");
+        });
         const currentElement = document.querySelector(`#collapse${id}`);
         currentElement.classList.toggle("show");
       }}

--- a/src/components/Shareable/Sidebar/style.scss
+++ b/src/components/Shareable/Sidebar/style.scss
@@ -178,6 +178,7 @@ body.dark-content {
       height: max-content;
     }
     .nav-item {
+      cursor: pointer;
       position: relative;
       text-align: -webkit-center;
       .bg-white.collapse-inner.rounded {


### PR DESCRIPTION
# Este PR:

- Retira o cursor padrão de escrita e adiciona o cursor pointer;
-  Implementa comportamento de abrir e fechar do menu quando o colapse estiver fechado;

### Referência Azure:
- 102672