### PR TITLE
Bugfix/114993 - Corrige breadcrumb da tela de conferência dos lançamentos

### DIFF
--- a/src/pages/LancamentoMedicaoInicial/ConferenciaDosLancamentosPage.jsx
+++ b/src/pages/LancamentoMedicaoInicial/ConferenciaDosLancamentosPage.jsx
@@ -11,7 +11,6 @@ import {
   CONFERENCIA_DOS_LANCAMENTOS,
   MEDICAO_INICIAL,
 } from "configs/constants";
-import { usuarioEhMedicao } from "helpers/utilities";
 
 const atual = {
   href: `/${MEDICAO_INICIAL}/${CONFERENCIA_DOS_LANCAMENTOS}`,
@@ -23,7 +22,7 @@ const anteriores = [
     href: `/${MEDICAO_INICIAL}/${ACOMPANHAMENTO_DE_LANCAMENTOS}`,
     titulo: "Medição Inicial",
   },
-  usuarioEhMedicao() && {
+  {
     href: `/${MEDICAO_INICIAL}/${ACOMPANHAMENTO_DE_LANCAMENTOS}`,
     titulo: "Acompanhamento de Lançamentos",
   },


### PR DESCRIPTION
# Este PR: 
- Corrige breadcrumb da tela de Conferência dos Lançamentos

### Referência azure:
- AB#114993