### PR TITLE
Feature/115799 libera acesso dilog diretoria

### DIFF
--- a/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
@@ -27,7 +27,11 @@ export default ({
                   <div key={key} className="row">
                     <div className="col-9">
                       {exibirTooltip ? (
-                        <Tooltip key={key} title={value.textoCompleto}>
+                        <Tooltip
+                          placement="topLeft"
+                          key={key}
+                          title={value.textoCompleto}
+                        >
                           <NavLink key={key} to={value.link}>
                             <p className={`data ms-4`}>{`${value.texto}`}</p>
                           </NavLink>

--- a/src/components/Shareable/Sidebar/SidebarContent.jsx
+++ b/src/components/Shareable/Sidebar/SidebarContent.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from "react";
+
 import {
   usuarioEhCODAEGestaoAlimentacao,
   usuarioEhCODAENutriManifestacao,
@@ -34,9 +35,11 @@ import {
   usuarioEhCoordenadorGpCODAE,
   usuarioEhOrgaoFiscalizador,
   usuarioEhCODAEGabinete,
-} from "../../../helpers/utilities";
-import { ListItem } from "./menus/shared";
+  usuarioEhDilogDiretoria,
+} from "helpers/utilities";
 import { ENVIRONMENT } from "constants/config";
+
+import { ListItem } from "./menus/shared";
 import {
   MenuGestaoDeAlimentacao,
   MenuDietaEspecial,
@@ -169,7 +172,8 @@ export const SidebarContent = () => {
     usuarioEhEscolaAbastecimentoDiretor() ||
     usuarioComAcessoTelaEntregasDilog() ||
     usuarioEhDilogQualidade() ||
-    usuarioEhCODAEGabinete();
+    usuarioEhCODAEGabinete() ||
+    usuarioEhDilogDiretoria();
 
   const exibirMenuPreRecebimento =
     usuarioEhPreRecebimento() ||

--- a/src/components/Shareable/Sidebar/menus/MenuConfiguracoes.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuConfiguracoes.jsx
@@ -28,6 +28,7 @@ import {
   usuarioEhCodaeDilog,
   usuarioEhDiretorUE,
   usuarioEhCODAEGabinete,
+  usuarioEhDilogDiretoria,
 } from "helpers/utilities";
 
 const MenuConfiguracoes = ({ activeMenu, onSubmenuClick }) => {
@@ -48,7 +49,8 @@ const MenuConfiguracoes = ({ activeMenu, onSubmenuClick }) => {
     usuarioEhCoordenadorGpCODAE() ||
     usuarioEhCoordenadorNutriSupervisao();
 
-  const exibirGestaoAcessoSomenteLeitura = usuarioEhCODAEGabinete();
+  const exibirGestaoAcessoSomenteLeitura =
+    usuarioEhCODAEGabinete() || usuarioEhDilogDiretoria();
 
   return (
     <Menu id="Configuracoes" icon="fa-cog" title={"Configurações"}>

--- a/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
@@ -29,12 +29,15 @@ import {
   usuarioEhDilogQualidade,
   usuarioEhDilog,
   usuarioEhCODAEGabinete,
+  usuarioEhDilogDiretoria,
 } from "helpers/utilities";
 
 const MenuLogistica = ({ activeMenu, onSubmenuClick }) => {
   return (
     <Menu id="Logistica" icon="fa-truck" title="Abastecimento">
-      {(usuarioEhLogistica() || usuarioEhCODAEGabinete()) && (
+      {(usuarioEhLogistica() ||
+        usuarioEhCODAEGabinete() ||
+        usuarioEhDilogDiretoria()) && (
         <LeafItem to={`/${LOGISTICA}/${ENVIO_REQUISICOES_ENTREGA_AVANCADO}`}>
           Requisição de Entrega
         </LeafItem>

--- a/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
@@ -61,7 +61,9 @@ const MenuLogistica = ({ activeMenu, onSubmenuClick }) => {
         </LeafItem>
       )}
 
-      {(usuarioEhLogistica() || usuarioEhCODAEGabinete()) && (
+      {(usuarioEhLogistica() ||
+        usuarioEhCODAEGabinete() ||
+        usuarioEhDilogDiretoria()) && (
         <LeafItem to={`/${LOGISTICA}/${GESTAO_SOLICITACAO_ALTERACAO}`}>
           Alteração da Requisição
         </LeafItem>

--- a/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuLogistica.jsx
@@ -106,7 +106,8 @@ const MenuLogistica = ({ activeMenu, onSubmenuClick }) => {
         >
           {(usuarioEhCodaeDilog() ||
             usuarioEhDilogJuridico() ||
-            usuarioEhCODAEGabinete()) && (
+            usuarioEhCODAEGabinete() ||
+            usuarioEhDilogDiretoria()) && (
             <LeafItem to={`/${LOGISTICA}/${GUIAS_NOTIFICACAO}/`}>
               Guias com Notificações
             </LeafItem>

--- a/src/components/screens/Configuracoes/GestaoAcesso/components/ListagemVinculos/styles.scss
+++ b/src/components/screens/Configuracoes/GestaoAcesso/components/ListagemVinculos/styles.scss
@@ -78,8 +78,7 @@
       }
 
       button:disabled {
-        color: #42474a;
-        opacity: 0.6;
+        color: $grayDisabled;
       }
 
       .flex-container {

--- a/src/components/screens/Configuracoes/GestaoAcesso/components/ListagemVinculos/styles.scss
+++ b/src/components/screens/Configuracoes/GestaoAcesso/components/ListagemVinculos/styles.scss
@@ -77,6 +77,11 @@
         outline: none;
       }
 
+      button:disabled {
+        color: #42474a;
+        opacity: 0.6;
+      }
+
       .flex-container {
         display: flex;
         justify-content: space-evenly;

--- a/src/components/screens/Configuracoes/GestaoAcesso/index.jsx
+++ b/src/components/screens/Configuracoes/GestaoAcesso/index.jsx
@@ -41,6 +41,7 @@ export default ({ diretor_escola, empresa, geral, cogestor, codae }) => {
 
   const somenteLeitura = useSomenteLeitura([
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ]);
 
   const buscaFiltros = async () => {

--- a/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/index.jsx
+++ b/src/components/screens/Logistica/ConsultaRequisicaoEntregaDilog/index.jsx
@@ -49,6 +49,7 @@ export default () => {
   const inicioResultado = useRef();
   const somenteLeitura = useSomenteLeitura([
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ]);
 
   const buscarSolicitacoes = async (page) => {

--- a/src/components/screens/Logistica/GestaoSolicitacaoAlteracao/components/ListagemSolicitacoes/index.js
+++ b/src/components/screens/Logistica/GestaoSolicitacaoAlteracao/components/ListagemSolicitacoes/index.js
@@ -16,7 +16,9 @@ const ListagemSolicitacoes = ({
 }) => {
   const somenteLeitura = useSomenteLeitura([
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ]);
+
   return (
     <section className="resultado-gestao-solicitacao-alteracao">
       <header>Solicitações Disponibilizadas</header>

--- a/src/components/screens/Logistica/GuiasComNotificacoes/index.jsx
+++ b/src/components/screens/Logistica/GuiasComNotificacoes/index.jsx
@@ -17,6 +17,7 @@ export default ({ fiscal = false }) => {
 
   const somenteLeitura = useSomenteLeitura([
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ]);
 
   useEffect(() => {

--- a/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Analisar/index.jsx
+++ b/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Analisar/index.jsx
@@ -34,6 +34,7 @@ export default () => {
   const { meusDados } = useContext(MeusDadosContext);
   const somenteLeitura = useSomenteLeitura([
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ]);
 
   const [carregando, setCarregando] = useState(true);

--- a/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Analisar/index.jsx
+++ b/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Analisar/index.jsx
@@ -135,7 +135,7 @@ export default () => {
   const retornaBotoesAprovacao = (index, form) => {
     const textoAprovacao = `Embalagem Aprovada em ${moment().format(
       "DD/MM/YYYY - HH:mm"
-    )}\n|Por: ${meusDados.nome}`;
+    )}\n|Por: ${meusDados?.nome}`;
 
     return (
       <div className="mt-4">
@@ -173,10 +173,10 @@ export default () => {
         values[`justificativa_${index}`].split("|");
 
       return (
-        <div className="col-7">
-          <div className="subtitulo d-flex ms-5">
+        <div className="col-7 d-flex align-items-center">
+          <div className="subtitulo d-flex align-items-center ms-5">
             <div className="w-5">
-              <i className="fas fa-check me-2" />
+              <i className="fas fa-check me-3 fa-2x" />
             </div>
             <div className="w-95">
               <div>{dataHoraAprovacao}</div>

--- a/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Detalhar/index.jsx
+++ b/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Detalhar/index.jsx
@@ -163,7 +163,7 @@ export default ({ analise }) => {
       );
     } else if (aprovacoes[index] === false) {
       return (
-        <div className="col-7 d-flex align-items-center">
+        <div className="col-7">
           <Field
             component={TextArea}
             label="Correções Necessárias"
@@ -412,7 +412,7 @@ export default ({ analise }) => {
                 >
                   Embalagem Primária
                 </div>
-                <div className="row">
+                <div className="row d-flex align-items-center">
                   <div className="col-5">
                     {embalagemPrimaria.map((e) => (
                       <div className="w-75" key={e.arquivo}>
@@ -436,7 +436,7 @@ export default ({ analise }) => {
                 >
                   Embalagem Secundária
                 </div>
-                <div className="row">
+                <div className="row d-flex align-items-center">
                   <div className="col-5">
                     {embalagemSecundaria.map((e) => (
                       <div className="w-75" key={e.arquivo}>
@@ -462,7 +462,7 @@ export default ({ analise }) => {
                     >
                       Embalagem Terciária
                     </div>
-                    <div className="row">
+                    <div className="row d-flex align-items-center">
                       <div className="col-5">
                         {embalagemTerciaria.map((e) => (
                           <div className="w-75" key={e.arquivo}>

--- a/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Detalhar/index.jsx
+++ b/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Detalhar/index.jsx
@@ -1,10 +1,18 @@
 import React, { useEffect, useState, useContext } from "react";
 import { Spin } from "antd";
-import "./styles.scss";
-import { LAYOUT_EMBALAGEM, PRE_RECEBIMENTO } from "configs/constants";
 import { useNavigate } from "react-router-dom";
+import { Field, Form } from "react-final-form";
+import moment from "moment";
+
+import {
+  LAYOUT_EMBALAGEM,
+  PRE_RECEBIMENTO,
+  PAINEL_LAYOUT_EMBALAGEM,
+} from "configs/constants";
+import { usuarioComAcessoAoPainelEmbalagens } from "helpers/utilities";
+import { textAreaRequired } from "helpers/fieldValidators";
+import MeusDadosContext from "context/MeusDadosContext";
 import BotaoVoltar from "components/Shareable/Page/BotaoVoltar";
-import { detalharLayoutEmabalagem } from "services/layoutEmbalagem.service";
 import { TextArea } from "components/Shareable/TextArea/TextArea";
 import BotaoAnexo from "components/PreRecebimento/BotaoAnexo";
 import Botao from "components/Shareable/Botao";
@@ -12,21 +20,17 @@ import {
   BUTTON_TYPE,
   BUTTON_STYLE,
 } from "components/Shareable/Botao/constants";
-import { Field, Form } from "react-final-form";
-import MeusDadosContext from "context/MeusDadosContext";
-import moment from "moment";
-import { textAreaRequired } from "helpers/fieldValidators";
-import ModalCancelarCorrecao from "./components/ModalCancelarCorrecao";
-import { PAINEL_LAYOUT_EMBALAGEM } from "../../../../../../configs/constants";
+import { FluxoDeStatusPreRecebimento } from "components/Shareable/FluxoDeStatusPreRecebimento";
+import { toastError, toastSuccess } from "components/Shareable/Toast/dialogs";
+import {
+  analiseCodaeLayoutEmbalagem,
+  detalharLayoutEmabalagem,
+} from "services/layoutEmbalagem.service";
+
 import ModalCancelarAnalise from "./components/ModalCancelarAnalise";
 import ModalEnviarAnalise from "./components/ModalEnviarAnalise";
-import { analiseCodaeLayoutEmbalagem } from "../../../../../../services/layoutEmbalagem.service";
-import {
-  toastError,
-  toastSuccess,
-} from "../../../../../Shareable/Toast/dialogs";
-import { usuarioComAcessoAoPainelEmbalagens } from "../../../../../../helpers/utilities";
-import { FluxoDeStatusPreRecebimento } from "components/Shareable/FluxoDeStatusPreRecebimento";
+import ModalCancelarCorrecao from "./components/ModalCancelarCorrecao";
+import "./styles.scss";
 
 export default ({ analise }) => {
   const navigate = useNavigate();
@@ -42,6 +46,7 @@ export default ({ analise }) => {
   const [modais, setModais] = useState([]);
   const [modalCancelar, setModalCancelar] = useState(false);
   const [modalEnviar, setModalEnviar] = useState(false);
+  const [initialValues, setInitialValues] = useState({});
 
   const [visaoCODAE, setVisaoCODAE] = useState(null);
 
@@ -52,37 +57,75 @@ export default ({ analise }) => {
     navigate(`/${PRE_RECEBIMENTO}/${PAINEL_LAYOUT_EMBALAGEM}`);
 
   const carregarDados = async () => {
-    setCarregando(true);
-    const urlParams = new URLSearchParams(window.location.search);
-    const uuid = urlParams.get("uuid");
-    const response = await detalharLayoutEmabalagem(uuid);
+    try {
+      setCarregando(true);
+      const urlParams = new URLSearchParams(window.location.search);
+      const uuid = urlParams.get("uuid");
+      const response = await detalharLayoutEmabalagem(uuid);
 
-    const objeto = response.data;
-    objeto.tipos_de_embalagens = objeto.tipos_de_embalagens.sort((a, b) => {
+      const objeto = response.data;
+      objeto.tipos_de_embalagens = ordenarTiposDeEmbalagens(
+        objeto.tipos_de_embalagens
+      );
+      setObjeto(objeto);
+      setVisaoCODAE(usuarioComAcessoAoPainelEmbalagens());
+      setEmbalagemPrimaria(obterImagensEmbalagem(response, "PRIMARIA"));
+      setEmbalagemSecundaria(obterImagensEmbalagem(response, "SECUNDARIA"));
+      setEmbalagemTerciaria(obterImagensEmbalagem(response, "TERCIARIA"));
+
+      const aprovacoesAtualizadas = definirAprovacoes(objeto);
+      setInitialValues(definirInitialValues(objeto, aprovacoesAtualizadas));
+    } finally {
+      setCarregando(false);
+    }
+  };
+
+  const ordenarTiposDeEmbalagens = (tiposDeEmbalagem) =>
+    tiposDeEmbalagem.sort((a, b) => {
       const embalagemA = a.tipo_embalagem.toUpperCase();
       const embalagemB = b.tipo_embalagem.toUpperCase();
+
       if (embalagemA < embalagemB) {
         return -1;
       }
       if (embalagemA > embalagemB) {
         return 1;
       }
+
       return 0;
     });
-
-    setObjeto(objeto);
-    setVisaoCODAE(usuarioComAcessoAoPainelEmbalagens());
-    setEmbalagemPrimaria(obterImagensEmbalagem(response, "PRIMARIA"));
-    setEmbalagemSecundaria(obterImagensEmbalagem(response, "SECUNDARIA"));
-    setEmbalagemTerciaria(obterImagensEmbalagem(response, "TERCIARIA"));
-    setCarregando(false);
-  };
 
   const obterImagensEmbalagem = (response, tipo_embalagem) => {
     return response.data.tipos_de_embalagens
       .filter((e) => e.tipo_embalagem === tipo_embalagem)
       .map((e) => e.imagens)
       .flat();
+  };
+
+  const definirAprovacoes = (objeto) => {
+    if (["Aprovado", "Solicitado Correção"].includes(objeto.status)) {
+      const aprovacoesAtualizadas = objeto.tipos_de_embalagens.map(
+        ({ status }) => (status === "APROVADO" ? true : false)
+      );
+
+      setAprovacoes(aprovacoesAtualizadas);
+      return aprovacoesAtualizadas;
+    }
+  };
+
+  const definirInitialValues = (objeto, aprovacoes) => {
+    return aprovacoes.length > 0 && !analise
+      ? {
+          justificativa_0: objeto.tipos_de_embalagens[0].complemento_do_status,
+          justificativa_1: objeto.tipos_de_embalagens[1].complemento_do_status,
+          justificativa_2:
+            objeto.tipos_de_embalagens[2]?.complemento_do_status || "",
+        }
+      : {
+          justificativa_0: "",
+          justificativa_1: "",
+          justificativa_2: "",
+        };
   };
 
   const changeModal = (index, value) => {
@@ -98,24 +141,29 @@ export default ({ analise }) => {
   };
 
   const retornaTextoAprovacao = (index, values) => {
+    if (!aprovacoes) return;
+
     if (aprovacoes[index] === true) {
-      let texto = values[`justificativa_${index}`].split("|");
+      let texto = values[`justificativa_${index}`]?.split("|");
+
       return (
-        <div className="col-7">
-          <div className="subtitulo d-flex ms-5">
-            <div className="w-5">
-              <i className="fas fa-check me-2" />
-            </div>
-            <div className="w-95">
-              <div>{texto[0]}</div>
-              <div>{texto[1]}</div>
+        texto && (
+          <div className="col-7 d-flex align-items-center">
+            <div className="subtitulo d-flex align-items-center ms-5">
+              <div className="w-5">
+                <i className="fas fa-check me-3 fa-2x" />
+              </div>
+              <div className="w-95">
+                <div>{texto[0]}</div>
+                <div>{texto[1]}</div>
+              </div>
             </div>
           </div>
-        </div>
+        )
       );
     } else if (aprovacoes[index] === false) {
       return (
-        <div className="col-7">
+        <div className="col-7 d-flex align-items-center">
           <Field
             component={TextArea}
             label="Correções Necessárias"
@@ -250,43 +298,8 @@ export default ({ analise }) => {
     (embalagemTerciaria.length === 0 || aprovacoes[2] !== undefined);
 
   useEffect(() => {
-    setCarregando(true);
-
     carregarDados();
-
-    setCarregando(false);
   }, []);
-
-  useEffect(() => {
-    definirAprovacoes();
-    definirInitialValues();
-  }, [visaoCODAE, objeto, aprovacoes]);
-
-  const definirAprovacoes = () => {
-    if (objeto && ["Aprovado", "Solicitado Correção"].includes(objeto.status)) {
-      const aprovacoesAtualizadas = objeto.tipos_de_embalagens.map(
-        (tipoEmbalagem) => (tipoEmbalagem.status === "APROVADO" ? true : false)
-      );
-      setAprovacoes(aprovacoesAtualizadas);
-    }
-  };
-
-  const definirInitialValues = () => {
-    return aprovacoes.length > 0 && !analise
-      ? {
-          justificativa_0: objeto.tipos_de_embalagens[0].complemento_do_status,
-          justificativa_1: objeto.tipos_de_embalagens[1].complemento_do_status,
-          justificativa_2:
-            objeto.tipos_de_embalagens.length === 3
-              ? objeto.tipos_de_embalagens[2].complemento_do_status
-              : "",
-        }
-      : {
-          justificativa_0: "",
-          justificativa_1: "",
-          justificativa_2: "",
-        };
-  };
 
   return (
     <Spin tip="Carregando..." spinning={carregando}>
@@ -376,7 +389,7 @@ export default ({ analise }) => {
 
           <Form
             onSubmit={onSubmit}
-            initialValues={definirInitialValues()}
+            initialValues={initialValues}
             render={({ handleSubmit, values, errors }) => (
               <form onSubmit={handleSubmit}>
                 <ModalCancelarAnalise

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1537,7 +1537,10 @@ const routesConfig = [
   {
     path: `/${constants.LOGISTICA}/${constants.GESTAO_SOLICITACAO_ALTERACAO}`,
     component: GestaoSolicitacaoAlteracaoPage,
-    tipoUsuario: usuarioEhLogistica() || usuarioEhCODAEGabinete(),
+    tipoUsuario:
+      usuarioEhLogistica() ||
+      usuarioEhCODAEGabinete() ||
+      usuarioEhDilogDiretoria(),
   },
   {
     path: `/${constants.LOGISTICA}/${constants.CONSULTA_SOLICITACAO_ALTERACAO}`,

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1625,7 +1625,8 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhCodaeDilog() ||
       usuarioEhDilogJuridico() ||
-      usuarioEhCODAEGabinete(),
+      usuarioEhCODAEGabinete() ||
+      usuarioEhDilogDiretoria(),
   },
   {
     path: `/${constants.LOGISTICA}/${constants.GUIAS_NOTIFICACAO_FISCAL}`,

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -846,7 +846,8 @@ const routesConfig = [
     tipoUsuario:
       usuarioEhCoordenadorCODAE() ||
       usuarioEhCodaeDilog() ||
-      usuarioEhCODAEGabinete(),
+      usuarioEhCODAEGabinete() ||
+      usuarioEhDilogDiretoria(),
   },
   {
     path: `/${constants.CONFIGURACOES}/${constants.GESTAO_ACESSO_DIRETOR_ESCOLA}`,

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -1524,7 +1524,10 @@ const routesConfig = [
   {
     path: `/${constants.LOGISTICA}/${constants.ENVIO_REQUISICOES_ENTREGA_AVANCADO}`,
     component: ConsultaRequisicaoEntregaDilog,
-    tipoUsuario: usuarioEhLogistica() || usuarioEhCODAEGabinete(),
+    tipoUsuario:
+      usuarioEhLogistica() ||
+      usuarioEhCODAEGabinete() ||
+      usuarioEhDilogDiretoria(),
   },
   {
     path: `/${constants.LOGISTICA}/${constants.GESTAO_REQUISICAO_ENTREGA}`,

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -532,6 +532,7 @@ export const usuarioComAcessoAoPainelDocumentos = () => {
     PERFIL.COORDENADOR_CODAE_DILOG_LOGISTICA,
     PERFIL.DILOG_CRONOGRAMA,
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ].includes(localStorage.getItem("perfil"));
 };
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -541,6 +541,7 @@ export const usuarioComAcessoAoPainelFichasTecnicas = () => {
     PERFIL.COORDENADOR_GESTAO_PRODUTO,
     PERFIL.COORDENADOR_CODAE_DILOG_LOGISTICA,
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ].includes(localStorage.getItem("perfil"));
 };
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -1029,12 +1029,13 @@ export const exibirModuloMedicaoInicial = () => {
 
 export const exibirModuloOcorrencias = () => {
   return (
-    (!["production"].includes(ENVIRONMENT) &&
-      (usuarioEhCodaeDilog() ||
-        usuarioEhDilogJuridico() ||
-        usuarioEhDilogQualidade() ||
-        usuarioEhDilog())) ||
-    usuarioEhCODAEGabinete()
+    !["production"].includes(ENVIRONMENT) &&
+    (usuarioEhCodaeDilog() ||
+      usuarioEhDilogJuridico() ||
+      usuarioEhDilogQualidade() ||
+      usuarioEhDilog() ||
+      usuarioEhCODAEGabinete() ||
+      usuarioEhDilogDiretoria())
   );
 };
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -491,6 +491,7 @@ export const usuarioComAcessoTelaDetalharNotificacaoOcorrencia = () => {
     PERFIL.COORDENADOR_CODAE_DILOG_LOGISTICA,
     PERFIL.ADMINISTRADOR_CODAE_DILOG_JURIDICO,
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ].includes(localStorage.getItem("perfil"));
 };
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -522,6 +522,7 @@ export const usuarioComAcessoAoPainelEmbalagens = () => {
     PERFIL.COORDENADOR_GESTAO_PRODUTO,
     PERFIL.COORDENADOR_CODAE_DILOG_LOGISTICA,
     PERFIL.ADMINISTRADOR_CODAE_GABINETE,
+    PERFIL.DILOG_DIRETORIA,
   ].includes(localStorage.getItem("perfil"));
 };
 

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -571,7 +571,10 @@ export const usuarioEhPreRecebimento = () => {
 };
 
 export const usuarioEhPreRecebimentoSemLogistica = () => {
-  return localStorage.getItem("tipo_perfil") === TIPO_PERFIL.PRE_RECEBIMENTO;
+  return (
+    localStorage.getItem("tipo_perfil") === TIPO_PERFIL.PRE_RECEBIMENTO &&
+    !usuarioEhDilogDiretoria()
+  );
 };
 
 export const usuarioEhDinutreDiretoria = () =>

--- a/src/pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoAprovados.tsx
+++ b/src/pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoAprovados.tsx
@@ -4,6 +4,7 @@ import Breadcrumb from "components/Shareable/Breadcrumb";
 import {
   PAINEL_DOCUMENTOS_RECEBIMENTO,
   PRE_RECEBIMENTO,
+  DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO,
 } from "configs/constants";
 import { getDashboardDocumentosRecebimentoPorStatus } from "services/documentosRecebimento.service";
 import { SolicitacoesDocumentoStatusGenerico } from "components/screens/SolicitacoesDocumentoStatusGenerico";
@@ -48,7 +49,7 @@ export default () => {
         getSolicitacoes={getDashboardDocumentosRecebimentoPorStatus}
         params={paramsDefault}
         limit={limit}
-        urlBaseItem={``}
+        urlBaseItem={`/${PRE_RECEBIMENTO}/${DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO}`}
       />
     </Page>
   );

--- a/src/pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoEnviadosParaCorrecao.tsx
+++ b/src/pages/PreRecebimento/CardsDocumentosRecebimento/StatusDocumentoEnviadosParaCorrecao.tsx
@@ -4,6 +4,7 @@ import Breadcrumb from "components/Shareable/Breadcrumb";
 import {
   PAINEL_DOCUMENTOS_RECEBIMENTO,
   PRE_RECEBIMENTO,
+  DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO,
 } from "configs/constants";
 import { getDashboardDocumentosRecebimentoPorStatus } from "services/documentosRecebimento.service";
 import { SolicitacoesDocumentoStatusGenerico } from "components/screens/SolicitacoesDocumentoStatusGenerico";
@@ -48,7 +49,7 @@ export default () => {
         getSolicitacoes={getDashboardDocumentosRecebimentoPorStatus}
         params={paramsDefault}
         limit={limit}
-        urlBaseItem={``}
+        urlBaseItem={`/${PRE_RECEBIMENTO}/${DETALHAR_CODAE_DOCUMENTO_RECEBIMENTO}`}
       />
     </Page>
   );

--- a/src/pages/PreRecebimento/FichaTecnica/AnalisarFichaTecnicaPage.tsx
+++ b/src/pages/PreRecebimento/FichaTecnica/AnalisarFichaTecnicaPage.tsx
@@ -8,7 +8,10 @@ import {
   PRE_RECEBIMENTO,
 } from "configs/constants";
 import Analisar from "components/screens/PreRecebimento/FichaTecnica/components/Analisar";
-import { usuarioEhCODAEGabinete } from "helpers/utilities";
+import {
+  usuarioEhCODAEGabinete,
+  usuarioEhDilogDiretoria,
+} from "helpers/utilities";
 
 const atual = {
   href: `/${PRE_RECEBIMENTO}/${ANALISAR_FICHA_TECNICA}`,
@@ -25,7 +28,8 @@ const anteriores = [
     titulo: "Fichas Técnicas",
   },
 ];
-const somenteLeitura = usuarioEhCODAEGabinete() ? true : false;
+
+const somenteLeitura = usuarioEhCODAEGabinete() || usuarioEhDilogDiretoria();
 
 export default () => (
   <Page

--- a/src/services/layoutEmbalagem.service.js
+++ b/src/services/layoutEmbalagem.service.js
@@ -14,8 +14,13 @@ export const listarLayoutsEmbalagens = async (params) => {
   }
 };
 
-export const detalharLayoutEmabalagem = async (uuid) =>
-  await axios.get(`/layouts-de-embalagem/${uuid}/`);
+export const detalharLayoutEmabalagem = async (uuid) => {
+  try {
+    return await axios.get(`/layouts-de-embalagem/${uuid}/`);
+  } catch (error) {
+    toastError(getMensagemDeErro(error.response.status));
+  }
+};
 
 export const getDashboardLayoutEmbalagem = async (params = null) =>
   await axios.get(`/layouts-de-embalagem/dashboard/`, { params });


### PR DESCRIPTION
# Este PR:

- Libera o acesso às seguintes funcionalidades pro perfil DILOG_DIRETORIA (com permissões somente de leitura):
  - Menu Abastecimento
    - Submenu Requisição de Entrega
    - Submenu Alteração da Requisição
    - Submenu Ocorrências
      - Item de menu Guias com Notificações
  - Menu Pré-Recebimento
    - Submenu Layout de Embalagens
    - Submenu Documentos de Recebimento
    - Submenu Fichas Técnicas
  - Menu Configurações
    - Submenu Gestão de Usuário
      - Item de menu Gestão de Acesso
- Corrige carregamento da página de Detalhar Layout de Embalagem
- Melhora estilização do texto de aprovação dos Layouts de Embalagem
- Corrige links dos itens nas páginas de  Ver Mais dos cards de Aprovados e Enviados para Correção no painel de Documentos de Recebimento
- Corrige alinhamento do tooltip nos itens das páginas de Ver Mais
- Corrige estilização dos botões desabilitados no componente ListagemVinculos

### Referência Azure:

- 115799