### PR TITLE
Feature/117402 questoes por produto copiar atribuicoes

### DIFF
--- a/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/index.tsx
+++ b/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/index.tsx
@@ -6,6 +6,7 @@ import Label from "components/Shareable/Label";
 import {
   RECEBIMENTO,
   EDITAR_ATRIBUICAO_QUESTOES_CONFERENCIA,
+  COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA,
 } from "configs/constants";
 
 import "./styles.scss";
@@ -38,7 +39,23 @@ const Listagem = ({ questoesPorProdutos }: ListagemProps) => {
       </NavLink>
     );
 
-    return botaoEditar;
+    const botaoCopiar = (
+      <NavLink
+        className="float-start"
+        to={`/${RECEBIMENTO}/${COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA}?uuid=${questao.uuid}`}
+      >
+        <span className="link-acoes px-2">
+          <i title="Fazer Cópia" className="fas fa-copy green" />
+        </span>
+      </NavLink>
+    );
+
+    return (
+      <>
+        {botaoEditar}
+        {botaoCopiar}
+      </>
+    );
   };
 
   const fecharCollapsesQuestoes = () => {
@@ -110,7 +127,7 @@ const Listagem = ({ questoesPorProdutos }: ListagemProps) => {
                       : "Ver Questões Atribuídas"}
                   </span>
                 </div>
-                <div>{renderizarAcoes(questao)}</div>
+                <div className="coluna-acoes">{renderizarAcoes(questao)}</div>
               </div>
 
               <div

--- a/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/index.tsx
+++ b/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/index.tsx
@@ -42,7 +42,9 @@ const Listagem = ({ questoesPorProdutos }: ListagemProps) => {
     const botaoCopiar = (
       <NavLink
         className="float-start"
-        to={`/${RECEBIMENTO}/${COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA}?uuid=${questao.uuid}`}
+        to={`/${RECEBIMENTO}/${COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA}?uuid=${
+          questao.uuid
+        }&copia=${true}`}
       >
         <span className="link-acoes px-2">
           <i title="Fazer Cópia" className="fas fa-copy green" />

--- a/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/styles.scss
+++ b/src/components/screens/Recebimento/QuestoesPorProduto/components/Listagem/styles.scss
@@ -27,7 +27,7 @@
       display: grid;
       align-items: center;
       text-align: center;
-      grid-template-columns: 2fr 10fr 5fr 1fr;
+      grid-template-columns: 3fr 10fr 5fr 2fr;
     }
 
     .header-table {
@@ -59,8 +59,11 @@
         color: $green;
       }
 
-      .actions {
+      .coluna-acoes {
         display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 0;
       }
 
       .link-acoes {

--- a/src/configs/RoutesConfig.js
+++ b/src/configs/RoutesConfig.js
@@ -311,6 +311,7 @@ import EditaisContratosEditarPage from "../pages/Cadastros/EditaisContratosEdita
 import QuestoesPorProdutoPage from "../pages/Recebimento/QuestoesPorProduto/QuestoesPorProdutoPage";
 import AtribuirQuestoesPage from "../pages/Recebimento/QuestoesPorProduto/AtribuirQuestoesPage";
 import EditarAtribuicaoQuestoesPage from "../pages/Recebimento/QuestoesPorProduto/EditarAtribuicaoQuestoesPage";
+import CopiarAtribuicaoQuestoesPage from "../pages/Recebimento/QuestoesPorProduto/CopiarAtribuicaoQuestoesPage";
 
 const routesConfig = [
   {
@@ -2045,6 +2046,11 @@ const routesConfig = [
   {
     path: `/${constants.RECEBIMENTO}/${constants.EDITAR_ATRIBUICAO_QUESTOES_CONFERENCIA}`,
     component: EditarAtribuicaoQuestoesPage,
+    tipoUsuario: usuarioEhRecebimento(),
+  },
+  {
+    path: `/${constants.RECEBIMENTO}/${constants.COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA}`,
+    component: CopiarAtribuicaoQuestoesPage,
     tipoUsuario: usuarioEhRecebimento(),
   },
 ];

--- a/src/configs/constants.js
+++ b/src/configs/constants.js
@@ -302,6 +302,8 @@ export const QUESTOES_POR_PRODUTO = "questoes-por-produto";
 export const ATRIBUIR_QUESTOES_CONFERENCIA = "atribuir-questoes-conferencia";
 export const EDITAR_ATRIBUICAO_QUESTOES_CONFERENCIA =
   "editar-atribuicao-questoes-conferencia";
+export const COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA =
+  "copiar-atribuicao-questoes-conferencia";
 
 // Status dos pedidos
 

--- a/src/pages/Recebimento/QuestoesPorProduto/CopiarAtribuicaoQuestoesPage.tsx
+++ b/src/pages/Recebimento/QuestoesPorProduto/CopiarAtribuicaoQuestoesPage.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+import { HOME } from "constants/config";
+import {
+  RECEBIMENTO,
+  QUESTOES_POR_PRODUTO,
+  COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA,
+} from "configs/constants";
+import Page from "components/Shareable/Page/Page";
+import Breadcrumb from "components/Shareable/Breadcrumb";
+import AtribuirQuestoes from "components/screens/Recebimento/QuestoesPorProduto/AtribuirQuestoes";
+
+const atual = {
+  href: `/${RECEBIMENTO}/${COPIAR_ATRIBUICAO_QUESTOES_CONFERENCIA}`,
+  titulo: "Copiar Questões para Conferência",
+};
+
+const anteriores = [
+  {
+    href: `/`,
+    titulo: "Recebimento",
+  },
+  {
+    href: `/${RECEBIMENTO}/${QUESTOES_POR_PRODUTO}`,
+    titulo: "Questões por Produto",
+  },
+];
+
+export default () => (
+  <Page
+    botaoVoltar
+    voltarPara={anteriores[anteriores.length - 1].href}
+    titulo={atual.titulo}
+  >
+    <Breadcrumb home={HOME} atual={atual} anteriores={anteriores} />
+    <AtribuirQuestoes />
+  </Page>
+);


### PR DESCRIPTION
# Este PR:

- Adiciona botão Fazer Cópia na listagem de resultados
- Cria página e rota de Copiar Questões para Conferência
- Parametriza screen de Atribuir Questões com base nos search params "uuid" e "copia" para permitir carregamento das questões de uma outra ficha

### Referência Azure:

- 117402