### PR TITLE
Hotfix/corrige-label-rastro-terceirizada

### DIFF
--- a/src/components/AlteracaoDeCardapioCEMEI/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/AlteracaoDeCardapioCEMEI/Relatorio/componentes/CorpoRelatorio.jsx
@@ -107,7 +107,7 @@ export const CorpoRelatorio = ({ ...props }) => {
         <div className="col-3">
           <p>Empresa:</p>
           <p>
-            <b>{solicitacao.escola.lote.terceirizada.nome_fantasia}</b>
+            <b>{solicitacao.rastro_terceirizada?.nome_fantasia}</b>
           </p>
         </div>
       </div>

--- a/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
+++ b/src/components/InclusaoDeAlimentacao/Relatorio/componentes/CorpoRelatorio.jsx
@@ -285,10 +285,7 @@ export const CorpoRelatorio = ({ ...props }) => {
         <div className="col-3 report-label-value">
           <p>Empresa</p>
           <p className="value-important">
-            {inclusaoDeAlimentacao.escola &&
-              inclusaoDeAlimentacao.escola.lote &&
-              inclusaoDeAlimentacao.escola.lote.terceirizada &&
-              inclusaoDeAlimentacao.escola.lote.terceirizada.nome_fantasia}
+            {inclusaoDeAlimentacao.rastro_terceirizada?.nome_fantasia}
           </p>
         </div>
       </div>


### PR DESCRIPTION
# Este PR:
- corrige label da empresa que deveria vir do `rastro_terceirizada` ao invés da empresa dentro do lote atual