### PR TITLE
Feature/147778 componentes registrar nova ocorrencia

### DIFF
--- a/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/modal_cancela_preenchimento.test.jsx
+++ b/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/modal_cancela_preenchimento.test.jsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ModalCancelaPreenchimento } from "../../components/ModalCancelaPreenchimento";
+
+describe("Testes de comportamentos componente - ModalCancelaPreenchimento", () => {
+  const handleClose = jest.fn();
+  const navigate = jest.fn();
+  const form = {
+    reset: jest.fn(),
+  };
+
+  const setup = (show = true) =>
+    render(
+      <MemoryRouter>
+        <ModalCancelaPreenchimento
+          show={show}
+          handleClose={handleClose}
+          form={form}
+          navigate={navigate}
+        />
+      </MemoryRouter>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o título e o texto do modal quando show = true", () => {
+    setup(true);
+
+    expect(
+      screen.getByText("Cancelar Registro da Ocorrência"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Deseja cancelar o registro da ocorrência/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /As informações inseridas serão apagadas e o registro não será salvo/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("não deve renderizar o modal quando show = false", () => {
+    setup(false);
+
+    expect(
+      screen.queryByText("Cancelar Registro da Ocorrência"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("deve fechar o modal ao clicar no botão de fechar", () => {
+    setup(true);
+
+    const botaoFechar = screen.getByRole("button", {
+      name: /close/i,
+    });
+    fireEvent.click(botaoFechar);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("deve clicar em 'Não' e chamar handleClose", () => {
+    setup(true);
+
+    const botaoNao = screen.getByRole("button", {
+      name: /Não/i,
+    });
+    fireEvent.click(botaoNao);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(form.reset).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("deve clicar em 'Sim', resetar o form, fechar modal e navegar para página anterior", () => {
+    setup(true);
+
+    const botaoSim = screen.getByRole("button", {
+      name: /Sim/i,
+    });
+    fireEvent.click(botaoSim);
+
+    expect(form.reset).toHaveBeenCalledTimes(1);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(-1);
+  });
+});

--- a/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/modal_salvar.test.jsx
+++ b/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/modal_salvar.test.jsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ModalSalvar } from "../../components/ModalSalvar";
+
+describe("Testes de comportamentos componente - ModalSalvar", () => {
+  const handleClose = jest.fn();
+  const salvar = jest.fn();
+
+  const values = {
+    categoria: "categoria_teste",
+    tipo_ocorrencia: "tipo_teste",
+    datas: ["2026-04-29"],
+    ocorrencias: [],
+    solicitacao_medicao_inicial: "123e4567-e89b-42d3-a456-426614174000",
+  };
+
+  const setup = (show = true) =>
+    render(
+      <MemoryRouter>
+        <ModalSalvar
+          show={show}
+          handleClose={handleClose}
+          salvar={salvar}
+          values={values}
+        />
+      </MemoryRouter>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o título e o texto do modal quando show = true", () => {
+    setup(true);
+
+    expect(
+      screen.getByText("Salvar Registro da Ocorrência"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Deseja salvar o registro da ocorrência/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Você ainda poderá editar o registro até o envio da Medição Inicial/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("não deve renderizar o modal quando show = false", () => {
+    setup(false);
+
+    expect(
+      screen.queryByText("Salvar Registro da Ocorrência"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("deve fechar o modal ao clicar no botão de fechar", () => {
+    setup(true);
+
+    const botaoFechar = screen.getByRole("button", {
+      name: /close/i,
+    });
+    fireEvent.click(botaoFechar);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("deve clicar em 'Não' e chamar handleClose", () => {
+    setup(true);
+
+    const botaoNao = screen.getByRole("button", {
+      name: /Não/i,
+    });
+    fireEvent.click(botaoNao);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(salvar).not.toHaveBeenCalled();
+  });
+
+  it("deve clicar em 'Sim', chamar salvar com values e depois handleClose", async () => {
+    salvar.mockResolvedValue();
+
+    setup(true);
+
+    const botaoSim = screen.getByRole("button", {
+      name: /Sim/i,
+    });
+    fireEvent.click(botaoSim);
+
+    await waitFor(() => {
+      expect(salvar).toHaveBeenCalledTimes(1);
+      expect(salvar).toHaveBeenCalledWith(values);
+    });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/seletor_categoria.test.jsx
+++ b/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/seletor_categoria.test.jsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Form } from "react-final-form";
+import { SeletorCategoria } from "../../components/SeletorCategoria";
+
+describe("Testes de comportamentos componente - SeletorCategoria", () => {
+  const setTiposOcorrenciaDaCategoria = jest.fn();
+
+  const categorias = [
+    { nome: "Categoria 1", uuid: "categoria-1" },
+    { nome: "Categoria 2", uuid: "categoria-2" },
+  ];
+
+  const tiposOcorrencia = [
+    {
+      uuid: "tipo-1",
+      titulo: "Tipo Ocorrência 1",
+      descricao: "Descrição 1",
+      aceita_multiplas_respostas: false,
+      posicao: 1,
+      parametrizacoes: [],
+      penalidade: {},
+      categoria: { uuid: "categoria-1", nome: "Categoria 1" },
+    },
+    {
+      uuid: "tipo-2",
+      titulo: "Tipo Ocorrência 2",
+      descricao: "Descrição 2",
+      aceita_multiplas_respostas: true,
+      posicao: 2,
+      parametrizacoes: [],
+      penalidade: {},
+      categoria: { uuid: "categoria-2", nome: "Categoria 2" },
+    },
+  ];
+
+  const setup = () =>
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        render={() => (
+          <SeletorCategoria
+            categorias={categorias}
+            setTiposOcorrenciaDaCategoria={setTiposOcorrenciaDaCategoria}
+            tiposOcorrencia={tiposOcorrencia}
+          />
+        )}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o campo de seleção com o label correto", () => {
+    setup();
+
+    expect(screen.getByText("Categoria da Ocorrência")).toBeInTheDocument();
+  });
+
+  it("deve renderizar a opção padrão e as categorias", () => {
+    setup();
+
+    expect(screen.getByText("Selecione uma categoria")).toBeInTheDocument();
+    expect(screen.getByText("Categoria 1")).toBeInTheDocument();
+    expect(screen.getByText("Categoria 2")).toBeInTheDocument();
+  });
+
+  it("deve filtrar os tipos de ocorrência ao selecionar uma categoria", () => {
+    setup();
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, {
+      target: { value: "categoria-1" },
+    });
+
+    expect(setTiposOcorrenciaDaCategoria).toHaveBeenCalledWith([
+      expect.objectContaining({
+        uuid: "tipo-1",
+        nome: "Tipo Ocorrência 1",
+      }),
+    ]);
+  });
+
+  it("deve retornar array vazio quando nenhuma categoria correspondente for encontrada", () => {
+    setup();
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, {
+      target: { value: "categoria-inexistente" },
+    });
+
+    expect(setTiposOcorrenciaDaCategoria).toHaveBeenCalledWith([]);
+  });
+});

--- a/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/seletor_tipo_ocorrencia.test.jsx
+++ b/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/components/seletor_tipo_ocorrencia.test.jsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Form } from "react-final-form";
+import { SeletorTipoOcorrencia } from "../../components/SeletorTipoOcorrencia";
+
+describe("Testes de comportamentos componente - SeletorTipoOcorrencia", () => {
+  const setTipoOcorrencia = jest.fn();
+
+  const form = {
+    change: jest.fn(),
+  };
+
+  const tiposOcorrencia = [
+    {
+      uuid: "tipo-1",
+      titulo: "Tipo 1",
+      descricao: "Desc",
+      aceita_multiplas_respostas: false,
+      posicao: 1,
+      parametrizacoes: [],
+      penalidade: {},
+      categoria: { uuid: "cat-1", nome: "Categoria 1" },
+    },
+    {
+      uuid: "tipo-2",
+      titulo: "Tipo 2",
+      descricao: "Desc",
+      aceita_multiplas_respostas: false,
+      posicao: 2,
+      parametrizacoes: [],
+      penalidade: {},
+      categoria: { uuid: "cat-1", nome: "Categoria 1" },
+    },
+  ];
+
+  const tiposOcorrenciaDaCategoria = [...tiposOcorrencia];
+
+  const renderComponent = (values = { categoria: "cat-1" }) =>
+    render(
+      <Form
+        onSubmit={jest.fn()}
+        render={() => (
+          <SeletorTipoOcorrencia
+            setTipoOcorrencia={setTipoOcorrencia}
+            tiposOcorrencia={tiposOcorrencia}
+            tiposOcorrenciaDaCategoria={tiposOcorrenciaDaCategoria}
+            values={values}
+            form={form}
+          />
+        )}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o label e opções", () => {
+    renderComponent();
+
+    expect(screen.getByText("Tipos de Ocorrência")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Selecione um tipo de ocorrência"),
+    ).toBeInTheDocument();
+
+    const options = screen.getAllByRole("option");
+
+    expect(options).toHaveLength(3);
+
+    expect(options[1]).toHaveValue("tipo-1");
+    expect(options[2]).toHaveValue("tipo-2");
+  });
+
+  it("deve estar desabilitado quando não houver categoria", () => {
+    renderComponent({ categoria: "" });
+
+    const select = screen.getByRole("combobox");
+
+    expect(select).toBeDisabled();
+  });
+
+  it("deve estar habilitado quando houver categoria", () => {
+    renderComponent({ categoria: "cat-1" });
+
+    const select = screen.getByRole("combobox");
+
+    expect(select).not.toBeDisabled();
+  });
+
+  it("deve chamar setTipoOcorrencia e form.change ao selecionar um tipo", async () => {
+    renderComponent();
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, {
+      target: { value: "tipo-1" },
+    });
+
+    await waitFor(() => {
+      expect(setTipoOcorrencia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          uuid: "tipo-1",
+        }),
+      );
+    });
+
+    expect(form.change).toHaveBeenCalledWith("grupos", [{}]);
+  });
+
+  it("deve passar undefined para setTipoOcorrencia se não encontrar o tipo", async () => {
+    renderComponent();
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, {
+      target: { value: "inexistente" },
+    });
+
+    await waitFor(() => {
+      expect(setTipoOcorrencia).toHaveBeenCalledWith(undefined);
+    });
+
+    expect(form.change).toHaveBeenCalledWith("grupos", [{}]);
+  });
+});

--- a/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/helpers.test.jsx
+++ b/src/components/screens/IMR/RegistrarNovaOcorrencia/__tests__/helpers.test.jsx
@@ -1,0 +1,121 @@
+import { formataPayload } from "../helpers";
+
+describe("Helpers formataPayload - Registrar Nova Corrência", () => {
+  it("deve formatar o payload corretamente com ocorrências e solicitacao_medicao_inicial", () => {
+    const values = {
+      categoria: "categoria_teste",
+      tipo_ocorrencia: "tipo_teste",
+      datas: ["2026-04-29"],
+      ocorrencias: [],
+      grupos: [
+        {
+          campo_tipo_uuidTipo1_param_uuidParam1: "Resposta 1",
+          campo_tipo_uuidTipo1_param_uuidParam2: true,
+        },
+        {
+          campo_tipo_uuidTipo2_param_uuidParam3: 10,
+        },
+      ],
+    };
+
+    const result = formataPayload(values, "uuid-solicitacao-medicao-inicial");
+
+    expect(result.solicitacao_medicao_inicial).toBe(
+      "uuid-solicitacao-medicao-inicial",
+    );
+
+    expect(result.ocorrencias).toEqual([
+      {
+        tipoOcorrencia: "uuidTipo1",
+        parametrizacao: "uuidParam1",
+        resposta: "Resposta 1",
+        grupo: 1,
+      },
+      {
+        tipoOcorrencia: "uuidTipo1",
+        parametrizacao: "uuidParam2",
+        resposta: true,
+        grupo: 1,
+      },
+      {
+        tipoOcorrencia: "uuidTipo2",
+        parametrizacao: "uuidParam3",
+        resposta: 10,
+        grupo: 2,
+      },
+    ]);
+  });
+
+  it("deve sobrescrever resposta duplicada quando a resposta anterior for string", () => {
+    const values = {
+      categoria: "categoria_teste",
+      tipo_ocorrencia: "tipo_teste",
+      datas: ["2026-04-29"],
+      ocorrencias: [],
+      grupos: [
+        {
+          campo_tipo_uuidTipo1_param_uuidParam1: "Resposta inicial",
+          outro_tipo_uuidTipo1_param_uuidParam1: false,
+        },
+      ],
+    };
+
+    const result = formataPayload(values, "uuid-solicitacao-medicao-inicial");
+
+    expect(result.ocorrencias).toEqual([
+      {
+        tipoOcorrencia: "uuidTipo1",
+        parametrizacao: "uuidParam1",
+        resposta: false,
+        grupo: 1,
+      },
+    ]);
+  });
+
+  it("não deve sobrescrever resposta duplicada quando a resposta anterior não for string", () => {
+    const values = {
+      categoria: "categoria_teste",
+      tipo_ocorrencia: "tipo_teste",
+      datas: ["2026-04-29"],
+      ocorrencias: [],
+      grupos: [
+        {
+          campo_tipo_uuidTipo1_param_uuidParam1: true,
+          outro_tipo_uuidTipo1_param_uuidParam1: "Nova resposta",
+        },
+      ],
+    };
+
+    const result = formataPayload(values, "uuid-solicitacao-medicao-inicial");
+
+    expect(result.ocorrencias).toEqual([
+      {
+        tipoOcorrencia: "uuidTipo1",
+        parametrizacao: "uuidParam1",
+        resposta: true,
+        grupo: 1,
+      },
+    ]);
+  });
+
+  it("não deve mutar o objeto original", () => {
+    const values = {
+      categoria: "categoria_teste",
+      tipo_ocorrencia: "tipo_teste",
+      datas: ["2026-04-29"],
+      ocorrencias: [],
+      grupos: [
+        {
+          campo_tipo_uuidTipo1_param_uuidParam1: "Resposta original",
+        },
+      ],
+    };
+
+    const valuesOriginal = JSON.parse(JSON.stringify(values));
+
+    formataPayload(values, "novo-uuid");
+
+    expect(values).toEqual(valuesOriginal);
+    expect(values.solicitacao_medicao_inicial).toBeUndefined();
+  });
+});


### PR DESCRIPTION
**Este pull request**
Implementa novos testes relacionados a interface de Registrar Nova Ocorrência:
- Helpers.jsx
- ModalSalvar
- ModalCancelaPreenchimento
- SeletorCategoria
- SeletorTipoOcorrencia

Referência no Azure: [AB#147778](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/147778)