### PR TITLE
hotfix/117316 - Corrige problema de total de embalagem ao salvar cronograma

### DIFF
--- a/src/components/screens/PreRecebimento/CadastroCronograma/helpers.js
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/helpers.js
@@ -75,7 +75,7 @@ export const formataPayload = (
         )
       : undefined,
     quantidade: values[`quantidade_${index}`]?.replaceAll(".", ""),
-    total_embalagens: values[`total_embalagens_${index}`],
+    total_embalagens: values[`total_embalagens_${index}`]?.replaceAll(".", ""),
   }));
 
   payload.programacoes_de_recebimento = recebimentos.map((etapa, index) => ({


### PR DESCRIPTION
# Este PR:

- Corrige problema de total de embalagem invalido ao salvar cronograma;

### Referência Azure:
- 117316