### PR TITLE
Feature/145337 ajuste mensagem botao voltar

### DIFF
--- a/src/components/Shareable/Page/ModalVoltar.jsx
+++ b/src/components/Shareable/Page/ModalVoltar.jsx
@@ -30,20 +30,20 @@ const ModalVoltar = ({
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
+        <p>Deseja voltar para a tela anterior?</p>
+
         {textoModalVoltar ? (
           <p> {textoModalVoltar} </p>
         ) : (
           <p>
-            Existem informações não salvas. Ao voltar à tela anterior, as
-            informações inseridas serão perdidas.
+            Verifique se todas as informações importantes já foram salvas antes
+            de sair.
           </p>
         )}
-
-        <p>Deseja retornar a tela anterior?</p>
       </Modal.Body>
       <Modal.Footer>
         <Botao
-          texto="Voltar sem Salvar"
+          texto="Voltar à Tela Anterior"
           type={BUTTON_TYPE.BUTTON}
           onClick={() => {
             voltarPagina();

--- a/src/components/Shareable/Page/__tests__/teste_ModalVoltar.jsx
+++ b/src/components/Shareable/Page/__tests__/teste_ModalVoltar.jsx
@@ -1,0 +1,36 @@
+import { act, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import ModalVoltar from "../ModalVoltar";
+
+describe("Testa componente <ModalVoltar>", () => {
+  beforeEach(async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <ModalVoltar
+            modalVoltar={true}
+            voltarPara="/"
+            setModalVoltar={jest.fn()}
+          />
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("Renderiza o modal corretamente", async () => {
+    expect(screen.getByText("Voltar a tela anterior")).toBeInTheDocument();
+    expect(
+      screen.getByText("Deseja voltar para a tela anterior?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Verifique se todas as informações importantes já foram salvas antes de sair.",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Este PR

 - Ajusta texto do ModalVoltar para uma opção mais genérica;
 - Adiciona teste unitário para validar conteúdo do Modal.

### Referência Azure

 - [AB#145337](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/145337)