### PR TITLE
Feature/114734 - Filtra editais validos para os seletores de P&D

### DIFF
--- a/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
+++ b/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
@@ -14,6 +14,7 @@ import {
   BUTTON_ICON,
 } from "components/Shareable/Botao/constants";
 import { peloMenosUmCaractere, required } from "helpers/fieldValidators";
+import { EDITAIS_INVALIDOS } from "helpers/gestaoDeProdutos";
 import { vinculosAtivosProdutoEditais } from "services/produto.service";
 import { meusDados } from "services/perfil.service";
 import { usuarioEhEscolaTerceirizadaQualquerPerfil } from "helpers/utilities";
@@ -70,7 +71,9 @@ const ModalSuspensaoProdutoEdital = ({
 
     if (vinculos_produto_edital) {
       vinculos_produto_edital = vinculos_produto_edital.filter(
-        (vinculo) => !vinculo.suspenso
+        (vinculo) =>
+          !vinculo.suspenso &&
+          !EDITAIS_INVALIDOS.find((item) => item.uuid === vinculo.edital.uuid)
       );
 
       return vinculos_produto_edital.map((vinculo) => ({

--- a/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
+++ b/src/components/Shareable/ModalSuspensaoProdutoEdital/index.jsx
@@ -73,7 +73,7 @@ const ModalSuspensaoProdutoEdital = ({
       vinculos_produto_edital = vinculos_produto_edital.filter(
         (vinculo) =>
           !vinculo.suspenso &&
-          !EDITAIS_INVALIDOS.find((item) => item.uuid === vinculo.edital.uuid)
+          !EDITAIS_INVALIDOS.includes(vinculo.edital.numero.toUpperCase())
       );
 
       return vinculos_produto_edital.map((vinculo) => ({

--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
@@ -21,6 +21,8 @@ import {
 import HTTP_STATUS from "http-status-codes";
 import { toastError, toastSuccess } from "components/Shareable/Toast/dialogs";
 import { formatarOpcoes, validatePayload } from "./helper";
+import { EDITAIS_INVALIDOS } from "helpers/gestaoDeProdutos";
+
 import "./style.scss";
 
 export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
@@ -169,7 +171,9 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
       setTipoProdEditalOrigem(changes.values["tipo_produto_edital_origem"]);
       let opcoesDestino = listaEditais
         .filter(
-          (edital) => !changes.values["edital_origem"].includes(edital.uuid)
+          (edital) =>
+            !changes.values["edital_origem"].includes(edital.uuid) &&
+            !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
         )
         .map((edital) => {
           return { nome: edital.numero, uuid: edital.uuid };

--- a/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
+++ b/src/components/screens/Cadastros/VincularProdutosEditais/componentes/ModalVincularProdutosEditais/index.jsx
@@ -173,7 +173,7 @@ export default ({ closeModal, showModal, listaEditais, opcoesTipos }) => {
         .filter(
           (edital) =>
             !changes.values["edital_origem"].includes(edital.uuid) &&
-            !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+            !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
         )
         .map((edital) => {
           return { nome: edital.numero, uuid: edital.uuid };

--- a/src/components/screens/Produto/AtivacaoSuspensao/ModalAtivacaoSuspensaoProduto/index.jsx
+++ b/src/components/screens/Produto/AtivacaoSuspensao/ModalAtivacaoSuspensaoProduto/index.jsx
@@ -109,7 +109,7 @@ const ModalAtivacaoSuspensaoProduto = ({
         options = vinculos_produto_edital
           .filter(
             ({ edital }) =>
-              !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+              !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
           )
           .map((vinculo) => ({
             value: vinculo.edital.uuid,
@@ -119,8 +119,7 @@ const ModalAtivacaoSuspensaoProduto = ({
       if (acao === "ativação" && editais?.length > 0) {
         options = editais
           .filter(
-            (edital) =>
-              !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+            (edital) => !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
           )
           .map((edital) => ({
             label: edital.numero,

--- a/src/components/screens/Produto/AtivacaoSuspensao/ModalAtivacaoSuspensaoProduto/index.jsx
+++ b/src/components/screens/Produto/AtivacaoSuspensao/ModalAtivacaoSuspensaoProduto/index.jsx
@@ -15,6 +15,7 @@ import {
   BUTTON_ICON,
 } from "components/Shareable/Botao/constants";
 import { peloMenosUmCaractere, required } from "helpers/fieldValidators";
+import { EDITAIS_INVALIDOS } from "helpers/gestaoDeProdutos";
 import { ativarProduto, suspenderProduto } from "services/produto.service";
 import { meusDados } from "services/perfil.service";
 import "./style.scss";
@@ -105,16 +106,26 @@ const ModalAtivacaoSuspensaoProduto = ({
             (vinculo) => !vinculo.suspenso
           );
         }
-        options = vinculos_produto_edital.map((vinculo) => ({
-          value: vinculo.edital.uuid,
-          label: vinculo.edital.numero,
-        }));
+        options = vinculos_produto_edital
+          .filter(
+            ({ edital }) =>
+              !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+          )
+          .map((vinculo) => ({
+            value: vinculo.edital.uuid,
+            label: vinculo.edital.numero,
+          }));
       }
       if (acao === "ativação" && editais?.length > 0) {
-        options = editais.map((edital) => ({
-          label: edital.numero,
-          value: edital.uuid,
-        }));
+        options = editais
+          .filter(
+            (edital) =>
+              !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+          )
+          .map((edital) => ({
+            label: edital.numero,
+            value: edital.uuid,
+          }));
       }
     }
     return options;

--- a/src/components/screens/Produto/Homologacao/components/Container.jsx
+++ b/src/components/screens/Produto/Homologacao/components/Container.jsx
@@ -9,6 +9,7 @@ import {
 import { getNumerosEditais } from "services/edital.service";
 import { Homologacao } from "../index";
 import { formataEditais, formataValoresBooleanos } from "../helper";
+import { EDITAIS_INVALIDOS } from "helpers/gestaoDeProdutos";
 
 export const Container = () => {
   const [erro, setErro] = useState(false);
@@ -32,7 +33,10 @@ export const Container = () => {
   const getNumerosEditaisAsync = async () => {
     const response = await getNumerosEditais();
     if (response.status === HTTP_STATUS.OK) {
-      setEditaisOptions(response.data.results);
+      let editais = response.data.results.filter(
+        (edital) => !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+      );
+      setEditaisOptions(editais);
     } else {
       toastError("Erro ao carregar editais");
       setErro(true);

--- a/src/components/screens/Produto/Homologacao/components/Container.jsx
+++ b/src/components/screens/Produto/Homologacao/components/Container.jsx
@@ -34,7 +34,7 @@ export const Container = () => {
     const response = await getNumerosEditais();
     if (response.status === HTTP_STATUS.OK) {
       let editais = response.data.results.filter(
-        (edital) => !EDITAIS_INVALIDOS.find((item) => item.uuid === edital.uuid)
+        (edital) => !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
       );
       setEditaisOptions(editais);
     } else {

--- a/src/components/screens/Produto/Homologacao/index.jsx
+++ b/src/components/screens/Produto/Homologacao/index.jsx
@@ -19,6 +19,7 @@ import {
   usuarioEhCODAEGestaoProduto,
   usuarioEhEmpresaTerceirizada,
 } from "helpers/utilities";
+import { EDITAIS_INVALIDOS } from "helpers/gestaoDeProdutos";
 import "./style.scss";
 
 export const Homologacao = ({
@@ -42,7 +43,11 @@ export const Homologacao = ({
         return vinculo.edital.uuid;
       });
     }
-    return result;
+    let resultadoFiltrado = result.filter(
+      (editalUuid) =>
+        !EDITAIS_INVALIDOS.find((item) => item.uuid === editalUuid)
+    );
+    return resultadoFiltrado;
   };
 
   const logAnaliseSensorial = homologacao.logs.filter(

--- a/src/components/screens/Produto/Homologacao/index.jsx
+++ b/src/components/screens/Produto/Homologacao/index.jsx
@@ -34,20 +34,26 @@ export const Homologacao = ({
   const setDefaultEditaisVinculados = () => {
     let result = [];
     if (homologacao.eh_para_alunos_com_dieta) {
-      result = homologacao.rastro_terceirizada.contratos.map((contrato) => {
-        return contrato.edital.uuid;
-      });
+      result = homologacao.rastro_terceirizada.contratos
+        .filter(
+          ({ edital }) =>
+            !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
+        )
+        .map((contrato) => {
+          return contrato.edital.uuid;
+        });
     }
     if (homologacao.produto.vinculos_produto_edital.length) {
-      result = homologacao.produto.vinculos_produto_edital.map((vinculo) => {
-        return vinculo.edital.uuid;
-      });
+      result = homologacao.produto.vinculos_produto_edital
+        .filter(
+          ({ edital }) =>
+            !EDITAIS_INVALIDOS.includes(edital.numero.toUpperCase())
+        )
+        .map((vinculo) => {
+          return vinculo.edital.uuid;
+        });
     }
-    let resultadoFiltrado = result.filter(
-      (editalUuid) =>
-        !EDITAIS_INVALIDOS.find((item) => item.uuid === editalUuid)
-    );
-    return resultadoFiltrado;
+    return result;
   };
 
   const logAnaliseSensorial = homologacao.logs.filter(

--- a/src/helpers/gestaoDeProdutos.js
+++ b/src/helpers/gestaoDeProdutos.js
@@ -256,7 +256,4 @@ export const CADASTROS = usuarioEhCODAEGestaoProduto()
     ])
   : [CADASTRO_GERAL];
 
-export const EDITAIS_INVALIDOS = [
-  { numero: "78/SME/2016", uuid: "b7b6a0a7-b230-4783-94b6-8d3d22041ab3" },
-  { numero: "41/SME/2017", uuid: "60f5a64e-8652-422d-a6e9-0a36717829c9" },
-];
+export const EDITAIS_INVALIDOS = ["78/SME/2016", "41/SME/2017"];

--- a/src/helpers/gestaoDeProdutos.js
+++ b/src/helpers/gestaoDeProdutos.js
@@ -255,3 +255,8 @@ export const CADASTROS = usuarioEhCODAEGestaoProduto()
       VINCULAR_PRODUTOS_EDITAIS,
     ])
   : [CADASTRO_GERAL];
+
+export const EDITAIS_INVALIDOS = [
+  { numero: "78/SME/2016", uuid: "b7b6a0a7-b230-4783-94b6-8d3d22041ab3" },
+  { numero: "41/SME/2017", uuid: "60f5a64e-8652-422d-a6e9-0a36717829c9" },
+];


### PR DESCRIPTION
# Este PR: 
- FIltra somente os editais válidos, removendo os editais 78 e 41 dos seletores de busca do módulo de Gestão de Produto.

### Referência azure:
- AB#114734
