### PR TITLE
Feature/118425 alteracao toast documentos de recebimento

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/InserirDocumento/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/InserirDocumento/index.tsx
@@ -66,7 +66,7 @@ const InserirDocumento: React.FC<Props> = ({
           accept={formatosAceitos}
           setFiles={setFiles}
           removeFile={removeFile}
-          toastSuccess={"Imagem incluída com sucesso!"}
+          toastSuccess={"Documento incluído com sucesso!"}
           alignLeft
           multiple={multiplosArquivos}
           limiteTamanho={DEZ_MB}

--- a/src/services/cronograma.service.js
+++ b/src/services/cronograma.service.js
@@ -26,8 +26,13 @@ export const getListagemCronogramas = async (params) => {
   return await axios.get(url, { params });
 };
 
-export const getListaCronogramasPraCadastro = async () =>
-  await axios.get("/cronogramas/lista-cronogramas-cadastro/");
+export const getListaCronogramasPraCadastro = async () => {
+  try {
+    return await axios.get("/cronogramas/lista-cronogramas-cadastro/");
+  } catch (error) {
+    toastError(getMensagemDeErro(error.response.status));
+  }
+};
 
 export const fornecedorAssinaCronograma = async (uuid, password) => {
   const url = `/cronogramas/${uuid}/fornecedor-assina-cronograma/`;


### PR DESCRIPTION
# Este PR:

- Altera texto do toast de sucesso ao inserir um documento na tela de cadastar Documentos de Recebimento.
- Aplica tratamento de erros padrão ao service getListaCronogramasPraCadastro.

### Referência Azure:

- 118425