### PR TITLE
Hotfix/121010 lancamento mi cei valor negativo

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -888,7 +888,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
         dadosValoresMatriculadosFaixaEtariaDia[
           `matriculados__faixa_${objMatriculado.faixa_etaria.uuid}__dia_${objMatriculado.dia}__categoria_${idCategoriaAlimentacao}`
         ] = objMatriculado.quantidade
-          ? `${objMatriculado.quantidade - somaDietasMesmoDia}`
+          ? `${Math.max(objMatriculado.quantidade - somaDietasMesmoDia, 0)}`
           : null;
       });
 


### PR DESCRIPTION
# Este PR:
- corrige bug de valor negativo na faixa etária do lançamento de medição inicial

### Referência azure:
- AB#121010