### PR TITLE
Feature/145959 tooltip lanche emergencial

### DIFF
--- a/src/components/Shareable/Input/InputValueMedicao/index.jsx
+++ b/src/components/Shareable/Input/InputValueMedicao/index.jsx
@@ -3,6 +3,9 @@ import { Tooltip } from "antd";
 import PropTypes from "prop-types";
 import "../style.scss";
 
+const WARNING_LANCHE_EMERGENCIAL_AUTORIZADO =
+  "Há lanche emergencial autorizado. Justifique o apontamento da alimentação";
+
 export const InputText = (props) => {
   const {
     classNameToNextInput,
@@ -76,7 +79,11 @@ export const InputText = (props) => {
   };
 
   const validacaoFrequencia = () => {
-    if (validacaoMeta() && input.name.includes("frequencia")) {
+    if (
+      validacaoMeta() &&
+      meta?.error !== WARNING_LANCHE_EMERGENCIAL_AUTORIZADO &&
+      input.name.includes("frequencia")
+    ) {
       msgTooltip = meta.error;
       return true;
     }
@@ -86,6 +93,7 @@ export const InputText = (props) => {
   const validacaoLancheRefeicaoSobremesa1Oferta = () => {
     let validacao =
       validacaoMeta() &&
+      meta?.error !== WARNING_LANCHE_EMERGENCIAL_AUTORIZADO &&
       (input.name.includes("refeicao") ||
         input.name.includes("sobremesa") ||
         input.name.includes("lanche") ||
@@ -101,6 +109,44 @@ export const InputText = (props) => {
     return (
       exibeTooltipAlimentacoesAutorizadasDiaNaoLetivo &&
       Number(input.value) > Number(numeroDeInclusoesAutorizadas)
+    );
+  };
+
+  const validacaoWarningLancheEmergencialAutorizadoTipoAlimentacao = () => {
+    if (meta?.error === WARNING_LANCHE_EMERGENCIAL_AUTORIZADO) {
+      msgTooltip = meta.error;
+      return true;
+    }
+    return false;
+  };
+
+  const exibeBorderWarning = () => {
+    const exibeWarningLancheEmergencialAutorizadoTipoAlimentacao =
+      validacaoWarningLancheEmergencialAutorizadoTipoAlimentacao();
+
+    return (
+      (!meta.error || exibeWarningLancheEmergencialAutorizadoTipoAlimentacao) &&
+      (exibeWarningLancheEmergencialAutorizadoTipoAlimentacao ||
+        exibirTooltipAlimentacoesAutorizadasDiaNaoLetivo() ||
+        exibeTooltipFrequenciaAlimentacaoZero ||
+        exibeTooltipErroQtdMaiorQueAutorizado ||
+        exibeTooltipSuspensoesAutorizadas ||
+        exibeTooltipRPLAutorizadas ||
+        exibeTooltipLPRAutorizadas ||
+        exibeTooltipQtdKitLancheDiferenteSolAlimentacoesAutorizadas ||
+        exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas ||
+        exibeTooltipKitLancheSolAlimentacoes ||
+        exibeTooltipQtdLancheEmergencialDiferenteSolAlimentacoesAutorizadas ||
+        exibeTooltipLancheEmergencialNaoAutorizado ||
+        exibeTooltipLancheEmergencialAutorizado ||
+        exibeTooltipFrequenciaZeroTabelaEtec ||
+        exibeTooltipLancheEmergTabelaEtec ||
+        exibeTooltipInclusoesAutorizadasComZero ||
+        exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero ||
+        exibeTooltipDietasInclusaoDiaNaoLetivoCEI ||
+        exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI ||
+        exibirTooltipPeriodosZeradosNoProgramasProjetos ||
+        exibeTooltipSuspensoesAutorizadasCEI)
     );
   };
 
@@ -297,6 +343,14 @@ export const InputText = (props) => {
           <i className="fas fa-info icone-info-warning" />
         </Tooltip>
       )}
+      {validacaoWarningLancheEmergencialAutorizadoTipoAlimentacao() && (
+        <Tooltip title={msgTooltip}>
+          <i
+            data-testid={`tooltip-lanche-emergencial-warning_${input.name}`}
+            className="fas fa-info icone-info-warning"
+          />
+        </Tooltip>
+      )}
       {(validacaoFrequencia() || validacaoLancheRefeicaoSobremesa1Oferta()) && (
         <Tooltip title={msgTooltip}>
           <i className="fas fa-info icone-info-error" />
@@ -383,31 +437,7 @@ export const InputText = (props) => {
           validacaoFrequencia() || validacaoLancheRefeicaoSobremesa1Oferta()
             ? "invalid-field"
             : ""
-        } ${
-          !meta.error &&
-          (exibirTooltipAlimentacoesAutorizadasDiaNaoLetivo() ||
-            exibeTooltipFrequenciaAlimentacaoZero ||
-            exibeTooltipErroQtdMaiorQueAutorizado ||
-            exibeTooltipSuspensoesAutorizadas ||
-            exibeTooltipRPLAutorizadas ||
-            exibeTooltipLPRAutorizadas ||
-            exibeTooltipQtdKitLancheDiferenteSolAlimentacoesAutorizadas ||
-            exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas ||
-            exibeTooltipKitLancheSolAlimentacoes ||
-            exibeTooltipQtdLancheEmergencialDiferenteSolAlimentacoesAutorizadas ||
-            exibeTooltipLancheEmergencialNaoAutorizado ||
-            exibeTooltipLancheEmergencialAutorizado ||
-            exibeTooltipFrequenciaZeroTabelaEtec ||
-            exibeTooltipLancheEmergTabelaEtec ||
-            exibeTooltipInclusoesAutorizadasComZero ||
-            exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero ||
-            exibeTooltipDietasInclusaoDiaNaoLetivoCEI ||
-            exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI ||
-            exibirTooltipPeriodosZeradosNoProgramasProjetos ||
-            exibeTooltipSuspensoesAutorizadasCEI)
-            ? "border-warning"
-            : ""
-        }`}
+        } ${exibeBorderWarning() ? "border-warning" : ""}`}
         disabled={disabled}
         min={min}
         max={max}

--- a/src/components/Shareable/Input/InputValueMedicao/index.jsx
+++ b/src/components/Shareable/Input/InputValueMedicao/index.jsx
@@ -42,6 +42,7 @@ export const InputText = (props) => {
     exibeTooltipQtdLancheEmergencialDiferenteSolAlimentacoesAutorizadas,
     exibeTooltipLancheEmergencialNaoAutorizado,
     exibeTooltipLancheEmergencialAutorizado,
+    exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao,
     exibeTooltipLancheEmergencialZeroAutorizado,
     exibeTooltipLancheEmergencialZeroAutorizadoJustificado,
     exibeTooltipFrequenciaZeroTabelaEtec,
@@ -268,6 +269,14 @@ export const InputText = (props) => {
           }
         >
           <i className="fas fa-info icone-info-warning" />
+        </Tooltip>
+      )}
+      {exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao && (
+        <Tooltip title={"Lanche Emergencial autorizado"}>
+          <i
+            data-testid={`tooltip-lanche-emergencial-autorizado_${input.name}`}
+            className="fas fa-info icone-info-success"
+          />
         </Tooltip>
       )}
       {exibeTooltipFrequenciaZeroTabelaEtec && (

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_erro_somatoria_lanches.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_erro_somatoria_lanches.test.jsx
@@ -197,12 +197,34 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - MANHA - Usuário EMEF", () =
     );
   });
 
-  it("exibe tooltip verde nos tipos de alimentação autorizados e remove ao digitar 0", async () => {
+  it("exibe warning laranja para lanche emergencial sem observação e desbloqueia ao digitar 0", async () => {
+    const inputElementLancheDia01 = screen.getByTestId(
+      "lanche__dia_01__categoria_1",
+    );
+    expect(inputElementLancheDia01).toHaveClass("border-warning");
+    expect(inputElementLancheDia01).not.toHaveClass("invalid-field");
+
+    const iconeWarning = screen.getByTestId(
+      "tooltip-lanche-emergencial-warning_lanche__dia_01__categoria_1",
+    );
+    expect(iconeWarning).toBeInTheDocument();
+    fireEvent.mouseOver(iconeWarning);
     expect(
-      screen.getByTestId(
-        "tooltip-lanche-emergencial-autorizado_lanche__dia_01__categoria_1",
+      await screen.findByText(
+        "Há lanche emergencial autorizado. Justifique o apontamento da alimentação",
       ),
     ).toBeInTheDocument();
+
+    const botaoAdicionarObservacao = screen.getByTestId(
+      "botao-observacao__dia_01__categoria_1",
+    );
+    expect(botaoAdicionarObservacao).toHaveClass("red-button-outline");
+
+    const botaoSalvarLancamentos = screen
+      .getByText("Salvar Lançamentos")
+      .closest("button");
+    expect(botaoSalvarLancamentos).toBeDisabled();
+
     expect(
       screen.getByTestId(
         "tooltip-lanche-emergencial-autorizado_refeicao__dia_01__categoria_1",
@@ -214,24 +236,26 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - MANHA - Usuário EMEF", () =
       ),
     ).not.toBeInTheDocument();
 
-    const inputElementLancheDia01 = screen.getByTestId(
-      "lanche__dia_01__categoria_1",
-    );
-
-    await waitFor(() => {
-      fireEvent.change(inputElementLancheDia01, {
-        target: { value: "0" },
-      });
+    fireEvent.change(inputElementLancheDia01, {
+      target: { value: "0" },
     });
 
     await waitFor(() => {
+      expect(inputElementLancheDia01).not.toHaveClass("border-warning");
       expect(
         screen.queryByTestId(
-          "tooltip-lanche-emergencial-autorizado_lanche__dia_01__categoria_1",
+          "tooltip-lanche-emergencial-warning_lanche__dia_01__categoria_1",
         ),
       ).not.toBeInTheDocument();
     });
 
+    expect(
+      screen.queryByTestId(
+        "tooltip-lanche-emergencial-autorizado_lanche__dia_01__categoria_1",
+      ),
+    ).not.toBeInTheDocument();
+    expect(botaoAdicionarObservacao).not.toHaveClass("red-button-outline");
+    expect(botaoSalvarLancamentos).not.toBeDisabled();
     expect(
       screen.getByTestId(
         "tooltip-lanche-emergencial-autorizado_refeicao__dia_01__categoria_1",

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_erro_somatoria_lanches.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/EMEF/lancamento_erro_somatoria_lanches.test.jsx
@@ -23,8 +23,10 @@ import mock from "src/services/_mock";
 describe("Teste <PeriodoLancamentoMedicaoInicial> - MANHA - Usuário EMEF", () => {
   const escolaUuid =
     mockMeusDadosEscolaEMEFPericles.vinculo_atual.instituicao.uuid;
+  const alteracoesAlimentacaoParams = [];
 
   beforeEach(async () => {
+    alteracoesAlimentacaoParams.length = 0;
     mock
       .onGet("/usuarios/meus-dados/")
       .reply(200, mockMeusDadosEscolaEMEFPericles);
@@ -57,7 +59,29 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - MANHA - Usuário EMEF", () =
       .reply(200, { results: [] });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
-      .reply(200, { results: [] });
+      .reply((config) => {
+        alteracoesAlimentacaoParams.push(config.params);
+
+        if (config.params?.eh_lanche_emergencial) {
+          return [
+            200,
+            {
+              results: [
+                {
+                  dia: "01",
+                  numero_alunos: 100,
+                  inclusao_id_externo: "8C896",
+                  motivo: "Lanche Emergencial",
+                  periodos_escolares: ["MANHA"],
+                  tipos_alimentacao_de: ["Lanche", "Refeição"],
+                },
+              ],
+            },
+          ];
+        }
+
+        return [200, { results: [] }];
+      });
     mock
       .onGet(
         "/medicao-inicial/permissao-lancamentos-especiais/permissoes-lancamentos-especiais-mes-ano-por-periodo/",
@@ -156,6 +180,63 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - MANHA - Usuário EMEF", () =
       "lanche__dia_01__categoria_1",
     );
     expect(inputElementLancheDia01).toHaveAttribute("value", "299");
+  });
+
+  it("consulta as alterações autorizadas com e sem lanche emergencial para o mesmo período escolar", async () => {
+    expect(alteracoesAlimentacaoParams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eh_lanche_emergencial: false,
+          nome_periodo_escolar: "MANHA",
+        }),
+        expect.objectContaining({
+          eh_lanche_emergencial: true,
+          nome_periodo_escolar: "MANHA",
+        }),
+      ]),
+    );
+  });
+
+  it("exibe tooltip verde nos tipos de alimentação autorizados e remove ao digitar 0", async () => {
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_lanche__dia_01__categoria_1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_refeicao__dia_01__categoria_1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        "tooltip-lanche-emergencial-autorizado_sobremesa__dia_01__categoria_1",
+      ),
+    ).not.toBeInTheDocument();
+
+    const inputElementLancheDia01 = screen.getByTestId(
+      "lanche__dia_01__categoria_1",
+    );
+
+    await waitFor(() => {
+      fireEvent.change(inputElementLancheDia01, {
+        target: { value: "0" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(
+          "tooltip-lanche-emergencial-autorizado_lanche__dia_01__categoria_1",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_refeicao__dia_01__categoria_1",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("exibe borda vermelha (erro) nos lanches das dietas", async () => {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -836,7 +836,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   params["mes"] = mes;
   params["ano"] = ano;
   params["eh_lanche_emergencial"] = ehLancheEmergencial;
-  if (!ehLancheEmergencial) {
+  if (nomePeriodoEscolar) {
     params["nome_periodo_escolar"] = nomePeriodoEscolar;
   }
   const responseAlteracoesAlimentacaoAutorizadas =

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -114,6 +114,7 @@ import {
   exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero,
   exibirTooltipRPLAutorizadas,
   exibirTooltipSuspensoesAutorizadas,
+  existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNaSemanaSemObservacao,
   existeAlgumCampoComFrequenciaAlimentacaoZeroESemObservacao,
   validacoesTabelaAlimentacao,
   validacoesTabelaEtecAlimentacao,
@@ -441,6 +442,17 @@ export default () => {
 
   const ehGrupoColaboradores = () => {
     return location.state.grupo === "Colaboradores";
+  };
+
+  const existeWarningLancheEmergencialAutorizadoTipoAlimentacao = (
+    values = formValuesAtualizados,
+  ) => {
+    return existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNaSemanaSemObservacao(
+      values,
+      categoriasDeMedicao,
+      weekColumns,
+      alteracoesLancheEmergencialAutorizadas,
+    );
   };
 
   useEffect(() => {
@@ -1665,6 +1677,23 @@ export default () => {
     categoriasDeMedicao,
   ]);
 
+  useEffect(() => {
+    if (
+      formValuesAtualizados &&
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(
+        formValuesAtualizados,
+      )
+    ) {
+      setDisableBotaoSalvarLancamentos(true);
+      setExibirTooltip(true);
+    }
+  }, [
+    formValuesAtualizados,
+    weekColumns,
+    categoriasDeMedicao,
+    alteracoesLancheEmergencialAutorizadas,
+  ]);
+
   const onSubmitObservacao = async (values, dia, categoria, form, errors) => {
     const prefixo = ehRecreioNasFerias() ? "participantes" : "matriculados";
     let valoresMedicao = [];
@@ -1804,24 +1833,27 @@ export default () => {
         (valor) => valor.nome_campo === "observacoes",
       ),
     );
-    setExibirTooltip(false);
+    const bloquearBotaoLancheEmergencial =
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(values);
     if (
-      valorPeriodoEscolar === "Programas e Projetos" &&
-      boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
-        "frequencia",
-        categoriasDeMedicao,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        valorPeriodoEscolar,
-        escolaEhEMEBS(),
-        alunosTabSelecionada,
-        weekColumns,
-      )
+      bloquearBotaoLancheEmergencial ||
+      (valorPeriodoEscolar === "Programas e Projetos" &&
+        boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
+          "frequencia",
+          categoriasDeMedicao,
+          values,
+          diasFrequenciaZerada,
+          valorPeriodoEscolar,
+          escolaEhEMEBS(),
+          alunosTabSelecionada,
+          weekColumns,
+        ))
     ) {
       setDisableBotaoSalvarLancamentos(true);
       setExibirTooltip(true);
     } else {
       setDisableBotaoSalvarLancamentos(false);
+      setExibirTooltip(false);
     }
   };
 
@@ -2166,7 +2198,10 @@ export default () => {
       weekColumns,
       feriadosNoMes,
     );
-    if (erro) {
+    if (
+      erro ||
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(values)
+    ) {
       setDisableBotaoSalvarLancamentos(true);
       setExibirTooltip(true);
     }
@@ -2233,6 +2268,8 @@ export default () => {
       }
     }
     desabilitaTooltip(values);
+    const existeWarningLancheEmergencial =
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(values);
 
     const ehChangeInput = true;
     if (
@@ -2343,6 +2380,7 @@ export default () => {
           ehGrupoETECUrlParam,
           inclusoesEtecAutorizadas,
         )) ||
+      existeWarningLancheEmergencial ||
       boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
         "frequencia",
         categoriasDeMedicao,
@@ -2398,12 +2436,14 @@ export default () => {
           dadosValoresInclusoesAutorizadasState,
           suspensoesAutorizadas,
           alteracoesAlimentacaoAutorizadas,
+          alteracoesLancheEmergencialAutorizadas,
           validacaoDiaLetivo,
           location,
           feriadosNoMes,
           valoresPeriodosLancamentos,
           escolaEhEMEBS(),
           alunosTabSelecionada,
+          nomeCategoria,
         );
       }
     };
@@ -3477,6 +3517,7 @@ export default () => {
                                                               column,
                                                               suspensoesAutorizadas,
                                                               alteracoesAlimentacaoAutorizadas,
+                                                              alteracoesLancheEmergencialAutorizadas,
                                                               kitLanchesAutorizadas,
                                                               inclusoesEtecAutorizadas,
                                                               ehGrupoETECUrlParam,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -103,6 +103,7 @@ import {
   exibirTooltipFrequenciaZeroTabelaEtec,
   exibirTooltipKitLancheSolAlimentacoes,
   exibirTooltipLancheEmergencialAutorizado,
+  exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao,
   exibirTooltipLancheEmergencialNaoAutorizado,
   exibirTooltipLancheEmergencialZeroAutorizado,
   exibirTooltipLancheEmergencialZeroAutorizadoJustificado,
@@ -161,6 +162,10 @@ export default () => {
   const [
     alteracoesAlimentacaoAutorizadas,
     setAlteracoesAlimentacaoAutorizadas,
+  ] = useState(null);
+  const [
+    alteracoesLancheEmergencialAutorizadas,
+    setAlteracoesLancheEmergencialAutorizadas,
   ] = useState(null);
   const [kitLanchesAutorizadas, setKitLanchesAutorizadas] = useState(null);
   const [
@@ -975,6 +980,7 @@ export default () => {
       let response_kit_lanches_autorizadas = [];
       let response_suspensoes_autorizadas = [];
       let response_alteracoes_alimentacao_autorizadas = [];
+      let response_alteracoes_lanche_emergencial_autorizadas = [];
       let response_permissoes_lancamentos_especiais_mes_ano_por_periodo = [];
 
       const calendario = await obterDiasLetivosCorretos(
@@ -1017,6 +1023,18 @@ export default () => {
           );
         setAlteracoesAlimentacaoAutorizadas(
           response_alteracoes_alimentacao_autorizadas,
+        );
+
+        response_alteracoes_lanche_emergencial_autorizadas =
+          await getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync(
+            escola.uuid,
+            mes,
+            ano,
+            periodo.periodo_escolar.nome,
+            true,
+          );
+        setAlteracoesLancheEmergencialAutorizadas(
+          response_alteracoes_lanche_emergencial_autorizadas,
         );
 
         if (ehPeriodoSimples) {
@@ -3620,6 +3638,13 @@ export default () => {
                                                             column,
                                                             categoria,
                                                             alteracoesAlimentacaoAutorizadas,
+                                                          )}
+                                                          exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
+                                                            formValuesAtualizados,
+                                                            row,
+                                                            column,
+                                                            categoria,
+                                                            alteracoesLancheEmergencialAutorizadas,
                                                           )}
                                                           exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas={exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas(
                                                             formValuesAtualizados,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
@@ -388,6 +388,118 @@ export const camposLancheEmergTabelaEtec = (
   return erro;
 };
 
+export const WARNING_LANCHE_EMERGENCIAL_AUTORIZADO =
+  "Há lanche emergencial autorizado. Justifique o apontamento da alimentação";
+
+const campoTemValorPreenchido = (value) => {
+  return (
+    ![undefined, null, ""].includes(value) &&
+    !["Mês anterior", "Mês posterior"].includes(value)
+  );
+};
+
+const normalizarTipoAlimentacaoLancheEmergencial = (tipoAlimentacao) => {
+  return tipoAlimentacao
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replaceAll(/ /g, "_");
+};
+
+const ehValorZeroDigitado = (value) => value === "0" || value === 0;
+
+const slotEhLancheEmergencialAutorizadoTipoAlimentacao = (
+  rowName,
+  dia,
+  alteracoesLancheEmergencialAutorizadas = [],
+) => {
+  return alteracoesLancheEmergencialAutorizadas?.some(
+    (alteracao) =>
+      alteracao.dia === dia &&
+      alteracao.tipos_alimentacao_de?.some(
+        (tipoAlimentacao) =>
+          normalizarTipoAlimentacaoLancheEmergencial(tipoAlimentacao) ===
+          rowName,
+      ),
+  );
+};
+
+export const campoLancheEmergencialAutorizadoTipoAlimentacaoComApontamentoSemObservacao =
+  (
+    rowName,
+    dia,
+    categoriaId,
+    values,
+    alteracoesLancheEmergencialAutorizadas = [],
+  ) => {
+    const value = values[`${rowName}__dia_${dia}__categoria_${categoriaId}`];
+
+    return (
+      campoTemValorPreenchido(value) &&
+      Number(value) > 0 &&
+      !values[`observacoes__dia_${dia}__categoria_${categoriaId}`] &&
+      slotEhLancheEmergencialAutorizadoTipoAlimentacao(
+        rowName,
+        dia,
+        alteracoesLancheEmergencialAutorizadas,
+      )
+    );
+  };
+
+export const existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao =
+  (dia, categoria, values, alteracoesLancheEmergencialAutorizadas = []) => {
+    if (categoria.nome !== "ALIMENTAÇÃO") return false;
+
+    const tiposAutorizadosNoDia = [
+      ...new Set(
+        alteracoesLancheEmergencialAutorizadas
+          .filter((alteracao) => alteracao.dia === dia)
+          .flatMap((alteracao) => alteracao.tipos_alimentacao_de || [])
+          .map(normalizarTipoAlimentacaoLancheEmergencial),
+      ),
+    ];
+
+    return tiposAutorizadosNoDia.some((rowName) =>
+      campoLancheEmergencialAutorizadoTipoAlimentacaoComApontamentoSemObservacao(
+        rowName,
+        dia,
+        categoria.id,
+        values,
+        alteracoesLancheEmergencialAutorizadas,
+      ),
+    );
+  };
+
+export const existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNaSemanaSemObservacao =
+  (
+    values,
+    categoriasDeMedicao,
+    weekColumns,
+    alteracoesLancheEmergencialAutorizadas = [],
+  ) => {
+    const categoriaAlimentacao = categoriasDeMedicao.find(
+      (categoria) => categoria.nome === "ALIMENTAÇÃO",
+    );
+
+    if (
+      !values ||
+      !categoriaAlimentacao ||
+      !weekColumns?.length ||
+      !alteracoesLancheEmergencialAutorizadas?.length
+    ) {
+      return false;
+    }
+
+    return weekColumns.some(({ dia }) =>
+      existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
+        dia,
+        categoriaAlimentacao,
+        values,
+        alteracoesLancheEmergencialAutorizadas,
+      ),
+    );
+  };
+
 export const botaoAdicionarObrigatorioTabelaAlimentacao = (
   formValuesAtualizados,
   dia,
@@ -400,6 +512,7 @@ export const botaoAdicionarObrigatorioTabelaAlimentacao = (
   column,
   suspensoesAutorizadas,
   alteracoesAlimentacaoAutorizadas,
+  alteracoesLancheEmergencialAutorizadas,
   kitLanchesAutorizadas,
   inclusoesEtecAutorizadas,
   ehGrupoETECUrlParam = false,
@@ -467,6 +580,12 @@ export const botaoAdicionarObrigatorioTabelaAlimentacao = (
         column,
         categoria,
         alteracoesAlimentacaoAutorizadas,
+      ) ||
+      existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
+        dia,
+        categoria,
+        formValuesAtualizados,
+        alteracoesLancheEmergencialAutorizadas,
       ) ||
       habitarBotaoAdicionar(
         "frequencia",
@@ -611,12 +730,14 @@ export const validacoesTabelaAlimentacao = (
   dadosValoresInclusoesAutorizadasState,
   suspensoesAutorizadas,
   alteracoesAlimentacaoAutorizadas,
+  alteracoesLancheEmergencialAutorizadas,
   validacaoDiaLetivo,
   location,
   feriadosNoMes,
   valoresPeriodosLancamentos,
   escolaEhEMEBS,
   alunosTabSelecionada,
+  nomeCategoria,
 ) => {
   const maxFrequencia = Number(
     allValues[`frequencia__dia_${dia}__categoria_${categoria}`],
@@ -826,6 +947,17 @@ export const validacoesTabelaAlimentacao = (
     Number(value) > maxMatriculados
   ) {
     return `A frequência não pode ser maior que o número de participantes.`;
+  } else if (
+    nomeCategoria === "ALIMENTAÇÃO" &&
+    campoLancheEmergencialAutorizadoTipoAlimentacaoComApontamentoSemObservacao(
+      rowName,
+      dia,
+      categoria,
+      allValues,
+      alteracoesLancheEmergencialAutorizadas,
+    )
+  ) {
+    return WARNING_LANCHE_EMERGENCIAL_AUTORIZADO;
   }
   return undefined;
 };
@@ -1694,16 +1826,6 @@ export const exibirTooltipLancheEmergencialAutorizado = (
   );
 };
 
-const normalizarTipoAlimentacaoLancheEmergencial = (tipoAlimentacao) => {
-  return tipoAlimentacao
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .replaceAll(/ /g, "_");
-};
-
-const ehValorZeroDigitado = (value) => value === "0" || value === 0;
-
 export const exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao = (
   formValuesAtualizados,
   row,
@@ -1715,18 +1837,20 @@ export const exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao = (
     formValuesAtualizados[
       `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
     ];
+  const temObservacao =
+    formValuesAtualizados[
+      `observacoes__dia_${column.dia}__categoria_${categoria.id}`
+    ];
 
   return (
     categoria.nome === "ALIMENTAÇÃO" &&
+    !temObservacao &&
+    !campoTemValorPreenchido(value) &&
     !ehValorZeroDigitado(value) &&
-    alteracoesLancheEmergencialAutorizadas?.some(
-      (alteracao) =>
-        alteracao.dia === column.dia &&
-        alteracao.tipos_alimentacao_de?.some(
-          (tipoAlimentacao) =>
-            normalizarTipoAlimentacaoLancheEmergencial(tipoAlimentacao) ===
-            row.name,
-        ),
+    slotEhLancheEmergencialAutorizadoTipoAlimentacao(
+      row.name,
+      column.dia,
+      alteracoesLancheEmergencialAutorizadas,
     )
   );
 };

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
@@ -1694,6 +1694,43 @@ export const exibirTooltipLancheEmergencialAutorizado = (
   );
 };
 
+const normalizarTipoAlimentacaoLancheEmergencial = (tipoAlimentacao) => {
+  return tipoAlimentacao
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replaceAll(/ /g, "_");
+};
+
+const ehValorZeroDigitado = (value) => value === "0" || value === 0;
+
+export const exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao = (
+  formValuesAtualizados,
+  row,
+  column,
+  categoria,
+  alteracoesLancheEmergencialAutorizadas,
+) => {
+  const value =
+    formValuesAtualizados[
+      `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+    ];
+
+  return (
+    categoria.nome === "ALIMENTAÇÃO" &&
+    !ehValorZeroDigitado(value) &&
+    alteracoesLancheEmergencialAutorizadas?.some(
+      (alteracao) =>
+        alteracao.dia === column.dia &&
+        alteracao.tipos_alimentacao_de?.some(
+          (tipoAlimentacao) =>
+            normalizarTipoAlimentacaoLancheEmergencial(tipoAlimentacao) ===
+            row.name,
+        ),
+    )
+  );
+};
+
 export const exibirTooltipLancheEmergencialZeroAutorizado = (
   formValuesAtualizados,
   row,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/EMEI/lancamento_frequencia_alimentacao_zero.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/EMEI/lancamento_frequencia_alimentacao_zero.test.jsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import { MODULO_GESTAO, PERFIL, TIPO_PERFIL } from "src/constants/shared";
@@ -15,7 +21,10 @@ import { PeriodoLancamentoMedicaoInicialCEIPage } from "src/pages/LancamentoMedi
 import mock from "src/services/_mock";
 
 describe("Teste de lançamento de frequência de alimentação zero - EMEI da CEMEI", () => {
+  const alteracoesAlimentacaoParams = [];
+
   beforeEach(async () => {
+    alteracoesAlimentacaoParams.length = 0;
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosEscolaCEMEI);
     mock.onGet("/faixas-etarias/").reply(200, mockFaixasEtarias);
     mock
@@ -26,7 +35,29 @@ describe("Teste de lançamento de frequência de alimentação zero - EMEI da CE
     });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
-      .reply(200, { results: [] });
+      .reply((config) => {
+        alteracoesAlimentacaoParams.push(config.params);
+
+        if (config.params?.eh_lanche_emergencial) {
+          return [
+            200,
+            {
+              results: [
+                {
+                  dia: "12",
+                  numero_alunos: 100,
+                  inclusao_id_externo: "8C896",
+                  motivo: "Lanche Emergencial",
+                  periodos_escolares: ["Infantil INTEGRAL"],
+                  tipos_alimentacao_de: ["Lanche", "Refeição"],
+                },
+              ],
+            },
+          ];
+        }
+
+        return [200, { results: [] }];
+      });
     mock
       .onGet("/escolas-solicitacoes/suspensoes-autorizadas/")
       .reply(200, { results: [] });
@@ -112,6 +143,107 @@ describe("Teste de lançamento de frequência de alimentação zero - EMEI da CE
     expect(
       screen.getByText("Semanas do Período para Lançamento da Medição Inicial"),
     ).toBeInTheDocument();
+  });
+
+  it("consulta as alterações autorizadas com e sem lanche emergencial para Infantil INTEGRAL", async () => {
+    expect(alteracoesAlimentacaoParams).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eh_lanche_emergencial: false,
+          nome_periodo_escolar: "Infantil INTEGRAL",
+        }),
+        expect.objectContaining({
+          eh_lanche_emergencial: true,
+          nome_periodo_escolar: "Infantil INTEGRAL",
+        }),
+      ]),
+    );
+  });
+
+  it("exibe tooltip verde por tipo autorizado e warning laranja ao preencher apontamento", async () => {
+    const semanaTres = screen.getByText("Semana 3");
+    fireEvent.click(semanaTres);
+
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_lanche__dia_12__categoria_1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_refeicao__dia_12__categoria_1",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId(
+        "tooltip-lanche-emergencial-autorizado_sobremesa__dia_12__categoria_1",
+      ),
+    ).not.toBeInTheDocument();
+
+    const inputFrequenciaDia12 = screen.getByTestId(
+      "frequencia__dia_12__categoria_1",
+    );
+    fireEvent.change(inputFrequenciaDia12, {
+      target: { value: "10" },
+    });
+
+    const inputLancheDia12 = screen.getByTestId("lanche__dia_12__categoria_1");
+    fireEvent.change(inputLancheDia12, {
+      target: { value: "1" },
+    });
+
+    await waitFor(() => {
+      expect(inputLancheDia12).toHaveClass("border-warning");
+      expect(inputLancheDia12).not.toHaveClass("invalid-field");
+    });
+
+    const iconeWarning = screen.getByTestId(
+      "tooltip-lanche-emergencial-warning_lanche__dia_12__categoria_1",
+    );
+    fireEvent.mouseOver(iconeWarning);
+    expect(
+      await screen.findByText(
+        "Há lanche emergencial autorizado. Justifique o apontamento da alimentação",
+      ),
+    ).toBeInTheDocument();
+
+    const botaoAdicionarObservacao = screen
+      .getByTestId("div-botao-add-obs-12-1-observacoes")
+      .querySelector("button");
+    expect(botaoAdicionarObservacao).toHaveClass("red-button-outline");
+
+    const botaoSalvarLancamentos = screen
+      .getByText("Salvar Lançamentos")
+      .closest("button");
+    await waitFor(() => {
+      expect(botaoSalvarLancamentos).toBeDisabled();
+    });
+
+    fireEvent.change(inputLancheDia12, {
+      target: { value: "0" },
+    });
+
+    await waitFor(() => {
+      expect(inputLancheDia12).not.toHaveClass("border-warning");
+      expect(
+        screen.queryByTestId(
+          "tooltip-lanche-emergencial-warning_lanche__dia_12__categoria_1",
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByTestId(
+        "tooltip-lanche-emergencial-autorizado_lanche__dia_12__categoria_1",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        "tooltip-lanche-emergencial-autorizado_refeicao__dia_12__categoria_1",
+      ),
+    ).toBeInTheDocument();
+    expect(botaoAdicionarObservacao).not.toHaveClass("red-button-outline");
+    expect(botaoSalvarLancamentos).not.toBeDisabled();
   });
 
   it("Exibe mensagem de erro ao tentar lançar dieta especial com frequência zero na alimentação", async () => {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
@@ -724,7 +724,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   params["mes"] = mes;
   params["ano"] = ano;
   params["eh_lanche_emergencial"] = ehLancheEmergencial;
-  if (!ehLancheEmergencial) {
+  if (nomePeriodoEscolar) {
     params["nome_periodo_escolar"] = nomePeriodoEscolar;
   }
   const responseAlteracoesAlimentacaoAutorizadas =

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -80,6 +80,7 @@ import {
   exibirTooltipFrequenciaAlimentacaoZeroESemObservacao,
   exibirTooltipKitLancheSolAlimentacoes,
   exibirTooltipLancheEmergencialAutorizado,
+  exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao,
   exibirTooltipLancheEmergencialNaoAutorizado,
   exibirTooltipLancheEmergencialZeroAutorizadoJustificado,
   exibirTooltipLPRAutorizadas,
@@ -89,6 +90,8 @@ import {
   exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero,
   exibirTooltipRPLAutorizadas,
   exibirTooltipSuspensoesAutorizadas,
+  existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNaSemanaSemObservacao,
+  existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao,
   existeAlgumCampoComFrequenciaAlimentacaoZeroESemObservacao,
   exibirTooltipPeriodosZeradosNoProgramasProjetos,
   habitarBotaoAdicionar,
@@ -172,6 +175,10 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
   const [
     alteracoesAlimentacaoAutorizadas,
     setAlteracoesAlimentacaoAutorizadas,
+  ] = useState(null);
+  const [
+    alteracoesLancheEmergencialAutorizadas,
+    setAlteracoesLancheEmergencialAutorizadas,
   ] = useState(null);
   const [kitLanchesAutorizadas, setKitLanchesAutorizadas] = useState(null);
   const [exibirTooltipAoSalvar] = useState(false);
@@ -276,6 +283,27 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
     return ehRecreioCemei() && ehEmeiDaCemeiLocation;
   };
 
+  const ehPeriodoInfantilEmeiDaCemei = () => {
+    return (
+      ehEmeiDaCemeiLocation && location?.state?.periodo?.includes("Infantil")
+    );
+  };
+
+  const existeWarningLancheEmergencialAutorizadoTipoAlimentacao = (
+    values = formValuesAtualizados,
+  ) => {
+    if (!ehPeriodoInfantilEmeiDaCemei()) {
+      return false;
+    }
+
+    return existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNaSemanaSemObservacao(
+      values,
+      categoriasDeMedicao,
+      weekColumns,
+      alteracoesLancheEmergencialAutorizadas,
+    );
+  };
+
   let valuesInputArray = [];
 
   useEffect(() => {
@@ -362,6 +390,20 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
       setAlteracoesAlimentacaoAutorizadas(
         response_alteracoes_alimentacao_autorizadas,
       );
+
+      if (ehPeriodoInfantilEmeiDaCemei()) {
+        const response_alteracoes_lanche_emergencial_autorizadas =
+          await getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync(
+            escola.uuid,
+            mes,
+            ano,
+            periodo,
+            true,
+          );
+        setAlteracoesLancheEmergencialAutorizadas(
+          response_alteracoes_lanche_emergencial_autorizadas,
+        );
+      }
 
       let response_suspensoes_autorizadas = [];
       response_suspensoes_autorizadas =
@@ -1192,6 +1234,23 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
   useEffect(() => {
     if (
       formValuesAtualizados &&
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(
+        formValuesAtualizados,
+      )
+    ) {
+      setDisableBotaoSalvarLancamentos(true);
+      setExibirTooltip(true);
+    }
+  }, [
+    formValuesAtualizados,
+    weekColumns,
+    categoriasDeMedicao,
+    alteracoesLancheEmergencialAutorizadas,
+  ]);
+
+  useEffect(() => {
+    if (
+      formValuesAtualizados &&
       formValuesAtualizados["periodo_escolar"] === "Programas e Projetos" &&
       diasFrequenciaZerada &&
       weekColumns
@@ -1226,6 +1285,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
     );
 
   const onSubmitObservacao = async (values, dia, categoria, form, errors) => {
+    const valorPeriodoEscolar = values["periodo_escolar"];
     let valoresMedicao = [];
     const valuesMesmoDiaDaObservacao = Object.fromEntries(
       Object.entries(values).filter(([key]) =>
@@ -1369,24 +1429,28 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
         (valor) => valor.nome_campo === "observacoes",
       ),
     );
+    const bloquearBotaoLancheEmergencial =
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(values);
     setExibirTooltip(false);
     if (
-      values["periodo_escolar"] === "Programas e Projetos" &&
-      boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
-        "frequencia",
-        categoriasDeMedicao,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        values["periodo_escolar"],
-        false,
-        null,
-        weekColumns,
-      )
+      bloquearBotaoLancheEmergencial ||
+      (valorPeriodoEscolar === "Programas e Projetos" &&
+        boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
+          "frequencia",
+          categoriasDeMedicao,
+          values,
+          diasFrequenciaZerada,
+          valorPeriodoEscolar,
+          false,
+          null,
+          weekColumns,
+        ))
     ) {
       setDisableBotaoSalvarLancamentos(true);
       setExibirTooltip(true);
     } else {
       setDisableBotaoSalvarLancamentos(false);
+      setExibirTooltip(false);
     }
   };
 
@@ -1612,7 +1676,10 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
       weekColumns,
       feriadosNoMes,
     );
-    if (erro) {
+    if (
+      erro ||
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(values)
+    ) {
       setDisableBotaoSalvarLancamentos(true);
       setExibirTooltip(true);
     }
@@ -1681,6 +1748,15 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
       }
     }
     desabilitaTooltip(formValuesAtualizados);
+    const existeWarningLancheEmergencial =
+      existeWarningLancheEmergencialAutorizadoTipoAlimentacao(
+        formValuesAtualizados,
+      );
+
+    if (existeWarningLancheEmergencial) {
+      setDisableBotaoSalvarLancamentos(true);
+      setExibirTooltip(true);
+    }
 
     if (
       (exibirTooltipRPLAutorizadas(
@@ -1924,6 +2000,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
           allValues,
           value,
           alteracoesAlimentacaoAutorizadas,
+          alteracoesLancheEmergencialAutorizadas,
           inclusoesAutorizadas,
           validacaoDiaLetivo,
           ehProgramasEProjetosLocation,
@@ -2727,6 +2804,13 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
                                                             ],
                                                             formValuesAtualizados,
                                                           )) ||
+                                                        (ehPeriodoInfantilEmeiDaCemei() &&
+                                                          existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
+                                                            column.dia,
+                                                            categoria,
+                                                            formValuesAtualizados,
+                                                            alteracoesLancheEmergencialAutorizadas,
+                                                          )) ||
                                                         alimentacoesFrequenciaZeroESemObservacaoCEI(
                                                           formValuesAtualizados,
                                                           column.dia,
@@ -2985,6 +3069,16 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
                                                             categoria,
                                                             alteracoesAlimentacaoAutorizadas,
                                                           )}
+                                                          exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={
+                                                            ehPeriodoInfantilEmeiDaCemei() &&
+                                                            exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesLancheEmergencialAutorizadas,
+                                                            )
+                                                          }
                                                           exibeTooltipLancheEmergencialNaoAutorizado={exibirTooltipLancheEmergencialNaoAutorizado(
                                                             formValuesAtualizados,
                                                             row,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/validacoes.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/validacoes.jsx
@@ -4,6 +4,10 @@ import {
   existeAlteracaoRPL,
   existeAlteracaoLPR,
 } from "../PeriodoLancamentoMedicaoInicial/helper";
+import {
+  WARNING_LANCHE_EMERGENCIAL_AUTORIZADO,
+  campoLancheEmergencialAutorizadoTipoAlimentacaoComApontamentoSemObservacao,
+} from "../PeriodoLancamentoMedicaoInicial/validacoes";
 
 /**
  * Verifica se deve exibir um tooltip de alerta quando há frequência de dieta registrada
@@ -532,6 +536,7 @@ export const validacoesTabelaAlimentacaoEmeidaCemei = (
   allValues,
   value,
   alteracoesAlimentacaoAutorizadas,
+  alteracoesLancheEmergencialAutorizadas,
   inclusoesAutorizadas,
   validacaoDiaLetivo,
   ehProgramasEProjetosLocation,
@@ -645,6 +650,16 @@ export const validacoesTabelaAlimentacaoEmeidaCemei = (
   ) {
     const nome = ehRecreioNasFerias ? "participantes" : "alunos";
     return `Lançamento maior que a frequência de ${nome} no dia.`;
+  } else if (
+    campoLancheEmergencialAutorizadoTipoAlimentacaoComApontamentoSemObservacao(
+      rowName,
+      dia,
+      categoria,
+      allValues,
+      alteracoesLancheEmergencialAutorizadas,
+    )
+  ) {
+    return WARNING_LANCHE_EMERGENCIAL_AUTORIZADO;
   }
 
   return undefined;


### PR DESCRIPTION
# Este PR:
- trata lanche emergencial no lançamento de períodos escolares na medição inicial para:
  - EMEF, EMEI, CIEJA, etc.
  - EMEI da CEMEI
- implementa testes unitários para a nova regra

### Referência azure:
- [AB#145959](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/145959)