### PR TITLE
Feature/113711 listagem docs recebimento coluna numero laudo

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
@@ -88,6 +88,7 @@ const Listagem: React.FC<Props> = ({ objetos, setCarregando }) => {
       <article>
         <div className="grid-table header-table">
           <div>Nº do Cronograma</div>
+          <div>Nº do Laudo</div>
           <div>Nº do Pregão/Chamada Pública</div>
           <div>Nome do Produto</div>
           <div>Data de Cadastro</div>
@@ -100,6 +101,7 @@ const Listagem: React.FC<Props> = ({ objetos, setCarregando }) => {
             <>
               <div key={objeto.uuid} className="grid-table body-table">
                 <div>{objeto.numero_cronograma}</div>
+                <div>{objeto.numero_laudo}</div>
                 <div>{objeto.pregao_chamada_publica}</div>
                 <div>{objeto.nome_produto}</div>
                 <div>{objeto.criado_em}</div>

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/styles.scss
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/styles.scss
@@ -26,7 +26,7 @@
       display: grid;
       align-items: center;
       text-align: center;
-      grid-template-columns: 3fr 4fr 4fr 3.5fr 4fr 2.4fr;
+      grid-template-columns: 9fr 8fr 12fr 11fr 8fr 10fr 7fr;
     }
 
     .header-table {

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/index.tsx
@@ -22,20 +22,22 @@ export default () => {
   );
 
   const buscarResultados = async (pageNumber: number) => {
-    setCarregando(true);
+    try {
+      setCarregando(true);
 
-    const params: URLSearchParams = gerarParametrosConsulta({
-      page: pageNumber,
-      ...filtros,
-    });
-    const response: ResponseDocumentosRecebimento =
-      await listarDocumentosRecebimento(params);
+      const params: URLSearchParams = gerarParametrosConsulta({
+        page: pageNumber,
+        ...filtros,
+      });
+      const response: ResponseDocumentosRecebimento =
+        await listarDocumentosRecebimento(params);
 
-    setDocumentos(response.data.results);
-    setTotalResultados(response.data.count);
-    setConsultaRealizada(true);
-
-    setCarregando(false);
+      setDocumentos(response.data.results);
+      setTotalResultados(response.data.count);
+      setConsultaRealizada(true);
+    } finally {
+      setCarregando(false);
+    }
   };
 
   const nextPage = (page: number) => {

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/index.tsx
@@ -32,9 +32,11 @@ export default () => {
       const response: ResponseDocumentosRecebimento =
         await listarDocumentosRecebimento(params);
 
-      setDocumentos(response.data.results);
-      setTotalResultados(response.data.count);
-      setConsultaRealizada(true);
+      if (response?.status === 200) {
+        setDocumentos(response.data.results);
+        setTotalResultados(response.data.count);
+        setConsultaRealizada(true);
+      }
     } finally {
       setCarregando(false);
     }

--- a/src/interfaces/pre_recebimento.interface.ts
+++ b/src/interfaces/pre_recebimento.interface.ts
@@ -8,6 +8,7 @@ export interface DocumentosRecebimento {
   criado_em: string;
   nome_produto: string;
   numero_cronograma: string;
+  numero_laudo: string;
   pregao_chamada_publica: string;
   status: string;
   uuid: string;

--- a/src/services/documentosRecebimento.service.ts
+++ b/src/services/documentosRecebimento.service.ts
@@ -13,6 +13,8 @@ import {
   ResponseDownloadArquivoLaudoAssinado,
 } from "interfaces/responses.interface";
 import { FiltrosDashboardDocumentos } from "interfaces/pre_recebimento.interface";
+import { getMensagemDeErro } from "../helpers/statusErrors";
+import { toastError } from "../components/Shareable/Toast/dialogs";
 
 export const cadastraDocumentoRecebimento = async (
   payload: DocumentosRecebimentoPayload
@@ -30,8 +32,13 @@ export const detalharDocumentoParaAnalise = async (
 
 export const listarDocumentosRecebimento = async (
   params: URLSearchParams
-): Promise<ResponseDocumentosRecebimento> =>
-  await axios.get("/documentos-de-recebimento/", { params });
+): Promise<ResponseDocumentosRecebimento> => {
+  try {
+    return await axios.get("/documentos-de-recebimento/", { params });
+  } catch (error) {
+    toastError(getMensagemDeErro(error.response.status));
+  }
+};
 
 // Service retorna vários status diferente dentro dos resultados, filtros são apenas strings
 export const getDashboardDocumentosRecebimento = async (


### PR DESCRIPTION
# Este PR:

- Adiciona campo numero_laudo à interface de Documentos de Recebimento;
- Adiciona coluna para exibição do número do laudo na listagem de Documentos de Recebimento;
- Melhora processo de carregamento adicionando tratamento de exceção no service e bloco try/finally na screen;

### Referência Azure:

- 113711