### PR TITLE
Feature/137369 visualizar dados laudo ficha

### DIFF
--- a/src/components/screens/Recebimento/FichaRecebimento/__tests__/Detalhar/index.test.tsx
+++ b/src/components/screens/Recebimento/FichaRecebimento/__tests__/Detalhar/index.test.tsx
@@ -129,6 +129,15 @@ describe("Testes de pagína de Detalhes da Ficha de Recebimento", () => {
     expect(tagLeveLeite).toBeInTheDocument();
     expect(tagLeveLeite).toHaveTextContent("LEVE LEITE - PLL");
   });
+
+  it("Exibe a coluna Qtde Recebida na tabela de Laudos com valor formatado", async () => {
+    const collapseTitulo = screen.getByText("Laudos");
+    fireEvent.click(collapseTitulo);
+
+    expect(screen.getByText("Qtde Recebida")).toBeInTheDocument();
+
+    expect(await screen.findByText("13.000,00 kg")).toBeInTheDocument();
+  });
 });
 
 describe("Testes quando reposicao_cronograma.tipo é Credito", () => {

--- a/src/components/screens/Recebimento/FichaRecebimento/components/Detalhar/index.tsx
+++ b/src/components/screens/Recebimento/FichaRecebimento/components/Detalhar/index.tsx
@@ -241,6 +241,7 @@ export default () => {
                           <th className="borda-crono">Lote(s) do Laudo</th>
                           <th className="borda-crono">Data(s) Fabricação</th>
                           <th className="borda-crono">Data(s) Validade</th>
+                          <th className="borda-crono">Qtde Recebida</th>
                         </thead>
                         <tbody>
                           {dadosCronograma?.documentos_de_recebimento?.map(
@@ -258,6 +259,17 @@ export default () => {
                                   </td>
                                   <td className="borda-crono">
                                     {documento.datas_validade}
+                                  </td>
+                                  <td className="borda-crono">
+                                    {formataMilharDecimal(
+                                      (
+                                        fichaRecebimento?.documentos_recebimento as any[]
+                                      )?.find(
+                                        (doc: any) =>
+                                          doc.uuid === documento.uuid,
+                                      )?.quantidade_recebida,
+                                    )}{" "}
+                                    {etapa.unidade_medida}
                                   </td>
                                 </tr>
                               );

--- a/src/mocks/services/fichaRecebimento.service/mockGetFichaRecebimentoDetalhada.tsx
+++ b/src/mocks/services/fichaRecebimento.service/mockGetFichaRecebimentoDetalhada.tsx
@@ -20,6 +20,7 @@ export const mockGetFichaRecebimentoDetalhada = {
     data_programada: "22/04/2024",
     quantidade: 13000.0,
     total_embalagens: 1182.0,
+    unidade_medida: "kg",
   },
   data_entrega: "01/09/2025",
   documentos_recebimento: [
@@ -29,6 +30,7 @@ export const mockGetFichaRecebimentoDetalhada = {
       numero_lote_laudo: "23",
       datas_fabricacao: "12/08/2025",
       datas_validade: "31/08/2025",
+      quantidade_recebida: 13000.0,
     },
   ],
   lote_fabricante_de_acordo: true,


### PR DESCRIPTION
Este PR:
- inclui dados de qtde recebida da ficha na tela de detalhar
- complementa testes unitarios

[AB#137369](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/137369)