### PR TITLE
fix(145275): Ajusta tratamento de erro para evitar que loading fique travado ao falhar requisição

### DIFF
--- a/src/components/screens/PreRecebimento/Relatorios/RelatorioCronograma/index.tsx
+++ b/src/components/screens/PreRecebimento/Relatorios/RelatorioCronograma/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "src/components/Shareable/Botao/constants";
 import { toastError } from "src/components/Shareable/Toast/dialogs";
 import ModalSolicitacaoDownload from "src/components/Shareable/ModalSolicitacaoDownload";
+import { getMensagemDeErro } from "src/helpers/statusErrors";
 
 export default () => {
   const [carregando, setCarregando] = useState<boolean>(false);
@@ -40,16 +41,21 @@ export default () => {
   const buscarResultados = async (page) => {
     setCarregando(true);
     const params = gerarParametrosConsulta({ page: page, ...filtros });
-    const response = await getListagemRelatorioCronogramas(params);
-    setAtivos([]);
-    setCronogramas(response.data.results);
-    setTotalizadores({
-      "Total de Cronogramas Criados": response.data.count,
-      ...response.data.totalizadores,
-    });
-    setTotalResultados(response.data.count);
-    setConsultaRealizada(true);
-    setCarregando(false);
+    try {
+      const response = await getListagemRelatorioCronogramas(params);
+      setAtivos([]);
+      setCronogramas(response.data.results);
+      setTotalizadores({
+        "Total de Cronogramas Criados": response.data.count,
+        ...response.data.totalizadores,
+      });
+      setTotalResultados(response.data.count);
+      setConsultaRealizada(true);
+    } catch (error) {
+      toastError(getMensagemDeErro(error.response?.status));
+    } finally {
+      setCarregando(false);
+    }
   };
 
   const nextPage = (page: number) => {

--- a/src/services/cronograma.service.jsx
+++ b/src/services/cronograma.service.jsx
@@ -27,15 +27,10 @@ export const getListagemCronogramas = async (params) => {
 };
 
 export const getListagemRelatorioCronogramas = async (params) => {
-  try {
-    const response = await axios.get("/cronogramas/listagem-relatorio/", {
-      params,
-    });
-    return response;
-  } catch (error) {
-    toastError(getMensagemDeErro(error.response?.status));
-    throw error;
-  }
+  const response = await axios.get("/cronogramas/listagem-relatorio/", {
+    params,
+  });
+  return response;
 };
 
 export const getListaCronogramasPraCadastro = async () => {


### PR DESCRIPTION
Esse pull request:

-  Correção no gerenciamento de loading durante erro na busca de relatório

**Referência no Azure:** [AB#145275](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/145275)