### PR TITLE
Feature/105980 cadastro ficha tecnica botoes proximo anterior info nutricionais

### DIFF
--- a/src/components/Shareable/TabelaNutricional/index.tsx
+++ b/src/components/Shareable/TabelaNutricional/index.tsx
@@ -83,6 +83,8 @@ const TabelaNutricional: React.FC<Props> = ({
     informacao.uuid &&
       options.push({ uuid: informacao.uuid, nome: informacao.nome });
 
+    options.sort((a, b) => a.nome.localeCompare(b.nome, "pt-BR"));
+
     return options;
   };
 

--- a/src/components/Shareable/TabelaNutricional/index.tsx
+++ b/src/components/Shareable/TabelaNutricional/index.tsx
@@ -5,7 +5,7 @@ import { Field } from "react-final-form";
 import {
   required,
   composeValidators,
-  inteiroOuDecimal,
+  inteiroOuDecimalComVirgula,
 } from "helpers/fieldValidators";
 import InputText from "components/Shareable/Input/InputText";
 import { OptionsGenerico } from "interfaces/pre_recebimento.interface";
@@ -87,7 +87,9 @@ const TabelaNutricional: React.FC<Props> = ({
   };
 
   const converterDeKcalParaKj = (valor: string) =>
-    ((Number(valor) || 0) * TAXA_CONVERSAO_KCAL_KJ).toFixed(2);
+    ((Number(valor?.replace(",", ".")) || 0) * TAXA_CONVERSAO_KCAL_KJ)
+      .toFixed(2)
+      .replace(".", ",");
 
   return (
     <div className="tabela-nutricional my-5">
@@ -119,7 +121,10 @@ const TabelaNutricional: React.FC<Props> = ({
                   name={`quantidade_por_100g_${informacao.uuid}`}
                   className="input-tabela-nutricional"
                   required
-                  validate={composeValidators(required, inteiroOuDecimal)}
+                  validate={composeValidators(
+                    required,
+                    inteiroOuDecimalComVirgula
+                  )}
                 />
                 <span>{informacao.medida}</span>
               </div>
@@ -130,7 +135,10 @@ const TabelaNutricional: React.FC<Props> = ({
                   name={`quantidade_porcao_${informacao.uuid}`}
                   className="input-tabela-nutricional"
                   required
-                  validate={composeValidators(required, inteiroOuDecimal)}
+                  validate={composeValidators(
+                    required,
+                    inteiroOuDecimalComVirgula
+                  )}
                 />
                 <span>{informacao.medida}</span>
                 {informacao.nome.toUpperCase() === "VALOR ENERGÉTICO" && (
@@ -198,7 +206,10 @@ const TabelaNutricional: React.FC<Props> = ({
                     name={`quantidade_por_100g_${informacao.uuid}`}
                     className="input-tabela-nutricional"
                     required
-                    validate={composeValidators(required, inteiroOuDecimal)}
+                    validate={composeValidators(
+                      required,
+                      inteiroOuDecimalComVirgula
+                    )}
                   />
                   <span>{informacao.medida}</span>
                 </div>
@@ -209,7 +220,10 @@ const TabelaNutricional: React.FC<Props> = ({
                     name={`quantidade_porcao_${informacao.uuid}`}
                     className="input-tabela-nutricional"
                     required
-                    validate={composeValidators(required, inteiroOuDecimal)}
+                    validate={composeValidators(
+                      required,
+                      inteiroOuDecimalComVirgula
+                    )}
                   />
                   <span>{informacao.medida}</span>
                   {informacao.nome.toUpperCase() === "VALOR ENERGÉTICO" && (

--- a/src/components/Shareable/TabelaNutricional/styles.scss
+++ b/src/components/Shareable/TabelaNutricional/styles.scss
@@ -57,7 +57,7 @@
         }
 
         input {
-          width: 75px;
+          width: 90px;
           height: 38px;
         }
 

--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/index.tsx
@@ -16,21 +16,14 @@ import {
   required,
   email,
   composeValidators,
-  inteiroOuDecimal,
+  inteiroOuDecimalComVirgula,
 } from "helpers/fieldValidators";
 import { Spin, Steps } from "antd";
-import {
-  CategoriaFichaTecnicaChoices,
-  FichaTecnicaDetalhada,
-  OptionsGenerico,
-} from "interfaces/pre_recebimento.interface";
 import { CATEGORIA_OPTIONS } from "../../constants";
 import InputText from "components/Shareable/Input/InputText";
 import MaskedInputText from "components/Shareable/Input/MaskedInputText";
 import Collapse from "components/Shareable/Collapse";
 import MeusDadosContext from "context/MeusDadosContext";
-import { MeusDadosInterfaceOuter } from "context/MeusDadosContext/interfaces";
-import { TerceirizadaComEnderecoInterface } from "interfaces/terceirizada.interface";
 import createDecorator from "final-form-calculate";
 import {
   BUTTON_TYPE,
@@ -38,10 +31,6 @@ import {
 } from "../../../../../Shareable/Botao/constants";
 import Botao from "../../../../../Shareable/Botao";
 import { cepMask, cnpjMask, telefoneMask } from "constants/shared";
-import {
-  FichaTecnicaPayload,
-  InformacoesNutricionaisFichaTecnicaPayload,
-} from "../../interfaces";
 import {
   cadastraRascunhoFichaTecnica,
   editaRascunhoFichaTecnica,
@@ -54,16 +43,28 @@ import {
 } from "../../../../../Shareable/Toast/dialogs";
 import { getListaFiltradaAutoCompleteSelect } from "../../../../../../helpers/autoCompleteSelect";
 import AutoCompleteSelectField from "components/Shareable/AutoCompleteSelectField";
+import FormPereciveis from "./components/FormPereciveis";
+import FormNaoPereciveis from "./components/FormNaoPereciveis";
+import { OnChange } from "react-final-form-listeners";
+import TabelaNutricional from "components/Shareable/TabelaNutricional";
+import ModalCadastrarItemIndividual from "components/Shareable/ModalCadastrarItemIndividual";
+
+import {
+  CategoriaFichaTecnicaChoices,
+  FichaTecnicaDetalhada,
+  OptionsGenerico,
+} from "interfaces/pre_recebimento.interface";
+import { MeusDadosInterfaceOuter } from "context/MeusDadosContext/interfaces";
+import { TerceirizadaComEnderecoInterface } from "interfaces/terceirizada.interface";
 import {
   ResponseFichaTecnicaDetalhada,
   ResponseInformacoesNutricionais,
 } from "interfaces/responses.interface";
-import FormPereciveis from "./components/FormPereciveis";
-import FormNaoPereciveis from "./components/FormNaoPereciveis";
-import { OnChange } from "react-final-form-listeners";
 import { InformacaoNutricional } from "interfaces/produto.interface";
-import TabelaNutricional from "components/Shareable/TabelaNutricional";
-import ModalCadastrarItemIndividual from "components/Shareable/ModalCadastrarItemIndividual";
+import {
+  FichaTecnicaPayload,
+  InformacoesNutricionaisFichaTecnicaPayload,
+} from "../../interfaces";
 
 export default () => {
   const { meusDados } = useContext<MeusDadosInterfaceOuter>(MeusDadosContext);
@@ -217,7 +218,7 @@ export default () => {
       lactose: booleanToString(ficha.lactose),
       lactose_detalhe: ficha.lactose_detalhe,
       porcao: ficha.porcao,
-      unidade_medida: ficha.unidade_medida?.uuid,
+      unidade_medida_porcao: ficha.unidade_medida_porcao?.uuid,
       valor_unidade_caseira: ficha.valor_unidade_caseira,
       unidade_medida_caseira: ficha.unidade_medida_caseira,
       ...valuesInformacoesNutricionais,
@@ -256,7 +257,7 @@ export default () => {
       lactose_detalhe: "",
       numero_registro: "",
       porcao: values.porcao || "",
-      unidade_medida: values.unidade_medida || null,
+      unidade_medida_porcao: values.unidade_medida_porcao || null,
       valor_unidade_caseira: values.valor_unidade_caseira || "",
       unidade_medida_caseira: values.unidade_medida_caseira || "",
       informacoes_nutricionais: formataInformacoesNutricionais(values),
@@ -442,7 +443,7 @@ export default () => {
     return (
       Object.keys(errors).length !== 0 ||
       !values.porcao ||
-      !values.unidade_medida ||
+      !values.unidade_medida_porcao ||
       !values.valor_unidade_caseira ||
       !values.unidade_medida_caseira
     );
@@ -864,7 +865,7 @@ export default () => {
                           proibeLetras
                           validate={composeValidators(
                             required,
-                            inteiroOuDecimal
+                            inteiroOuDecimalComVirgula
                           )}
                         />
                       </div>
@@ -873,9 +874,10 @@ export default () => {
                           component={SelectSelecione}
                           naoDesabilitarPrimeiraOpcao
                           options={unidadesMedidaOptions}
-                          name={`unidade_medida`}
+                          name={`unidade_medida_porcao`}
                           placeholder="Unidade de Medida"
                           className="input-ficha-tecnica"
+                          required
                           validate={required}
                         />
                       </div>
@@ -889,7 +891,7 @@ export default () => {
                           proibeLetras
                           validate={composeValidators(
                             required,
-                            inteiroOuDecimal
+                            inteiroOuDecimalComVirgula
                           )}
                         />
                       </div>

--- a/src/components/screens/PreRecebimento/FichaTecnica/interfaces.ts
+++ b/src/components/screens/PreRecebimento/FichaTecnica/interfaces.ts
@@ -45,7 +45,7 @@ export interface FichaTecnicaPayload {
   lactose?: boolean | string;
   lactose_detalhe?: string;
   porcao?: string;
-  unidade_medida?: string;
+  unidade_medida_porcao?: string;
   valor_unidade_caseira?: string;
   unidade_medida_caseira?: string;
   informacoes_nutricionais?: InformacoesNutricionaisFichaTecnicaPayload[];

--- a/src/helpers/fieldValidators.js
+++ b/src/helpers/fieldValidators.js
@@ -339,6 +339,12 @@ export const inteiroOuDecimal = (value) => {
     : undefined;
 };
 
+export const inteiroOuDecimalComVirgula = (value) => {
+  return value && !/^[0-9]+([,][0-9]+)?$/g.test(value)
+    ? "Somente números inteiros ou decimais (separados por vírgula)"
+    : undefined;
+};
+
 export const numeroInteiro = (value) =>
   value ? (!/\D/.test(value) ? undefined : "Somente números") : [];
 

--- a/src/interfaces/pre_recebimento.interface.ts
+++ b/src/interfaces/pre_recebimento.interface.ts
@@ -177,7 +177,7 @@ export interface FichaTecnicaDetalhada {
   lactose: boolean;
   lactose_detalhe: string;
   porcao: string;
-  unidade_medida: UnidadeMedidaSimples;
+  unidade_medida_porcao: UnidadeMedidaSimples;
   valor_unidade_caseira: string;
   unidade_medida_caseira: string;
   informacoes_nutricionais: InformacoesNutricionaisFichaTecnica[];


### PR DESCRIPTION
# Este PR:

- Complementa PR #3938 
  - Renomeia campo unidade_medida nas interfaces relacionadas à Ficha Técnica
  - Implementa nova validação para números inteiros ou decimais com separador sendo vírgula
  - Ordena opções do seletor de Informações Nutricionais

### Referência Azure:

- 105980