### PR TITLE
Bugfix/117780 duplica seletor ficha

### DIFF
--- a/src/components/screens/PreRecebimento/CadastroCronograma/helpers.js
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/helpers.js
@@ -13,8 +13,7 @@ export const getOpcoesContrato = (empresaSelecionada) => {
 
 export const geraOptionsFichasTecnicas = (
   fichasTecnicas,
-  empresaSelecionada,
-  fichaTecnicaSelecionada
+  empresaSelecionada
 ) => {
   const options = fichasTecnicas
     .filter((ficha) => ficha.uuid_empresa === empresaSelecionada?.uuid)
@@ -23,12 +22,6 @@ export const geraOptionsFichasTecnicas = (
         nome: formatarNumeroEProdutoFichaTecnica(ficha),
         uuid: ficha.uuid,
       };
-    });
-
-  fichaTecnicaSelecionada &&
-    options.unshift({
-      nome: formatarNumeroEProdutoFichaTecnica(fichaTecnicaSelecionada),
-      uuid: fichaTecnicaSelecionada.uuid,
     });
 
   return options;

--- a/src/components/screens/PreRecebimento/CadastroCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/index.jsx
@@ -522,7 +522,6 @@ export default () => {
                                 <Field
                                   className="input-cronograma"
                                   component={Select}
-                                  naoDesabilitarPrimeiraOpcao
                                   options={[
                                     {
                                       nome: "Selecione uma Ficha Técnica de Produto",
@@ -530,8 +529,7 @@ export default () => {
                                     },
                                     ...geraOptionsFichasTecnicas(
                                       fichasTecnicas,
-                                      empresaSelecionada,
-                                      fichaTecnicaSelecionada
+                                      empresaSelecionada
                                     ),
                                   ]}
                                   label="Ficha Técnica e Produto"


### PR DESCRIPTION
Este PR:
- corrige bug em que a ficha tecnica selecionada se duplicava no seletor de ficha tecnica no cadastro de cronograma