### PR TITLE
Bugfix/114084 botao de enviar e remover etapas com problema

### DIFF
--- a/src/components/PreRecebimento/FormEtapa/index.jsx
+++ b/src/components/PreRecebimento/FormEtapa/index.jsx
@@ -182,6 +182,7 @@ export default ({
                       className="float-end ms-3"
                       onClick={() => deletaEtapa(index)}
                       tooltipExterno="Remover Etapa"
+                      disabled={desabilitar[index]}
                     />
                   </div>
                 </div>

--- a/src/components/screens/PreRecebimento/AlterarCronograma/components/AcoesAlterar/index.jsx
+++ b/src/components/screens/PreRecebimento/AlterarCronograma/components/AcoesAlterar/index.jsx
@@ -28,10 +28,12 @@ export default ({
   disabledDilog,
 }) => {
   const [show, setShow] = useState(false);
+  const [showVoltar, setShowVoltar] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
+  const handleShowVoltar = () => setShowVoltar(true);
 
   const enviaAnaliseCronograma = async (values) => {
     setLoading(true);
@@ -187,9 +189,9 @@ export default ({
         type={BUTTON_TYPE.BUTTON}
         style={BUTTON_STYLE.GREEN_OUTLINE}
         className="float-end ms-3"
-        onClick={() => handleShow()}
+        onClick={() => handleShowVoltar()}
       />
-      <ModalVoltar modalVoltar={show} setModalVoltar={handleClose} />
+      <ModalVoltar modalVoltar={showVoltar} setModalVoltar={handleClose} />
     </>
   );
 };


### PR DESCRIPTION
# Este PR:

- Resolve problema do botão enviar que abria o modal errado;
- Resolve problema do botão de remover etapa que ficava sempre habilitado quando devia ser desativado em caso da data programada da etapa estiver no passado.

### Referência Azure:
- 114084