### PR TITLE
Bugfix/114371 acesso aos arquivos layout embalagem ambiente treinamento

### DIFF
--- a/src/components/Shareable/Input/InputFile/helper.js
+++ b/src/components/Shareable/Input/InputFile/helper.js
@@ -18,7 +18,7 @@ export async function readerFile(file) {
 
 export async function downloadAndConvertToBase64(fileUrl) {
   let finalFileUrl = fileUrl;
-  if (ENVIRONMENT === "homolog" || ENVIRONMENT === "production")
+  if (["production", "homolog", "treinamento"].includes(ENVIRONMENT))
     finalFileUrl = finalFileUrl.replace("http://", "https://");
 
   const response = await axios.get(finalFileUrl, {

--- a/src/services/downloads.service.js
+++ b/src/services/downloads.service.js
@@ -17,7 +17,7 @@ export const deletarDownload = async (uuid) =>
 export const baixarArquivoCentral = async (download) => {
   let status = 0;
   let url = download.arquivo;
-  if (ENVIRONMENT === "homolog" || ENVIRONMENT === "production")
+  if (["production", "homolog", "treinamento"].includes(ENVIRONMENT))
     url = url.replace("http://", "https://");
   return fetch(url, {
     method: "GET",


### PR DESCRIPTION
# Este PR:

- Corrige problema de acesso a tela de layout de embalagem que possuíssem arquivos no ambiente de treinamento;

### Referência Azure:
- 114371 🐛 