### PR TITLE
Fix/117125-DE-dietas-negadas-retirar-dados-nutri-ajuste-dre

### DIFF
--- a/src/components/Shareable/FluxoDeStatus/index.jsx
+++ b/src/components/Shareable/FluxoDeStatus/index.jsx
@@ -135,7 +135,7 @@ export const FluxoDeStatus = (props) => {
                 status.status_evento_explicacao === "CODAE negou" &&
                 [
                   TIPO_PERFIL.ESCOLA,
-                  TIPO_PERFIL.DRE,
+                  TIPO_PERFIL.DIRETORIA_REGIONAL,
                   TIPO_PERFIL.TERCEIRIZADA,
                   TIPO_PERFIL.SUPERVISAO_NUTRICAO,
                   TIPO_PERFIL.NUTRICAO_MANIFESTACAO,


### PR DESCRIPTION
**### Este PR visa:**

- ajusta tipo perfil dre para retirar dados da nutri de dietas negadas

**Referência:**
117125