### PR TITLE
Hotfix/114419 editar lote quebrado

### DIFF
--- a/src/components/screens/Cadastros/CadastroLote/components/LotesCadastrados/index.jsx
+++ b/src/components/screens/Cadastros/CadastroLote/components/LotesCadastrados/index.jsx
@@ -100,7 +100,7 @@ class LotesCadastrados extends Component {
                           (lote.terceirizada !== null ||
                             lote.escolas.length > 0) && (
                             <NavLink
-                              to="/configuracoes/cadastros/lote"
+                              to={`/configuracoes/cadastros/lote?uuid=${lote.uuid}`}
                               state={{
                                 prevPath: window.location.pathname,
                                 uuid: lote.uuid,

--- a/src/components/screens/Cadastros/CadastroLote/index.jsx
+++ b/src/components/screens/Cadastros/CadastroLote/index.jsx
@@ -89,6 +89,7 @@ class CadastroLote extends Component {
       }
     }
     const urlParams = new URLSearchParams(window.location.search);
+
     const uuid =
       this.props.location && this.props.location.state
         ? this.props.location.state.uuid
@@ -128,8 +129,7 @@ class CadastroLote extends Component {
     }
 
     if (
-      location &&
-      location.state &&
+      ((location && location.state) || uuid) &&
       diretoria_regional &&
       !escolasParaEdicaoCarregadas
     ) {


### PR DESCRIPTION
# Este PR:
- corrige a edição de lote pós virada do react-router-dom

### Referência azure:
- AB#114419