### PR TITLE
Feature/147778 testes novo relatorio visitas

### DIFF
--- a/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalCancelaPreenchimento.test.jsx
+++ b/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalCancelaPreenchimento.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ModalCancelaPreenchimento } from "../../components/ModalCancelaPreenchimento";
+
+describe("Testes de comportamentos componente - ModalCancelaPreenchimento (Novo Relatório de Visitas)", () => {
+  const handleClose = jest.fn();
+  const navigate = jest.fn();
+
+  const form = {
+    reset: jest.fn(),
+  };
+
+  const setup = (show = true) =>
+    render(
+      <ModalCancelaPreenchimento
+        show={show}
+        handleClose={handleClose}
+        form={form}
+        navigate={navigate}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o título e o texto corretamente quando show = true", () => {
+    setup(true);
+
+    expect(screen.getByText("Cancelar Preenchimento")).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Deseja cancelar o preenchimento do Relatório/i),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        /As informações preenchidas serão perdidas e o formulário não será salvo/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("não deve renderizar o modal quando show = false", () => {
+    setup(false);
+
+    expect(
+      screen.queryByText("Cancelar Preenchimento"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("deve fechar o modal ao clicar no botão de fechar", () => {
+    setup(true);
+
+    const botaoFechar = screen.getByRole("button", { name: /close/i });
+
+    fireEvent.click(botaoFechar);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("deve clicar em 'Não' e chamar handleClose", () => {
+    setup(true);
+
+    const botaoNao = screen.getByRole("button", { name: /Não/i });
+
+    fireEvent.click(botaoNao);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(form.reset).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("deve clicar em 'Sim', resetar o form, fechar o modal e navegar para trás", () => {
+    setup(true);
+
+    const botaoSim = screen.getByRole("button", { name: /Sim/i });
+
+    fireEvent.click(botaoSim);
+
+    expect(form.reset).toHaveBeenCalledTimes(1);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledWith(-1);
+  });
+});

--- a/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvar.test.jsx
+++ b/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvar.test.jsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModalSalvar } from "../../components/ModalSalvar";
+
+describe("Testes de comportamentos componente - Modal Salvar (Novo Relatório de Visitas)", () => {
+  const handleClose = jest.fn();
+  const salvar = jest.fn();
+
+  const values = {
+    campo1: "valor",
+  };
+
+  const escolaSelecionada = {
+    label: "ESCOLA CEI CEU",
+    value: "9f1c2a7e-3b44-4d91-8a6e-5c2f7b9e1a3d",
+  };
+
+  const setup = (show = true) =>
+    render(
+      <ModalSalvar
+        show={show}
+        handleClose={handleClose}
+        salvar={salvar}
+        values={values}
+        escolaSelecionada={escolaSelecionada}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o título e o texto corretamente quando show = true", () => {
+    setup(true);
+
+    expect(
+      screen.getByText("Enviar Relatório de Fiscalização"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Deseja enviar seu relatório de fiscalização/i),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("ESCOLA CEI CEU")).toBeInTheDocument();
+  });
+
+  it("não deve renderizar o modal quando show = false", () => {
+    setup(false);
+
+    expect(
+      screen.queryByText("Enviar Relatório de Fiscalização"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("deve fechar o modal ao clicar no botão de fechar", () => {
+    setup(true);
+
+    const botaoFechar = screen.getByRole("button", { name: /close/i });
+
+    fireEvent.click(botaoFechar);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("deve clicar em 'Não' e chamar handleClose", () => {
+    setup(true);
+
+    const botaoNao = screen.getByRole("button", { name: /Não/i });
+
+    fireEvent.click(botaoNao);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(salvar).not.toHaveBeenCalled();
+  });
+
+  it("deve clicar em 'Sim', chamar salvar com values e depois fechar o modal", async () => {
+    salvar.mockResolvedValue();
+
+    setup(true);
+
+    const botaoSim = screen.getByRole("button", { name: /Sim/i });
+
+    fireEvent.click(botaoSim);
+
+    await waitFor(() => {
+      expect(salvar).toHaveBeenCalledWith(values);
+    });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvarRascunho.test.jsx
+++ b/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvarRascunho.test.jsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ModalSalvarRascunho } from "../../components/ModalSalvarRascunho";
+
+describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo Relatório de Visitas)", () => {
+  const handleClose = jest.fn();
+  const salvarRascunho = jest.fn();
+
+  const values = {
+    campo1: "valor",
+  };
+
+  const escolaSelecionada = {
+    label: "ESCOLA CEI CEU",
+    value: "9f1c2a7e-3b44-4d91-8a6e-5c2f7b9e1a3d",
+  };
+
+  const renderComponent = (show = true) =>
+    render(
+      <ModalSalvarRascunho
+        show={show}
+        handleClose={handleClose}
+        salvarRascunho={salvarRascunho}
+        values={values}
+        escolaSelecionada={escolaSelecionada}
+      />,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deve renderizar o título e o texto corretamente quando show = true", () => {
+    renderComponent(true);
+
+    expect(screen.getByText("Salvar Rascunho")).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Deseja salvar o rascunho do relatório/i),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("ESCOLA CEI CEU")).toBeInTheDocument();
+  });
+
+  it("não deve renderizar o modal quando show = false", () => {
+    renderComponent(false);
+
+    expect(screen.queryByText("Salvar Rascunho")).not.toBeInTheDocument();
+  });
+
+  it("deve fechar o modal ao clicar no botão de fechar", () => {
+    renderComponent(true);
+
+    const botaoFechar = screen.getByRole("button", { name: /close/i });
+
+    fireEvent.click(botaoFechar);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("deve clicar em 'Não' e chamar handleClose", () => {
+    renderComponent(true);
+
+    const botaoNao = screen.getByRole("button", { name: /Não/i });
+
+    fireEvent.click(botaoNao);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+    expect(salvarRascunho).not.toHaveBeenCalled();
+  });
+
+  it("deve clicar em 'Sim', chamar salvarRascunho com values e depois fechar o modal", async () => {
+    salvarRascunho.mockResolvedValue();
+
+    renderComponent(true);
+
+    const botaoSim = screen.getByRole("button", { name: /Sim/i });
+
+    fireEvent.click(botaoSim);
+
+    await waitFor(() => {
+      expect(salvarRascunho).toHaveBeenCalledWith(values);
+    });
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvarRascunho.test.jsx
+++ b/src/components/screens/IMR/Terceirizadas/RelatorioFiscalizacaoTerceirizadas/NovoRelatorioVisitas/components/__tests__/ModalSalvarRascunho.test.jsx
@@ -14,7 +14,7 @@ describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo RelatÃ
     value: "9f1c2a7e-3b44-4d91-8a6e-5c2f7b9e1a3d",
   };
 
-  const renderComponent = (show = true) =>
+  const setup = (show = true) =>
     render(
       <ModalSalvarRascunho
         show={show}
@@ -30,7 +30,7 @@ describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo RelatÃ
   });
 
   it("deve renderizar o tÃ­tulo e o texto corretamente quando show = true", () => {
-    renderComponent(true);
+    setup(true);
 
     expect(screen.getByText("Salvar Rascunho")).toBeInTheDocument();
 
@@ -42,13 +42,13 @@ describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo RelatÃ
   });
 
   it("nÃ£o deve renderizar o modal quando show = false", () => {
-    renderComponent(false);
+    setup(false);
 
     expect(screen.queryByText("Salvar Rascunho")).not.toBeInTheDocument();
   });
 
   it("deve fechar o modal ao clicar no botÃ£o de fechar", () => {
-    renderComponent(true);
+    setup(true);
 
     const botaoFechar = screen.getByRole("button", { name: /close/i });
 
@@ -58,7 +58,7 @@ describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo RelatÃ
   });
 
   it("deve clicar em 'NÃ£o' e chamar handleClose", () => {
-    renderComponent(true);
+    setup(true);
 
     const botaoNao = screen.getByRole("button", { name: /NÃ£o/i });
 
@@ -71,7 +71,7 @@ describe("Testes de comportamentos componente - ModalSalvarRascunho (Novo RelatÃ
   it("deve clicar em 'Sim', chamar salvarRascunho com values e depois fechar o modal", async () => {
     salvarRascunho.mockResolvedValue();
 
-    renderComponent(true);
+    setup(true);
 
     const botaoSim = screen.getByRole("button", { name: /Sim/i });
 


### PR DESCRIPTION
**Este pull request**
Implementa testes unitários referente a Novo Registro de Visitas - Relatório Fiscalização de Terceirizadas:
- ModalSalvar
- ModalSalvarRascunho
- ModalCancelarPreenchimento

Referência no Azure: [AB#147778](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/147778)