### PR TITLE
Feature/114786 liberacao de painel de pre recebimento para novos perfis

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Listagem/index.tsx
@@ -4,7 +4,7 @@ import "./styles.scss";
 import { DocumentosRecebimento } from "interfaces/pre_recebimento.interface";
 import {
   PRE_RECEBIMENTO,
-  DETALHAR_DOCUMENTO_RECEBIMENTO,
+  DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO,
   CORRIGIR_DOCUMENTOS_RECEBIMENTO,
 } from "../../../../../../configs/constants";
 import { downloadArquivoLaudoAssinado } from "services/documentosRecebimento.service";
@@ -32,7 +32,7 @@ const Listagem: React.FC<Props> = ({ objetos, setCarregando }) => {
     const botaoDetalharVerde = (
       <NavLink
         className="float-start"
-        to={`/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}?uuid=${objeto.uuid}`}
+        to={`/${PRE_RECEBIMENTO}/${DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO}?uuid=${objeto.uuid}`}
       >
         <span className="link-acoes px-2">
           <i title="Detalhar" className="fas fa-eye green" />

--- a/src/components/screens/PreRecebimento/PainelDocumentosRecebimento/index.tsx
+++ b/src/components/screens/PreRecebimento/PainelDocumentosRecebimento/index.tsx
@@ -4,7 +4,8 @@ import CardCronograma from "components/Shareable/CardCronograma/CardCronograma";
 import { cardsPainel } from "./constants";
 import {
   ANALISAR_DOCUMENTO_RECEBIMENTO,
-  DETALHAR_DOCUMENTO_RECEBIMENTO,
+  DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO,
+  DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO,
   PRE_RECEBIMENTO,
 } from "configs/constants";
 import {
@@ -66,10 +67,15 @@ export default () => {
   const gerarLinkDocumento = (item: DocumentosRecebimentoDashboard): string => {
     const perfilLogado = localStorage.getItem("perfil");
 
-    return item.status === "Enviado para Análise" &&
-      perfilLogado === PERFIL.DILOG_QUALIDADE
-      ? `/${PRE_RECEBIMENTO}/${ANALISAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`
-      : `/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`;
+    if (item.status === "Enviado para Análise") {
+      if (perfilLogado === PERFIL.DILOG_QUALIDADE) {
+        return `/${PRE_RECEBIMENTO}/${ANALISAR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`;
+      }
+
+      return `/${PRE_RECEBIMENTO}/${DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`;
+    }
+
+    return `/${PRE_RECEBIMENTO}/${DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO}?uuid=${item.uuid}`;
   };
 
   const agruparCardsPorStatus = (

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -278,7 +278,8 @@ import CorrigirLayoutEmbalagemPage from "../pages/PreRecebimento/CorrigirLayoutE
 import AtualizarLayoutEmbalagemPage from "../pages/PreRecebimento/AtualizarLayoutEmbalagemPage";
 import DocumentosRecebimentoPage from "../pages/PreRecebimento/DocumentosRecebimentoPage";
 import CadastroDocumentosRecebimentoPage from "../pages/PreRecebimento/CadastroDocumentosRecebimentoPage";
-import DetalharDocumentosRecebimentoPage from "../pages/PreRecebimento/DetalharDocumentosRecebimentoPage";
+import DetalharFornecedorDocumentosRecebimentoPage from "../pages/PreRecebimento/DetalharFornecedorDocumentosRecebimentoPage";
+import DetalharCodaeDocumentosRecebimentoPage from "../pages/PreRecebimento/DetalharCodaeDocumentosRecebimentoPage";
 import PainelDocumentosRecebimentoPage from "../pages/PreRecebimento/PainelDocumentosRecebimentoPage";
 import StatusDocumentoPendenteAprovacao from "../pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoPendenteAprovacao";
 import StatusDocumentoAprovados from "../pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoAprovados";
@@ -1845,8 +1846,14 @@ const routesConfig = [
     tipoUsuario: usuarioEhEmpresaFornecedor(),
   },
   {
-    path: `/${constants.PRE_RECEBIMENTO}/${constants.DETALHAR_DOCUMENTO_RECEBIMENTO}`,
-    component: DetalharDocumentosRecebimentoPage,
+    path: `/${constants.PRE_RECEBIMENTO}/${constants.DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO}`,
+    component: DetalharFornecedorDocumentosRecebimentoPage,
+    tipoUsuario:
+      usuarioEhEmpresaFornecedor() || usuarioComAcessoAoPainelDocumentos(),
+  },
+  {
+    path: `/${constants.PRE_RECEBIMENTO}/${constants.DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO}`,
+    component: DetalharCodaeDocumentosRecebimentoPage,
     tipoUsuario:
       usuarioEhEmpresaFornecedor() || usuarioComAcessoAoPainelDocumentos(),
   },

--- a/src/configs/constants.js
+++ b/src/configs/constants.js
@@ -248,7 +248,10 @@ export const ENVIADOS_PARA_CORRECAO = "enviados-para-correcao";
 export const DOCUMENTOS_RECEBIMENTO = "documentos-recebimento";
 export const CADASTRO_DOCUMENTOS_RECEBIMENTO =
   "cadastro-documentos-recebimento";
-export const DETALHAR_DOCUMENTO_RECEBIMENTO = "detalhe-documento-recebimento";
+export const DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO =
+  "detalhe-fornecedor-documento-recebimento";
+export const DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO =
+  "detalhe-codae-documento-recebimento";
 export const ANALISAR_DOCUMENTO_RECEBIMENTO = "analise-documento-recebimento";
 export const PAINEL_DOCUMENTOS_RECEBIMENTO = "painel-documentos-recebimento";
 export const CORRIGIR_DOCUMENTOS_RECEBIMENTO =

--- a/src/pages/PreRecebimento/DetalharCodaeDocumentosRecebimentoPage.tsx
+++ b/src/pages/PreRecebimento/DetalharCodaeDocumentosRecebimentoPage.tsx
@@ -3,23 +3,16 @@ import { HOME } from "constants/config";
 import Breadcrumb from "components/Shareable/Breadcrumb";
 import Page from "components/Shareable/Page/Page";
 import {
-  DETALHAR_DOCUMENTO_RECEBIMENTO,
+  DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO,
   PAINEL_DOCUMENTOS_RECEBIMENTO,
-  DOCUMENTOS_RECEBIMENTO,
   PRE_RECEBIMENTO,
 } from "configs/constants";
-import Detalhar from "components/screens/PreRecebimento/DocumentosRecebimento/components/Detalhar";
 import DetalharCodae from "components/screens/PreRecebimento/DocumentosRecebimento/components/DetalharCodae";
-import { usuarioEhEmpresaFornecedor } from "helpers/utilities";
 
 const atual = {
-  href: `/${PRE_RECEBIMENTO}/${DETALHAR_DOCUMENTO_RECEBIMENTO}`,
+  href: `/${PRE_RECEBIMENTO}/${DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO}`,
   titulo: "Detalhar Documentos de Recebimento",
 };
-
-const link = usuarioEhEmpresaFornecedor()
-  ? `/${PRE_RECEBIMENTO}/${DOCUMENTOS_RECEBIMENTO}`
-  : `/${PRE_RECEBIMENTO}/${PAINEL_DOCUMENTOS_RECEBIMENTO}`;
 
 const anteriores = [
   {
@@ -27,14 +20,18 @@ const anteriores = [
     titulo: "Pré-Recebimento",
   },
   {
-    href: link,
+    href: `/${PRE_RECEBIMENTO}/${PAINEL_DOCUMENTOS_RECEBIMENTO}`,
     titulo: "Documentos de Recebimento",
   },
 ];
 
 export default () => (
-  <Page botaoVoltar voltarPara={link} titulo={atual.titulo}>
+  <Page
+    botaoVoltar
+    voltarPara={anteriores[anteriores.length - 1].href}
+    titulo={atual.titulo}
+  >
     <Breadcrumb home={HOME} atual={atual} anteriores={anteriores} />
-    {usuarioEhEmpresaFornecedor() ? <Detalhar /> : <DetalharCodae />}
+    <DetalharCodae />
   </Page>
 );

--- a/src/pages/PreRecebimento/DetalharFornecedorDocumentosRecebimentoPage.tsx
+++ b/src/pages/PreRecebimento/DetalharFornecedorDocumentosRecebimentoPage.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { HOME } from "constants/config";
+import Breadcrumb from "components/Shareable/Breadcrumb";
+import Page from "components/Shareable/Page/Page";
+import {
+  DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO,
+  PAINEL_DOCUMENTOS_RECEBIMENTO,
+  DOCUMENTOS_RECEBIMENTO,
+  PRE_RECEBIMENTO,
+} from "configs/constants";
+import Detalhar from "components/screens/PreRecebimento/DocumentosRecebimento/components/Detalhar";
+import { usuarioEhEmpresaFornecedor } from "helpers/utilities";
+
+const atual = {
+  href: `/${PRE_RECEBIMENTO}/${DETALHAR_FORNECEDOR_DOCUMENTO_RECEBIMENTO}`,
+  titulo: "Detalhar Documentos de Recebimento",
+};
+
+const link = usuarioEhEmpresaFornecedor()
+  ? `/${PRE_RECEBIMENTO}/${DOCUMENTOS_RECEBIMENTO}`
+  : `/${PRE_RECEBIMENTO}/${PAINEL_DOCUMENTOS_RECEBIMENTO}`;
+
+const anteriores = [
+  {
+    href: `/`,
+    titulo: "Pré-Recebimento",
+  },
+  {
+    href: link,
+    titulo: "Documentos de Recebimento",
+  },
+];
+
+export default () => (
+  <Page botaoVoltar voltarPara={link} titulo={atual.titulo}>
+    <Breadcrumb home={HOME} atual={atual} anteriores={anteriores} />
+    <Detalhar />
+  </Page>
+);


### PR DESCRIPTION
# Este PR:

- Divide page de Detalhar Documentos de Recebimento em duas novas pages, uma para a visão fornecedor e outra para visão CODAE.

### Referência Azure:

- 114786