### PR TITLE
Feature/101641 relatorio de adesao filtros

### DIFF
--- a/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLancamentoInicial.jsx
@@ -60,6 +60,7 @@ const MenuLancamentoInicial = ({ activeSubmenu, onSubmenuLancamentoClick }) => {
         )}
         {exibeRelatorios && (
           <SubMenu
+            path="relatorios"
             icon="fa-chevron-down"
             onClick={onSubmenuLancamentoClick}
             title="Relatórios"

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/types.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/types.ts
@@ -14,10 +14,6 @@ export type MultiSelectOption = {
   value: string | number;
 };
 
-export type EscolasSimplissimaParams =
-  | { diretoria_regional__uuid: string; lote__uuid: string }
-  | Record<string, any>;
-
 export type Option = {
   label: string;
   value: any;

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
@@ -169,18 +169,28 @@ export default ({ form }: Args) => {
   };
 
   const onChangeLotes = (lotes: Array<string>) => {
-    if (lotes.length === 0) {
-      setUnidadesEducacionaisOpcoes(
-        formataUnidadesEducacionaisOpcoes(unidadesEducacionais)
+    limpaCampo("unidade_educacional");
+
+    let escolas = unidadesEducacionais;
+
+    const dreUUID = form.getState().values.dre;
+    if (dreUUID) {
+      escolas = escolas.filter(
+        (escola) => escola.diretoria_regional.uuid === dreUUID
       );
-    } else if (!buscandoOpcoes.buscandoUnidadesEducacionais)
+    }
+
+    if (lotes.length === 0) {
+      setUnidadesEducacionaisOpcoes(formataUnidadesEducacionaisOpcoes(escolas));
+    } else {
       setUnidadesEducacionaisOpcoes(
         formataUnidadesEducacionaisOpcoes(
-          unidadesEducacionais.filter(
+          escolas.filter(
             (escola) => escola.lote && lotes.includes(escola.lote.uuid)
           )
         )
       );
+    }
   };
 
   const onChangeUnidadeEducacional = (escolaLabel: string) => {

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
@@ -267,7 +267,8 @@ export default ({ form }: Args) => {
     const hoje = new Date();
     let [mesSelecionado, anoSelecionado] = mesAno.split("_");
 
-    return hoje <= new Date(Number(anoSelecionado), Number(mesSelecionado), 0)
+    return new Date(Number(anoSelecionado), Number(mesSelecionado) - 1, 1) >
+      hoje
       ? "Não é possível exportar o relatório com mês posterior ao atual"
       : "";
   };

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
@@ -105,6 +105,20 @@ export default ({ form }: Args) => {
         setTiposAlimentacao(tipos);
         setTiposAlimentacaoOpcoes(tipos);
 
+        form.subscribe(
+          (values) => {
+            if (!values.dirty) {
+              setLotesOpcoes(formatarOpcoesLote(lotes));
+              setUnidadesEducacionaisOpcoes(
+                formataUnidadesEducacionaisOpcoes(escolas)
+              );
+              setPeriodosEscolaresOpcoes(periodos);
+              setTiposAlimentacaoOpcoes(tipos);
+            }
+          },
+          { dirty: true }
+        );
+
         setBuscandoOpcoes({
           buscandoMesesAnos: false,
           buscandoDiretoriasRegionais: false,
@@ -198,6 +212,8 @@ export default ({ form }: Args) => {
   };
 
   const onChangeUnidadeEducacional = (escolaLabel: string) => {
+    limpaCampos(["periodos", "tipo_alimentacao"]);
+
     if (!escolaLabel) {
       setPeriodosEscolaresOpcoes(periodosEscolares);
       setTiposAlimentacaoOpcoes(tiposAlimentacao);

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
@@ -87,7 +87,12 @@ export default ({ form }: Args) => {
         setLotes(lotes);
         setLotesOpcoes(formatarOpcoesLote(lotes));
 
-        let escolas = responseEscolas.results;
+        let escolas = responseEscolas.results.filter(
+          (escola) =>
+            !["CEI", "CCI", "CEU CEI", "CEU CEMEI", "CEMEI"].includes(
+              escola.tipo_unidade.iniciais
+            )
+        );
         setUnidadesEducacionais(escolas);
         setUnidadesEducacionaisOpcoes(
           formataUnidadesEducacionaisOpcoes(escolas)

--- a/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
+++ b/src/components/screens/LancamentoInicial/Relatorios/RelatorioAdesao/components/FormFiltro/view.ts
@@ -39,6 +39,7 @@ export default ({ form }: Args) => {
     Array<MultiSelectOption>
   >([]);
 
+  const [lotes, setLotes] = useState([]);
   const [unidadesEducacionais, setUnidadesEducacionais] = useState([]);
   const [periodosEscolares, setPeriodosEscolares] = useState([]);
   const [tiposAlimentacao, setTiposAlimentacao] = useState([]);
@@ -57,6 +58,7 @@ export default ({ form }: Args) => {
       ...prev,
       buscandoMesesAnos: true,
       buscandoDiretoriasRegionais: true,
+      buscandoLotes: true,
       buscandoPeriodosEscolares: true,
       buscandoTiposAlimentacao: true,
     }));
@@ -85,6 +87,18 @@ export default ({ form }: Args) => {
       setBuscandoOpcoes((prev) => ({
         ...prev,
         buscandoDiretoriasRegionais: false,
+      }));
+    });
+
+    getLotesSimples().then((response) => {
+      const lotes = response.data.results;
+
+      setLotes(lotes);
+      setLotesOpcoes(formatarOpcoesLote(lotes));
+
+      setBuscandoOpcoes((prev) => ({
+        ...prev,
+        buscandoLotes: false,
       }));
     });
 
@@ -120,26 +134,21 @@ export default ({ form }: Args) => {
   }, []);
 
   const onChangeDRE = (e: ChangeEvent<HTMLInputElement>) => {
-    form.resetFieldState("lotes");
+    if (form.getFieldState("lotes")) form.resetFieldState("lotes");
 
     if (!e.target.value) {
-      form.resetFieldState("unidade_educacional");
+      if (form.getFieldState("unidade_educacional"))
+        form.resetFieldState("unidade_educacional");
+
+      setLotesOpcoes(formatarOpcoesLote(lotes));
+
       return;
     }
 
-    setBuscandoOpcoes((prev) => ({
-      ...prev,
-      buscandoLotes: true,
-    }));
-
-    getLotesSimples({ diretoria_regional__uuid: e.target.value }).then(
-      (response) => {
-        setLotesOpcoes(formatarOpcoesLote(response.data.results));
-        setBuscandoOpcoes((prev) => ({
-          ...prev,
-          buscandoLotes: false,
-        }));
-      }
+    setLotesOpcoes(
+      formatarOpcoesLote(
+        lotes.filter((lote) => lote.diretoria_regional.uuid === e.target.value)
+      )
     );
 
     buscaUnidadesEducacionais();


### PR DESCRIPTION
# Este PR
corrige os seguintes pontos:
- Menu lateral que tá abrindo junto o submenu relatório
- Campo Lote qdo não preenchido DRE não traz todos os lotes
- Campo Unidade Educacional tb não tá trazendo as UES qdo não preenchido a DRE
- Ao limpar a tela sistema continua com os filtros anteriores 
- Exclusao das escolas CEI, CCI, CEU CEI, CEU CEMEI e CEMEI das opcoes de unidade educacional
- Validacao do mes/ano caso seja posterior ao atual

### Referencia Azure
AB#101641