### PR TITLE
Feature/120763 remocao obrigatoriedade outros documentos

### DIFF
--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
@@ -157,10 +157,14 @@ export default () => {
 
   const validaArquivos = (values: Record<string, any>): boolean => {
     let laudoInvalido = laudo.length === 0;
-    let documentoValido = values.tipos_de_documentos?.every((valor: string) => {
-      return documentos[valor]?.length > 0;
-    });
-    return laudoInvalido || !documentoValido;
+
+    let documentosValidos = values.tipos_de_documentos
+      ? values.tipos_de_documentos?.every((valor: string) => {
+          return documentos[valor]?.length > 0;
+        })
+      : true;
+
+    return laudoInvalido || !documentosValidos;
   };
 
   const optionsCronograma = (values: Record<string, any>) =>

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
@@ -98,7 +98,12 @@ export default () => {
   };
 
   const formataPayload = (values): DocumentosRecebimentoPayload => {
-    let documentosPayload: Array<TiposDocumentosPayload> =
+    let documentoLaudo = {
+      tipo_documento: "LAUDO",
+      arquivos_do_tipo_de_documento: laudo,
+    };
+
+    let outrosDocumentos =
       values.tipos_de_documentos?.map(
         (valor: TiposDocumentoChoices): TiposDocumentosPayload => {
           return {
@@ -108,12 +113,12 @@ export default () => {
               valor === "OUTROS" ? values.descricao_documento : undefined,
           };
         }
-      );
+      ) ?? [];
 
-    documentosPayload.push({
-      tipo_documento: "LAUDO",
-      arquivos_do_tipo_de_documento: laudo,
-    });
+    let documentosPayload: Array<TiposDocumentosPayload> = [
+      documentoLaudo,
+      ...outrosDocumentos,
+    ];
 
     let payload: DocumentosRecebimentoPayload = {
       cronograma: cronogramas.find(({ numero }) => numero === values.cronograma)

--- a/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/DocumentosRecebimento/components/Cadastrar/index.tsx
@@ -264,8 +264,6 @@ export default () => {
                       nomeDoItemNoPlural="documentos"
                       options={OUTROS_DOCUMENTOS_OPTIONS}
                       placeholder="Selecione o documento"
-                      required
-                      validate={required}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
# Este PR:

- Remove obrigatoriedade do campo Outros Documentos ao cadastrar um novo Documento de Recebimento
- Ajusta lógica que desabilita botão Salvar e Enviar na tela Cadastrar Documentos de Recebimento para que seja possível cadastrar um novo Documento sem preencher o campo Outros Documento, mas mantendo a validação de obrigatoriedade para quando itens forem selecionados.

### Referência Azure:

- 120763