### PR TITLE
Feature/146511 remover tolltip verde nas repeticoes alimentacao

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_com_suspensao.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_com_suspensao.test.jsx
@@ -285,4 +285,94 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> com suspensão cancelada parci
 
     expect(inputElementLancheDia31).not.toHaveClass("border-warning");
   });
+
+  it("ao clicar na tab `Semana 5`, preencher repetição de refeição maior que refeição no dia 27, e NÃO exibe tooltip verde", async () => {
+    await awaitServices();
+    const semana5Element = screen.getByText("Semana 5");
+    fireEvent.click(semana5Element);
+
+    const inputElementFrequenciaDia27 = screen.getByTestId(
+      "frequencia__dia_27__categoria_1",
+    );
+    fireEvent.change(inputElementFrequenciaDia27, {
+      target: { value: "50" },
+    });
+
+    const inputRefeicaoDia27 = screen.getByTestId(
+      "refeicao__dia_27__categoria_1",
+    );
+
+    fireEvent.change(inputRefeicaoDia27, {
+      target: { value: "45" },
+    });
+    const inputRepeticaoRefeicaoDia27 = screen.getByTestId(
+      "repeticao_refeicao__dia_27__categoria_1",
+    );
+    waitFor(() => {
+      fireEvent.change(inputRepeticaoRefeicaoDia27, {
+        target: { value: "48" },
+      });
+    });
+    expect(inputRepeticaoRefeicaoDia27).not.toHaveClass("icone-info-success");
+  });
+
+  it("ao clicar na tab `Semana 5`, preencher repetição de sobremesa maior que sobremesa no dia 27, e NÃO exibe tooltip verde", async () => {
+    await awaitServices();
+    const semana5Element = screen.getByText("Semana 5");
+    fireEvent.click(semana5Element);
+
+    const inputElementFrequenciaDia27 = screen.getByTestId(
+      "frequencia__dia_27__categoria_1",
+    );
+    fireEvent.change(inputElementFrequenciaDia27, {
+      target: { value: "68" },
+    });
+
+    const inputRefeicaoDia27 = screen.getByTestId(
+      "sobremesa__dia_27__categoria_1",
+    );
+
+    fireEvent.change(inputRefeicaoDia27, {
+      target: { value: "53" },
+    });
+    const inputRepeticaoRefeicaoDia27 = screen.getByTestId(
+      "repeticao_sobremesa__dia_27__categoria_1",
+    );
+    waitFor(() => {
+      fireEvent.change(inputRepeticaoRefeicaoDia27, {
+        target: { value: "62" },
+      });
+    });
+    expect(inputRepeticaoRefeicaoDia27).not.toHaveClass("icone-info-success");
+  });
+
+  it("ao clicar na tab `Semana 5`, preencher repetição 2ª refeição maior que 2ª refeição  no dia 27, e NÃO exibe tooltip verde", async () => {
+    await awaitServices();
+    const semana5Element = screen.getByText("Semana 5");
+    fireEvent.click(semana5Element);
+
+    const inputElementFrequenciaDia27 = screen.getByTestId(
+      "frequencia__dia_27__categoria_1",
+    );
+    fireEvent.change(inputElementFrequenciaDia27, {
+      target: { value: "30" },
+    });
+
+    const inputRefeicaoDia27 = screen.getByTestId(
+      "2_refeicao_1_oferta__dia_27__categoria_1",
+    );
+
+    fireEvent.change(inputRefeicaoDia27, {
+      target: { value: "23" },
+    });
+    const inputRepeticaoRefeicaoDia27 = screen.getByTestId(
+      "repeticao_2_refeicao__dia_27__categoria_1",
+    );
+    waitFor(() => {
+      fireEvent.change(inputRepeticaoRefeicaoDia27, {
+        target: { value: "29" },
+      });
+    });
+    expect(inputRepeticaoRefeicaoDia27).not.toHaveClass("icone-info-success");
+  });
 });

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/lancamento_EMEF.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/lancamento_EMEF.test.jsx
@@ -648,7 +648,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       expect(botao).toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
       await awaitServices();
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
@@ -670,15 +670,14 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_refeicao__dia_05__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();
       expect(botao).not.toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e não exibe tooltip verde", async () => {
       await awaitServices();
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
@@ -702,8 +701,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_sobremesa__dia_05__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();
@@ -949,7 +947,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       expect(botao).toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 2`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 2`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
       await awaitServices();
       const semana2Element = screen.getByText("Semana 2");
       fireEvent.click(semana2Element);
@@ -978,15 +976,14 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_refeicao__dia_08__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();
       expect(botao).not.toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 2`, preencher repetição de sobremesa maior que sobremesa e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 2`, preencher repetição de sobremesa maior que sobremesa e não exibe tooltip verde", async () => {
       await awaitServices();
       const semana2Element = screen.getByText("Semana 2");
       fireEvent.click(semana2Element);
@@ -1017,8 +1014,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Recreio Nas Féri
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_sobremesa__dia_08__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/lancamento_colaboradores_EMEF.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/lancamento_colaboradores_EMEF.test.jsx
@@ -563,7 +563,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Colaboradores - E
     expect(botao).toBeDisabled();
   });
 
-  it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+  it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
     await awaitServices();
     const semana1Element = screen.getByText("Semana 1");
     fireEvent.click(semana1Element);
@@ -585,8 +585,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Colaboradores - E
     const tooltip = document.querySelector(
       '[data-test-id="tooltip_repeticao_refeicao__dia_03__categoria_1"]',
     );
-    expect(tooltip).not.toBeNull();
-    expect(tooltip).toHaveClass("icone-info-success");
+    expect(tooltip).toBeNull();
 
     const botao = screen.getByText("Salvar Lançamentos").closest("button");
     expect(botao).toBeInTheDocument();
@@ -714,7 +713,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Colaboradores - E
     expect(botao).toBeDisabled();
   });
 
-  it("ao clicar na tab `Semana 2`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+  it("ao clicar na tab `Semana 2`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
     await awaitServices();
     const semana2Element = screen.getByText("Semana 2");
     fireEvent.click(semana2Element);
@@ -743,8 +742,8 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> para o Grupo Colaboradores - E
     const tooltip = document.querySelector(
       '[data-test-id="tooltip_repeticao_refeicao__dia_08__categoria_1"]',
     );
-    expect(tooltip).not.toBeNull();
-    expect(tooltip).toHaveClass("icone-info-success");
+
+    expect(tooltip).toBeNull();
 
     const botao = screen.getByText("Salvar Lançamentos").closest("button");
     expect(botao).toBeInTheDocument();

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -110,7 +110,6 @@ import {
   exibirTooltipLPRAutorizadas,
   exibirTooltipPadraoRepeticaoDiasSobremesaDoce,
   exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas,
-  exibirTooltipRepeticao,
   exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero,
   exibirTooltipRPLAutorizadas,
   exibirTooltipSuspensoesAutorizadas,
@@ -3582,13 +3581,6 @@ export default () => {
                                                             categoria,
                                                             diasSobremesaDoce,
                                                             location,
-                                                          )}
-                                                          exibeTooltipRepeticao={exibirTooltipRepeticao(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            diasSobremesaDoce,
                                                           )}
                                                           exibeTooltipAlimentacoesAutorizadasDiaNaoLetivo={
                                                             `${row.name}__dia_${column.dia}__categoria_${categoria.id}` in

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/EMEI/lancamento_inclusao_fim_de_semana.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/EMEI/lancamento_inclusao_fim_de_semana.test.jsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { act, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import { MODULO_GESTAO, PERFIL, TIPO_PERFIL } from "src/constants/shared";
@@ -13,6 +19,7 @@ import { mockMatriculadosNoMesCEMEIEMEIINTEGRALAgosto2025 } from "src/mocks/medi
 import { mockMeusDadosEscolaCEMEI } from "src/mocks/meusDados/escola/CEMEI";
 import { PeriodoLancamentoMedicaoInicialCEIPage } from "src/pages/LancamentoMedicaoInicial/PeriodoLancamentoMedicaoInicialCEIPage";
 import mock from "src/services/_mock";
+import preview from "jest-preview";
 
 describe("Testes de inclusão de lançamento em fim de semana", () => {
   beforeEach(async () => {
@@ -129,5 +136,58 @@ describe("Testes de inclusão de lançamento em fim de semana", () => {
       "frequencia__dia_03__categoria_1",
     );
     expect(inputDiaFrequenciaDia2).toBeDisabled();
+    preview.debug();
+  });
+
+  it("renderiza input do dia 01/08/2025, preencher repetição de refeição maior que refeição no dia 27, e NÃO exibe tooltip verde", async () => {
+    const inputElementFrequenciaDia1 = screen.getByTestId(
+      "frequencia__dia_01__categoria_1",
+    );
+    fireEvent.change(inputElementFrequenciaDia1, {
+      target: { value: "50" },
+    });
+
+    const inputRefeicaoDia1 = screen.getByTestId(
+      "refeicao__dia_01__categoria_1",
+    );
+
+    fireEvent.change(inputRefeicaoDia1, {
+      target: { value: "45" },
+    });
+    const inputRepeticaoRefeicaoDia1 = screen.getByTestId(
+      "repeticao_refeicao__dia_01__categoria_1",
+    );
+    waitFor(() => {
+      fireEvent.change(inputRepeticaoRefeicaoDia1, {
+        target: { value: "48" },
+      });
+    });
+    expect(inputRepeticaoRefeicaoDia1).not.toHaveClass("icone-info-success");
+  });
+
+  it("renderiza input do dia 01/08/2025, preencher repetição de sobremesa maior que sobremesa no dia 27, e NÃO exibe tooltip verde", async () => {
+    const inputElementFrequenciaDia1 = screen.getByTestId(
+      "frequencia__dia_01__categoria_1",
+    );
+    fireEvent.change(inputElementFrequenciaDia1, {
+      target: { value: "68" },
+    });
+
+    const inputRefeicaoDia1 = screen.getByTestId(
+      "sobremesa__dia_01__categoria_1",
+    );
+
+    fireEvent.change(inputRefeicaoDia1, {
+      target: { value: "53" },
+    });
+    const inputRepeticaoRefeicaoDia1 = screen.getByTestId(
+      "repeticao_sobremesa__dia_01__categoria_1",
+    );
+    waitFor(() => {
+      fireEvent.change(inputRepeticaoRefeicaoDia1, {
+        target: { value: "62" },
+      });
+    });
+    expect(inputRepeticaoRefeicaoDia1).not.toHaveClass("icone-info-success");
   });
 });

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/lancamento_colaboradores.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/lancamento_colaboradores.test.jsx
@@ -791,7 +791,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Colaboradores 
       expect(botao).toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
 
@@ -812,15 +812,14 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Colaboradores 
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_refeicao__dia_02__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();
       expect(botao).not.toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e não exibe tooltip verde", async () => {
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
 
@@ -843,8 +842,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Colaboradores 
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_sobremesa__dia_02__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/lancamento_emei_da_cemei.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/lancamento_emei_da_cemei.test.jsx
@@ -919,7 +919,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Recreio nas F�
       expect(botao).toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de refeição maior que refeição e não exibe tooltip verde", async () => {
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
 
@@ -940,15 +940,14 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Recreio nas F�
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_refeicao__dia_02__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();
       expect(botao).not.toBeDisabled();
     });
 
-    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e exibe atenção", async () => {
+    it("ao clicar na tab `Semana 1`, preencher repetição de sobremesa maior que sobremesa e não exibe tooltip verde", async () => {
       const semana1Element = screen.getByText("Semana 1");
       fireEvent.click(semana1Element);
 
@@ -971,8 +970,7 @@ describe("Teste <PeriodoLancamentoMedicaoInicialCEI> para o Grupo Recreio nas F�
       const tooltip = document.querySelector(
         '[data-test-id="tooltip_repeticao_sobremesa__dia_02__categoria_1"]',
       );
-      expect(tooltip).not.toBeNull();
-      expect(tooltip).toHaveClass("icone-info-success");
+      expect(tooltip).toBeNull();
 
       const botao = screen.getByText("Salvar Lançamentos").closest("button");
       expect(botao).toBeInTheDocument();

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -86,7 +86,6 @@ import {
   exibirTooltipPadraoRepeticaoDiasSobremesaDoce,
   exibirTooltipQtdKitLancheDiferenteSolAlimentacoesAutorizadas,
   exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas,
-  exibirTooltipRepeticao,
   exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero,
   exibirTooltipRPLAutorizadas,
   exibirTooltipSuspensoesAutorizadas,
@@ -3035,16 +3034,6 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
                                                               categoria,
                                                               diasSobremesaDoce,
                                                               location,
-                                                            )
-                                                          }
-                                                          exibeTooltipRepeticao={
-                                                            (ehProgramasEProjetosLocation ||
-                                                              ehRecreioNasFerias) &&
-                                                            exibirTooltipRepeticao(
-                                                              formValuesAtualizados,
-                                                              row,
-                                                              column,
-                                                              categoria,
                                                             )
                                                           }
                                                           exibirTooltipPeriodosZeradosNoProgramasProjetos={exibirTooltipPeriodosZeradosNoProgramasProjetos(


### PR DESCRIPTION
Esse pull request:

- Remove os tooltips de aviso de repetição de alimentação maior que a primeira oferta

**Referência no Azure:** [AB#146511](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/146511)