### PR TITLE
Feature/148146 tooltip feriado programas projetos

### DIFF
--- a/src/components/Shareable/Input/InputValueMedicao/index.jsx
+++ b/src/components/Shareable/Input/InputValueMedicao/index.jsx
@@ -148,7 +148,8 @@ export const InputText = (props) => {
         exibeTooltipDietasInclusaoDiaNaoLetivoCEI ||
         exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI ||
         exibirTooltipPeriodosZeradosNoProgramasProjetos ||
-        exibeTooltipSuspensoesAutorizadasCEI)
+        exibeTooltipSuspensoesAutorizadasCEI ||
+        exibirTooltipFeriado)
     );
   };
 

--- a/src/components/Shareable/Input/InputValueMedicao/index.jsx
+++ b/src/components/Shareable/Input/InputValueMedicao/index.jsx
@@ -63,6 +63,7 @@ export const InputText = (props) => {
     exibeTooltipFrequenciaAlimentacaoZero,
     exibirTooltipPeriodosZeradosNoProgramasProjetos,
     exibirTooltipRefeicaoSimultanea,
+    exibirTooltipFeriado,
   } = props;
 
   const inputProps = {
@@ -167,6 +168,18 @@ export const InputText = (props) => {
           {label}
         </label>,
       ]}
+      {exibirTooltipFeriado && (
+        <Tooltip
+          title={
+            "A data selecionada corresponde a um feriado. Verifique se o apontamento está correto."
+          }
+        >
+          <i
+            data-testid="icone-tooltip-warning"
+            className="fas fa-info icone-info-warning"
+          />
+        </Tooltip>
+      )}
       {exibeTooltipPadraoRepeticaoDiasSobremesaDoce && (
         <Tooltip title={"Dia de sobremesa doce."}>
           <i className="fas fa-info icone-info-success" />

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -330,6 +330,7 @@ export const desabilitarField = (
   ehUltimoDiaLetivoDoAno,
 ) => {
   const grupoRecreio = ehGrupoRecreioNasFerias(grupoLocation);
+  const ehProgramasEProjetos = grupoLocation === "Programas e Projetos";
   const valorAtual = values[`${rowName}__dia_${dia}__categoria_${categoria}`];
 
   if (["Mês anterior", "Mês posterior"].includes(valorAtual)) {
@@ -427,10 +428,7 @@ export const desabilitarField = (
               alunosTabSelecionada,
         )
       ) {
-        if (
-          grupoLocation === "Programas e Projetos" &&
-          !valorFieldParaCorrecao
-        ) {
+        if (ehProgramasEProjetos && !valorFieldParaCorrecao) {
           return true;
         }
         return false;
@@ -560,10 +558,7 @@ export const desabilitarField = (
       );
     }
   }
-  if (
-    grupoLocation === "Programas e Projetos" ||
-    location.state?.periodoEspecifico
-  ) {
+  if (ehProgramasEProjetos || location.state?.periodoEspecifico) {
     return (
       validacaoSemana(dia) ||
       rowName === "numero_de_alunos" ||
@@ -591,10 +586,7 @@ export const desabilitarField = (
       )
     );
   }
-  if (
-    grupoLocation === "Programas e Projetos" &&
-    dadosValoresInclusoesAutorizadasState
-  ) {
+  if (ehProgramasEProjetos && dadosValoresInclusoesAutorizadasState) {
     if (feriadosNoMes.includes(dia)) {
       return true;
     }
@@ -716,8 +708,7 @@ export const desabilitarField = (
     return true;
   }
   if (
-    (location.state?.ehPeriodoEspecifico ||
-      grupoLocation === "Programas e Projetos") &&
+    (location.state?.ehPeriodoEspecifico || ehProgramasEProjetos) &&
     inclusoesAutorizadas?.length > 0 &&
     nomeCategoria.includes("DIETA ESPECIAL") &&
     !inclusoesAutorizadas.some((inclusao) => inclusao.dia === dia)

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -128,6 +128,8 @@ import {
   boqueaSalvamentoPeriodosZeradosNoProgramasProjetos,
   exibirTooltipRefeicaoSimultanea,
   bloquearSalvamentoRefeicaoSimultanea,
+  verificaFeriadoProgramasProjetos,
+  obrigarAdiocionarFeriadoProgramasProjetos,
 } from "./validacoes";
 
 export default () => {
@@ -249,6 +251,7 @@ export default () => {
   const ehGrupoETECUrlParam =
     urlParams.get("ehGrupoETEC") === "true" ? true : false;
   const grupoLocation = location && location.state && location.state.grupo;
+  const ehProgramasEProjetos = grupoLocation === "Programas e Projetos";
 
   const getListaDiasSobremesaDoceAsync = async (escola_uuid) => {
     const params = {
@@ -1672,21 +1675,37 @@ export default () => {
     if (
       formValuesAtualizados &&
       formValuesAtualizados["periodo_escolar"] === "Programas e Projetos" &&
-      diasFrequenciaZerada &&
       weekColumns
     ) {
-      const bloquearBotao = boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
-        "frequencia",
-        categoriasDeMedicao,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        formValuesAtualizados["periodo_escolar"],
-        escolaEhEMEBS(),
-        alunosTabSelecionada,
-        weekColumns,
-      );
-      setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-      setExibirTooltip(bloquearBotao || temErrosFormulario);
+      if (diasFrequenciaZerada) {
+        const bloquearBotao =
+          boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
+            "frequencia",
+            categoriasDeMedicao,
+            formValuesAtualizados,
+            diasFrequenciaZerada,
+            formValuesAtualizados["periodo_escolar"],
+            escolaEhEMEBS(),
+            alunosTabSelecionada,
+            weekColumns,
+          );
+        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
+        setExibirTooltip(bloquearBotao || temErrosFormulario);
+      }
+
+      if (categoriasDeMedicao.length > 0) {
+        const bloquearBotao = weekColumns.some((week) =>
+          obrigarAdiocionarFeriadoProgramasProjetos(
+            week,
+            categoriasDeMedicao.find(
+              (categoria) => categoria.nome === "ALIMENTAÇÃO",
+            ),
+            formValuesAtualizados,
+          ),
+        );
+        setDisableBotaoSalvarLancamentos(bloquearBotao);
+        setExibirTooltip(bloquearBotao);
+      }
     }
 
     if (
@@ -3339,6 +3358,7 @@ export default () => {
                                                             diasFrequenciaZerada,
                                                             escolaEhEMEBS(),
                                                             alunosTabSelecionada,
+                                                            validacaoDiaLetivo,
                                                           )
                                                             ? textoBotaoObservacao(
                                                                 formValuesAtualizados[
@@ -3533,98 +3553,122 @@ export default () => {
                                                     {row.nome}
                                                   </b>
                                                 </div>
-                                                {weekColumns.map((column) => (
-                                                  <div
-                                                    key={column.dia}
-                                                    className={`${
-                                                      colunaDesabilitada(column)
-                                                        ? "input-desabilitado"
-                                                        : row.name ===
-                                                            "observacoes"
-                                                          ? "input-habilitado-observacoes"
-                                                          : "input-habilitado"
-                                                    }${
-                                                      alimentacoesLancamentosEspeciais?.includes(
-                                                        row.name,
-                                                      )
-                                                        ? " input-alimentacao-permissao-lancamento-especial"
-                                                        : ""
-                                                    }`}
-                                                  >
-                                                    {row.name ===
-                                                    "observacoes" ? (
-                                                      !colunaDesabilitada(
-                                                        column,
-                                                      ) &&
-                                                      exibeBotaoAdicionarObservacao(
-                                                        column.dia,
-                                                        categoria.id,
-                                                      ) && (
-                                                        <Botao
-                                                          texto={textoBotaoObservacao(
-                                                            formValuesAtualizados[
-                                                              `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                            ],
-                                                            valoresObservacoes,
-                                                            column.dia,
-                                                            categoria.id,
-                                                            escolaEhEMEBS(),
-                                                            alunosTabSelecionada,
-                                                            formValuesAtualizados,
-                                                          )}
-                                                          dataTestId={`botao-observacao__dia_${column.dia}__categoria_${categoria.id}`}
-                                                          disabled={desabilitarBotaoColunaObservacoes(
-                                                            location,
-                                                            valoresPeriodosLancamentos,
-                                                            column,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            valoresObservacoes,
-                                                            column.dia,
-                                                            diasParaCorrecao,
-                                                          )}
-                                                          type={
-                                                            BUTTON_TYPE.BUTTON
-                                                          }
-                                                          style={
-                                                            botaoAdicionarObrigatorioTabelaAlimentacao(
-                                                              formValuesAtualizados,
+                                                {weekColumns.map((column) => {
+                                                  const campoDesabilitado =
+                                                    desabilitarField(
+                                                      column.dia,
+                                                      row.name,
+                                                      categoria.id,
+                                                      categoria.nome,
+                                                      formValuesAtualizados,
+                                                      mesAnoConsiderado,
+                                                      mesAnoDefault,
+                                                      dadosValoresInclusoesAutorizadasState,
+                                                      validacaoDiaLetivo,
+                                                      validacaoDiaLetivoCalendario,
+                                                      validacaoDiaLetivoLancheEmergencial,
+                                                      validacaoSemana,
+                                                      location,
+                                                      ehGrupoETECUrlParam,
+                                                      dadosValoresInclusoesEtecAutorizadasState,
+                                                      inclusoesEtecAutorizadas,
+                                                      grupoLocation,
+                                                      valoresPeriodosLancamentos,
+                                                      feriadosNoMes,
+                                                      inclusoesAutorizadas,
+                                                      categoriasDeMedicao,
+                                                      kitLanchesAutorizadas,
+                                                      alteracoesAlimentacaoAutorizadas,
+                                                      diasLancheEmergencialDiarioAtivo,
+                                                      diasParaCorrecao,
+                                                      ehPeriodoEscolarSimples,
+                                                      permissoesLancamentosEspeciaisPorDia,
+                                                      alimentacoesLancamentosEspeciais,
+                                                      escolaEhEMEBS(),
+                                                      alunosTabSelecionada,
+                                                      ehUltimoDiaLetivoDoAno,
+                                                    );
+
+                                                  return (
+                                                    <div
+                                                      key={column.dia}
+                                                      className={`${
+                                                        colunaDesabilitada(
+                                                          column,
+                                                        )
+                                                          ? "input-desabilitado"
+                                                          : row.name ===
+                                                              "observacoes"
+                                                            ? "input-habilitado-observacoes"
+                                                            : "input-habilitado"
+                                                      }${
+                                                        alimentacoesLancamentosEspeciais?.includes(
+                                                          row.name,
+                                                        )
+                                                          ? " input-alimentacao-permissao-lancamento-especial"
+                                                          : ""
+                                                      }`}
+                                                    >
+                                                      {row.name ===
+                                                      "observacoes" ? (
+                                                        !colunaDesabilitada(
+                                                          column,
+                                                        ) &&
+                                                        exibeBotaoAdicionarObservacao(
+                                                          column.dia,
+                                                          categoria.id,
+                                                        ) && (
+                                                          <Botao
+                                                            texto={textoBotaoObservacao(
+                                                              formValuesAtualizados[
+                                                                `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                              ],
+                                                              valoresObservacoes,
                                                               column.dia,
-                                                              categoria,
-                                                              diasSobremesaDoce,
-                                                              location,
-                                                              row,
-                                                              dadosValoresInclusoesAutorizadasState,
-                                                              validacaoDiaLetivo,
-                                                              column,
-                                                              suspensoesAutorizadas,
-                                                              alteracoesAlimentacaoAutorizadas,
-                                                              alteracoesLancheEmergencialAutorizadas,
-                                                              permissoesLancamentosEspeciaisPorDia,
-                                                              kitLanchesAutorizadas,
-                                                              inclusoesEtecAutorizadas,
-                                                              ehGrupoETECUrlParam,
-                                                              feriadosNoMes,
-                                                              diasFrequenciaZerada,
+                                                              categoria.id,
                                                               escolaEhEMEBS(),
                                                               alunosTabSelecionada,
-                                                            )
-                                                              ? textoBotaoObservacao(
-                                                                  formValuesAtualizados[
-                                                                    `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                                  ],
-                                                                  valoresObservacoes,
-                                                                  column.dia,
-                                                                  categoria.id,
-                                                                  escolaEhEMEBS(),
-                                                                  alunosTabSelecionada,
-                                                                  formValuesAtualizados,
-                                                                ) ===
-                                                                "Visualizar"
-                                                                ? BUTTON_STYLE.RED
-                                                                : BUTTON_STYLE.RED_OUTLINE
-                                                              : textoBotaoObservacao(
+                                                              formValuesAtualizados,
+                                                            )}
+                                                            dataTestId={`botao-observacao__dia_${column.dia}__categoria_${categoria.id}`}
+                                                            disabled={desabilitarBotaoColunaObservacoes(
+                                                              location,
+                                                              valoresPeriodosLancamentos,
+                                                              column,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              valoresObservacoes,
+                                                              column.dia,
+                                                              diasParaCorrecao,
+                                                            )}
+                                                            type={
+                                                              BUTTON_TYPE.BUTTON
+                                                            }
+                                                            style={
+                                                              botaoAdicionarObrigatorioTabelaAlimentacao(
+                                                                formValuesAtualizados,
+                                                                column.dia,
+                                                                categoria,
+                                                                diasSobremesaDoce,
+                                                                location,
+                                                                row,
+                                                                dadosValoresInclusoesAutorizadasState,
+                                                                validacaoDiaLetivo,
+                                                                column,
+                                                                suspensoesAutorizadas,
+                                                                alteracoesAlimentacaoAutorizadas,
+                                                                alteracoesLancheEmergencialAutorizadas,
+                                                                permissoesLancamentosEspeciaisPorDia,
+                                                                kitLanchesAutorizadas,
+                                                                inclusoesEtecAutorizadas,
+                                                                ehGrupoETECUrlParam,
+                                                                feriadosNoMes,
+                                                                diasFrequenciaZerada,
+                                                                escolaEhEMEBS(),
+                                                                alunosTabSelecionada,
+                                                              )
+                                                                ? textoBotaoObservacao(
                                                                     formValuesAtualizados[
                                                                       `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
                                                                     ],
@@ -3636,275 +3680,267 @@ export default () => {
                                                                     formValuesAtualizados,
                                                                   ) ===
                                                                   "Visualizar"
-                                                                ? BUTTON_STYLE.GREEN
-                                                                : BUTTON_STYLE.GREEN_OUTLINE_WHITE
-                                                          }
-                                                          onClick={() =>
-                                                            onClickBotaoObservacao(
-                                                              column.dia,
-                                                              categoria.id,
-                                                            )
-                                                          }
-                                                        />
-                                                      )
-                                                    ) : (
-                                                      <div className="field-values-input">
-                                                        <Field
-                                                          className={`m-2 ${classNameFieldTabelaAlimentacao(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            kitLanchesAutorizadas,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            valoresPeriodosLancamentos,
-                                                            diasParaCorrecao,
-                                                          )}`}
-                                                          component={
-                                                            InputValueMedicao
-                                                          }
-                                                          classNameToNextInput={getClassNameToNextInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          classNameToPrevInput={getClassNameToPrevInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          apenasNumeros
-                                                          name={`${row.name}__dia_${column.dia}__categoria_${categoria.id}`}
-                                                          disabled={desabilitarField(
-                                                            column.dia,
-                                                            row.name,
-                                                            categoria.id,
-                                                            categoria.nome,
-                                                            formValuesAtualizados,
-                                                            mesAnoConsiderado,
-                                                            mesAnoDefault,
-                                                            dadosValoresInclusoesAutorizadasState,
-                                                            validacaoDiaLetivo,
-                                                            validacaoDiaLetivoCalendario,
-                                                            validacaoDiaLetivoLancheEmergencial,
-                                                            validacaoSemana,
-                                                            location,
-                                                            ehGrupoETECUrlParam,
-                                                            dadosValoresInclusoesEtecAutorizadasState,
-                                                            inclusoesEtecAutorizadas,
-                                                            grupoLocation,
-                                                            valoresPeriodosLancamentos,
-                                                            feriadosNoMes,
-                                                            inclusoesAutorizadas,
-                                                            categoriasDeMedicao,
-                                                            kitLanchesAutorizadas,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            diasLancheEmergencialDiarioAtivo,
-                                                            diasParaCorrecao,
-                                                            ehPeriodoEscolarSimples,
-                                                            permissoesLancamentosEspeciaisPorDia,
-                                                            alimentacoesLancamentosEspeciais,
-                                                            escolaEhEMEBS(),
-                                                            alunosTabSelecionada,
-                                                            ehUltimoDiaLetivoDoAno,
-                                                          )}
-                                                          exibeTooltipPadraoRepeticaoDiasSobremesaDoce={exibirTooltipPadraoRepeticaoDiasSobremesaDoce(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            diasSobremesaDoce,
-                                                            location,
-                                                          )}
-                                                          exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero={exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            diasSobremesaDoce,
-                                                            location,
-                                                          )}
-                                                          exibeTooltipAlimentacoesAutorizadasDiaNaoLetivo={
-                                                            `${row.name}__dia_${column.dia}__categoria_${categoria.id}` in
-                                                              dadosValoresInclusoesAutorizadasState &&
-                                                            !validacaoDiaLetivo(
-                                                              column.dia,
-                                                            ) &&
-                                                            !formValuesAtualizados[
-                                                              `observacoes__dia_${column.dia}__categoria_${categoria.id}`
-                                                            ] &&
-                                                            !existeAlteracaoRPL(
+                                                                  ? BUTTON_STYLE.RED
+                                                                  : BUTTON_STYLE.RED_OUTLINE
+                                                                : textoBotaoObservacao(
+                                                                      formValuesAtualizados[
+                                                                        `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                                      ],
+                                                                      valoresObservacoes,
+                                                                      column.dia,
+                                                                      categoria.id,
+                                                                      escolaEhEMEBS(),
+                                                                      alunosTabSelecionada,
+                                                                      formValuesAtualizados,
+                                                                    ) ===
+                                                                    "Visualizar"
+                                                                  ? BUTTON_STYLE.GREEN
+                                                                  : BUTTON_STYLE.GREEN_OUTLINE_WHITE
+                                                            }
+                                                            onClick={() =>
+                                                              onClickBotaoObservacao(
+                                                                column.dia,
+                                                                categoria.id,
+                                                              )
+                                                            }
+                                                          />
+                                                        )
+                                                      ) : (
+                                                        <div className="field-values-input">
+                                                          <Field
+                                                            className={`m-2 ${classNameFieldTabelaAlimentacao(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              kitLanchesAutorizadas,
                                                               alteracoesAlimentacaoAutorizadas,
-                                                              column.dia,
-                                                            ) &&
-                                                            !existeAlteracaoLPR(
+                                                              valoresPeriodosLancamentos,
+                                                              diasParaCorrecao,
+                                                            )}`}
+                                                            component={
+                                                              InputValueMedicao
+                                                            }
+                                                            classNameToNextInput={getClassNameToNextInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            classNameToPrevInput={getClassNameToPrevInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            apenasNumeros
+                                                            name={`${row.name}__dia_${column.dia}__categoria_${categoria.id}`}
+                                                            disabled={
+                                                              campoDesabilitado
+                                                            }
+                                                            exibeTooltipPadraoRepeticaoDiasSobremesaDoce={exibirTooltipPadraoRepeticaoDiasSobremesaDoce(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              diasSobremesaDoce,
+                                                              location,
+                                                            )}
+                                                            exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero={exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              diasSobremesaDoce,
+                                                              location,
+                                                            )}
+                                                            exibeTooltipAlimentacoesAutorizadasDiaNaoLetivo={
+                                                              `${row.name}__dia_${column.dia}__categoria_${categoria.id}` in
+                                                                dadosValoresInclusoesAutorizadasState &&
+                                                              !validacaoDiaLetivo(
+                                                                column.dia,
+                                                              ) &&
+                                                              !formValuesAtualizados[
+                                                                `observacoes__dia_${column.dia}__categoria_${categoria.id}`
+                                                              ] &&
+                                                              !existeAlteracaoRPL(
+                                                                alteracoesAlimentacaoAutorizadas,
+                                                                column.dia,
+                                                              ) &&
+                                                              !existeAlteracaoLPR(
+                                                                alteracoesAlimentacaoAutorizadas,
+                                                                column.dia,
+                                                              )
+                                                            }
+                                                            exibeTooltipSuspensoesAutorizadas={exibirTooltipSuspensoesAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              suspensoesAutorizadas,
+                                                            )}
+                                                            exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
                                                               alteracoesAlimentacaoAutorizadas,
-                                                              column.dia,
-                                                            )
-                                                          }
-                                                          exibeTooltipSuspensoesAutorizadas={exibirTooltipSuspensoesAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            suspensoesAutorizadas,
-                                                          )}
-                                                          exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLPRAutorizadas={exibirTooltipLPRAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesLancheEmergencialAutorizadas,
-                                                            permissoesLancamentosEspeciaisPorDia,
-                                                          )}
-                                                          exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas={exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            kitLanchesAutorizadas,
-                                                          )}
-                                                          exibeTooltipKitLancheSolAlimentacoes={exibirTooltipKitLancheSolAlimentacoes(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            kitLanchesAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialNaoAutorizado={exibirTooltipLancheEmergencialNaoAutorizado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            diasLancheEmergencialDiarioAtivo,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialAutorizado={exibirTooltipLancheEmergencialAutorizado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialZeroAutorizado={exibirTooltipLancheEmergencialZeroAutorizado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            validacaoDiaLetivo,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialZeroAutorizadoJustificado={exibirTooltipLancheEmergencialZeroAutorizadoJustificado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            validacaoDiaLetivo,
-                                                          )}
-                                                          exibeTooltipFrequenciaZeroTabelaEtec={exibirTooltipFrequenciaZeroTabelaEtec(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            ehGrupoETECUrlParam,
-                                                          )}
-                                                          exibeTooltipLancheEmergTabelaEtec={exibirTooltipLancheEmergTabelaEtec(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            ehGrupoETECUrlParam,
-                                                            inclusoesEtecAutorizadas,
-                                                          )}
-                                                          exibirTooltipPeriodosZeradosNoProgramasProjetos={exibirTooltipPeriodosZeradosNoProgramasProjetos(
-                                                            row.name,
-                                                            column.dia,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            diasFrequenciaZerada,
-                                                            location.state
-                                                              .grupo,
-                                                            escolaEhEMEBS(),
-                                                            alunosTabSelecionada,
-                                                          )}
-                                                          exibirTooltipRefeicaoSimultanea={exibirTooltipRefeicaoSimultanea(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            usuarioEhEscolaCIEJA(),
-                                                            location.state
-                                                              .periodo,
-                                                          )}
-                                                          ehGrupoETECUrlParam={
-                                                            ehGrupoETECUrlParam
-                                                          }
-                                                          ehProgramasEProjetos={
-                                                            location.state
-                                                              .grupo ===
-                                                            "Programas e Projetos"
-                                                          }
-                                                          numeroDeInclusoesAutorizadas={
-                                                            dadosValoresInclusoesAutorizadasState[
-                                                              `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                            ]
-                                                          }
-                                                          defaultValue={defaultValue(
-                                                            column,
-                                                            row,
-                                                          )}
-                                                          validate={fieldValidationsTabelaAlimentacao(
-                                                            row.name,
-                                                            column.dia,
-                                                            categoria.id,
-                                                            categoria.nome,
-                                                          )}
-                                                          inputOnChange={(
-                                                            e,
-                                                          ) => {
-                                                            const value =
-                                                              e.target.value;
-
-                                                            onChangeInput(
-                                                              value,
-                                                              previousValue,
-                                                              form.getState()
-                                                                .errors,
-                                                              form.getState()
-                                                                .values,
+                                                            )}
+                                                            exibeTooltipLPRAutorizadas={exibirTooltipLPRAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesLancheEmergencialAutorizadas,
+                                                              permissoesLancamentosEspeciaisPorDia,
+                                                            )}
+                                                            exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas={exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              kitLanchesAutorizadas,
+                                                            )}
+                                                            exibeTooltipKitLancheSolAlimentacoes={exibirTooltipKitLancheSolAlimentacoes(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              kitLanchesAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialNaoAutorizado={exibirTooltipLancheEmergencialNaoAutorizado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                              diasLancheEmergencialDiarioAtivo,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialAutorizado={exibirTooltipLancheEmergencialAutorizado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialZeroAutorizado={exibirTooltipLancheEmergencialZeroAutorizado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                              validacaoDiaLetivo,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialZeroAutorizadoJustificado={exibirTooltipLancheEmergencialZeroAutorizadoJustificado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                              validacaoDiaLetivo,
+                                                            )}
+                                                            exibeTooltipFrequenciaZeroTabelaEtec={exibirTooltipFrequenciaZeroTabelaEtec(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              ehGrupoETECUrlParam,
+                                                            )}
+                                                            exibeTooltipLancheEmergTabelaEtec={exibirTooltipLancheEmergTabelaEtec(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              ehGrupoETECUrlParam,
+                                                              inclusoesEtecAutorizadas,
+                                                            )}
+                                                            exibirTooltipPeriodosZeradosNoProgramasProjetos={exibirTooltipPeriodosZeradosNoProgramasProjetos(
+                                                              row.name,
                                                               column.dia,
                                                               categoria,
-                                                              row.name,
-                                                              form,
+                                                              formValuesAtualizados,
+                                                              diasFrequenciaZerada,
+                                                              location.state
+                                                                .grupo,
+                                                              escolaEhEMEBS(),
+                                                              alunosTabSelecionada,
+                                                            )}
+                                                            exibirTooltipRefeicaoSimultanea={exibirTooltipRefeicaoSimultanea(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              usuarioEhEscolaCIEJA(),
+                                                              location.state
+                                                                .periodo,
+                                                            )}
+                                                            ehGrupoETECUrlParam={
+                                                              ehGrupoETECUrlParam
+                                                            }
+                                                            ehProgramasEProjetos={
+                                                              ehProgramasEProjetos
+                                                            }
+                                                            exibirTooltipFeriado={verificaFeriadoProgramasProjetos(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              campoDesabilitado,
+                                                              ehProgramasEProjetos,
+                                                              validacaoDiaLetivo,
+                                                              formValuesAtualizados,
+                                                            )}
+                                                            numeroDeInclusoesAutorizadas={
+                                                              dadosValoresInclusoesAutorizadasState[
+                                                                `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                              ]
+                                                            }
+                                                            defaultValue={defaultValue(
                                                               column,
                                                               row,
-                                                            );
+                                                            )}
+                                                            validate={fieldValidationsTabelaAlimentacao(
+                                                              row.name,
+                                                              column.dia,
+                                                              categoria.id,
+                                                              categoria.nome,
+                                                            )}
+                                                            inputOnChange={(
+                                                              e,
+                                                            ) => {
+                                                              const value =
+                                                                e.target.value;
 
-                                                            setPreviousValue(
-                                                              value,
-                                                            );
-                                                          }}
-                                                        />
-                                                      </div>
-                                                    )}
-                                                  </div>
-                                                ))}
+                                                              onChangeInput(
+                                                                value,
+                                                                previousValue,
+                                                                form.getState()
+                                                                  .errors,
+                                                                form.getState()
+                                                                  .values,
+                                                                column.dia,
+                                                                categoria,
+                                                                row.name,
+                                                                form,
+                                                                column,
+                                                                row,
+                                                              );
+
+                                                              setPreviousValue(
+                                                                value,
+                                                              );
+                                                            }}
+                                                          />
+                                                        </div>
+                                                      )}
+                                                    </div>
+                                                  );
+                                                })}
                                               </div>
                                             </Fragment>
                                           );

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1689,9 +1689,12 @@ export default () => {
             alunosTabSelecionada,
             weekColumns,
           );
-        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-        setExibirTooltip(bloquearBotao || temErrosFormulario);
-      } else if (categoriasDeMedicao.length > 0) {
+        const bloquear = bloquearBotao || temErrosFormulario;
+        setDisableBotaoSalvarLancamentos(bloquear);
+        setExibirTooltip(bloquear);
+        if (bloquear) return;
+      }
+      if (categoriasDeMedicao.length > 0) {
         const bloquearBotao = weekColumns.some((week) =>
           obrigarAdiocionarFeriadoProgramasProjetos(
             week,
@@ -1701,8 +1704,10 @@ export default () => {
             formValuesAtualizados,
           ),
         );
-        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-        setExibirTooltip(bloquearBotao || temErrosFormulario);
+        const bloquear = bloquearBotao || temErrosFormulario;
+        setDisableBotaoSalvarLancamentos(bloquear);
+        setExibirTooltip(bloquear);
+        if (bloquear) return;
       }
     }
 
@@ -1719,8 +1724,9 @@ export default () => {
         usuarioEhEscolaCIEJA(),
         location.state.periodo,
       );
-      setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-      setExibirTooltip(bloquearBotao || temErrosFormulario);
+      const bloquear = bloquearBotao || temErrosFormulario;
+      setDisableBotaoSalvarLancamentos(bloquear);
+      setExibirTooltip(bloquear);
     }
   }, [
     formValuesAtualizados,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1703,8 +1703,8 @@ export default () => {
             formValuesAtualizados,
           ),
         );
-        setDisableBotaoSalvarLancamentos(bloquearBotao);
-        setExibirTooltip(bloquearBotao);
+        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
+        setExibirTooltip(bloquearBotao || temErrosFormulario);
       }
     }
 

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -1691,9 +1691,7 @@ export default () => {
           );
         setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
         setExibirTooltip(bloquearBotao || temErrosFormulario);
-      }
-
-      if (categoriasDeMedicao.length > 0) {
+      } else if (categoriasDeMedicao.length > 0) {
         const bloquearBotao = weekColumns.some((week) =>
           obrigarAdiocionarFeriadoProgramasProjetos(
             week,
@@ -1721,8 +1719,8 @@ export default () => {
         usuarioEhEscolaCIEJA(),
         location.state.periodo,
       );
-      setDisableBotaoSalvarLancamentos(bloquearBotao);
-      setExibirTooltip(bloquearBotao);
+      setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
+      setExibirTooltip(bloquearBotao || temErrosFormulario);
     }
   }, [
     formValuesAtualizados,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
@@ -602,93 +602,91 @@ export const botaoAdicionarObrigatorioTabelaAlimentacao = (
   escolaEmebs,
   alunosTabSelecionada,
 ) => {
-  if (
-    location.state.grupo === "Programas e Projetos" &&
-    feriadosNoMes.includes(dia)
-  ) {
-    return false;
-  } else {
-    return (
-      repeticaoSobremesaDoceComValorESemObservacao(
-        formValuesAtualizados,
-        dia,
-        categoria,
-        diasSobremesaDoce,
-        location,
-      ) ||
-      campoFrequenciaValor0ESemObservacao(
-        dia,
-        categoria,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        location.state.grupo,
-        escolaEmebs,
-        alunosTabSelecionada,
-      ) ||
-      campoComSuspensaoAutorizadaESemObservacao(
-        formValuesAtualizados,
-        column,
-        categoria,
-        suspensoesAutorizadas,
-      ) ||
-      campoRefeicaoComRPLAutorizadaESemObservacao(
-        formValuesAtualizados,
-        column,
-        categoria,
-        alteracoesAlimentacaoAutorizadas,
-      ) ||
-      campoLancheComLPRAutorizadaESemObservacao(
-        formValuesAtualizados,
-        column,
-        categoria,
-        alteracoesAlimentacaoAutorizadas,
-      ) ||
-      camposKitLancheSolicitacoesAlimentacaoESemObservacao(
-        formValuesAtualizados,
-        column,
-        categoria,
-        kitLanchesAutorizadas,
-      ) ||
-      camposLancheEmergTabelaEtec(
-        formValuesAtualizados,
-        column,
-        categoria,
-        inclusoesEtecAutorizadas,
-        ehGrupoETECUrlParam,
-      ) ||
-      campoLancheEmergencialComZeroOuSemObservacao(
-        formValuesAtualizados,
-        column,
-        categoria,
-        alteracoesAlimentacaoAutorizadas,
-      ) ||
-      existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
-        dia,
-        categoria,
-        formValuesAtualizados,
-        alteracoesLancheEmergencialAutorizadas,
-        permissoesLancamentosEspeciaisPorDia,
-      ) ||
-      habitarBotaoAdicionar(
-        "frequencia",
-        column.dia,
-        categoria,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        location.state.grupo,
-        escolaEmebs,
-        alunosTabSelecionada,
-      ) ||
-      refeicaoSimultaneaESemObservacao(
-        formValuesAtualizados,
-        row,
-        column,
-        categoria,
-        usuarioEhEscolaCIEJA(),
-        location.state.periodo,
-      )
-    );
-  }
+  return (
+    repeticaoSobremesaDoceComValorESemObservacao(
+      formValuesAtualizados,
+      dia,
+      categoria,
+      diasSobremesaDoce,
+      location,
+    ) ||
+    campoFrequenciaValor0ESemObservacao(
+      dia,
+      categoria,
+      formValuesAtualizados,
+      diasFrequenciaZerada,
+      location.state.grupo,
+      escolaEmebs,
+      alunosTabSelecionada,
+    ) ||
+    campoComSuspensaoAutorizadaESemObservacao(
+      formValuesAtualizados,
+      column,
+      categoria,
+      suspensoesAutorizadas,
+    ) ||
+    campoRefeicaoComRPLAutorizadaESemObservacao(
+      formValuesAtualizados,
+      column,
+      categoria,
+      alteracoesAlimentacaoAutorizadas,
+    ) ||
+    campoLancheComLPRAutorizadaESemObservacao(
+      formValuesAtualizados,
+      column,
+      categoria,
+      alteracoesAlimentacaoAutorizadas,
+    ) ||
+    camposKitLancheSolicitacoesAlimentacaoESemObservacao(
+      formValuesAtualizados,
+      column,
+      categoria,
+      kitLanchesAutorizadas,
+    ) ||
+    camposLancheEmergTabelaEtec(
+      formValuesAtualizados,
+      column,
+      categoria,
+      inclusoesEtecAutorizadas,
+      ehGrupoETECUrlParam,
+    ) ||
+    campoLancheEmergencialComZeroOuSemObservacao(
+      formValuesAtualizados,
+      column,
+      categoria,
+      alteracoesAlimentacaoAutorizadas,
+    ) ||
+    existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
+      dia,
+      categoria,
+      formValuesAtualizados,
+      alteracoesLancheEmergencialAutorizadas,
+      permissoesLancamentosEspeciaisPorDia,
+    ) ||
+    habitarBotaoAdicionar(
+      "frequencia",
+      column.dia,
+      categoria,
+      formValuesAtualizados,
+      diasFrequenciaZerada,
+      location.state.grupo,
+      escolaEmebs,
+      alunosTabSelecionada,
+    ) ||
+    refeicaoSimultaneaESemObservacao(
+      formValuesAtualizados,
+      row,
+      column,
+      categoria,
+      usuarioEhEscolaCIEJA(),
+      location.state.periodo,
+    ) ||
+    obrigarAdiocionarFeriadoProgramasProjetos(
+      column,
+      categoria,
+      formValuesAtualizados,
+    )
+  );
 };
 
 export const botaoAdicionarObrigatorio = (
@@ -2652,4 +2650,56 @@ export const refeicaoSimultaneaESemObservacao = (
 
   if (!temRefeicaoOuSobremesa || !temLanche4h || temObservacao) return false;
   return true;
+};
+
+export const verificaFeriadoProgramasProjetos = (
+  row,
+  column,
+  categoria,
+  campoDesabilitado,
+  ehProgramasEProjetos,
+  validacaoDiaLetivo,
+  formValuesAtualizados,
+) => {
+  if (row.name === "frequencia") return false;
+
+  const campoApontamento = `${row.name}__dia_${column.dia}__categoria_${categoria.id}`;
+  const campoObservacao = `observacoes__dia_${column.dia}__categoria_${categoria.id}`;
+
+  const valor = formValuesAtualizados[campoApontamento];
+  const observacao = formValuesAtualizados[campoObservacao];
+
+  if (!valor || parseInt(valor) === 0 || observacao) return false;
+
+  return (
+    !campoDesabilitado &&
+    ehProgramasEProjetos &&
+    !validacaoDiaLetivo(column.dia) &&
+    !observacao
+  );
+};
+
+export const obrigarAdiocionarFeriadoProgramasProjetos = (
+  column,
+  categoria,
+  formValuesAtualizados,
+) => {
+  const sufixoCampo = `__dia_${column.dia}__categoria_${categoria.id}`;
+
+  return Object.entries(formValuesAtualizados).some(([key, value]) => {
+    if (
+      key.startsWith("observacoes__") ||
+      key.startsWith("numero_de_alunos__") ||
+      key.startsWith("matriculados__") ||
+      key.startsWith("frequencia__")
+    )
+      return false;
+
+    if (!key.includes(sufixoCampo)) return false;
+
+    const numero = Number(value);
+    if (Number.isNaN(numero) || numero === 0) return false;
+
+    return !formValuesAtualizados[`observacoes${sufixoCampo}`];
+  });
 };

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -1305,9 +1305,12 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             null,
             weekColumns,
           );
-        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-        setExibirTooltip(bloquearBotao);
-      } else if (categoriasDeMedicao.length > 0) {
+        const bloquear = bloquearBotao || temErrosFormulario;
+        setDisableBotaoSalvarLancamentos(bloquear);
+        setExibirTooltip(bloquear);
+        if (bloquear) return;
+      }
+      if (categoriasDeMedicao.length > 0) {
         const bloquearBotao = weekColumns.some((week) =>
           obrigarAdiocionarFeriadoProgramasProjetos(
             week,
@@ -1317,8 +1320,9 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             formValuesAtualizados,
           ),
         );
-        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
-        setExibirTooltip(bloquearBotao || temErrosFormulario);
+        const bloquear = bloquearBotao || temErrosFormulario;
+        setDisableBotaoSalvarLancamentos(bloquear);
+        setExibirTooltip(bloquear);
       }
     }
   }, [

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -96,6 +96,8 @@ import {
   exibirTooltipPeriodosZeradosNoProgramasProjetos,
   habitarBotaoAdicionar,
   boqueaSalvamentoPeriodosZeradosNoProgramasProjetos,
+  verificaFeriadoProgramasProjetos,
+  obrigarAdiocionarFeriadoProgramasProjetos,
 } from "../PeriodoLancamentoMedicaoInicial/validacoes";
 import ModalErro from "./components/ModalErro";
 import ModalObservacaoDiaria from "./components/ModalObservacaoDiaria";
@@ -1285,21 +1287,37 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
     if (
       formValuesAtualizados &&
       formValuesAtualizados["periodo_escolar"] === "Programas e Projetos" &&
-      diasFrequenciaZerada &&
       weekColumns
     ) {
-      const bloquearBotao = boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
-        "frequencia",
-        categoriasDeMedicao,
-        formValuesAtualizados,
-        diasFrequenciaZerada,
-        formValuesAtualizados["periodo_escolar"],
-        false,
-        null,
-        weekColumns,
-      );
-      setDisableBotaoSalvarLancamentos(bloquearBotao);
-      setExibirTooltip(bloquearBotao);
+      if (diasFrequenciaZerada) {
+        const bloquearBotao =
+          boqueaSalvamentoPeriodosZeradosNoProgramasProjetos(
+            "frequencia",
+            categoriasDeMedicao,
+            formValuesAtualizados,
+            diasFrequenciaZerada,
+            formValuesAtualizados["periodo_escolar"],
+            false,
+            null,
+            weekColumns,
+          );
+        setDisableBotaoSalvarLancamentos(bloquearBotao);
+        setExibirTooltip(bloquearBotao);
+      }
+
+      if (categoriasDeMedicao.length > 0) {
+        const bloquearBotao = weekColumns.some((week) =>
+          obrigarAdiocionarFeriadoProgramasProjetos(
+            week,
+            categoriasDeMedicao.find(
+              (categoria) => categoria.nome === "ALIMENTAÇÃO",
+            ),
+            formValuesAtualizados,
+          ),
+        );
+        setDisableBotaoSalvarLancamentos(bloquearBotao);
+        setExibirTooltip(bloquearBotao);
+      }
     }
   }, [
     formValuesAtualizados,
@@ -2784,193 +2802,225 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
                                                   </b>
                                                 )}
                                             </div>
-                                            {weekColumns.map((column) => (
-                                              <div
-                                                data-testid={`div-botao-add-obs-${column.dia}-${categoria.id}-${row.name}`}
-                                                key={column.dia}
-                                                className={`${
-                                                  colunaDesabilitada(column)
-                                                    ? "input-desabilitado"
-                                                    : row.name === "observacoes"
-                                                      ? "input-habilitado-observacoes"
-                                                      : "input-habilitado"
-                                                }`}
-                                              >
-                                                {row.name === "observacoes" ? (
-                                                  !colunaDesabilitada(column) &&
-                                                  exibeBotaoAdicionarObservacao(
-                                                    column.dia,
-                                                  ) && (
-                                                    <Botao
-                                                      texto={textoBotaoObservacao(
-                                                        formValuesAtualizados[
-                                                          `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                        ],
-                                                        valoresObservacoes,
-                                                        column.dia,
-                                                        categoria.id,
-                                                      )}
-                                                      disabled={desabilitarBotaoColunaObservacoes(
-                                                        location,
-                                                        valoresPeriodosLancamentos,
-                                                        column,
-                                                        categoria,
-                                                        formValuesAtualizados,
-                                                        row,
-                                                        valoresObservacoes,
-                                                        column.dia,
-                                                        diasParaCorrecao,
-                                                      )}
-                                                      type={BUTTON_TYPE.BUTTON}
-                                                      style={
-                                                        (exibirTooltipAoSalvar &&
-                                                          inputsInclusaoComErro.some(
-                                                            (inputComErro) =>
-                                                              inputComErro.nome ===
-                                                              `${row.name}__dia_${column.dia}__categoria_${categoria.id}`,
-                                                          ) &&
-                                                          botaoAdicionarObrigatorioTabelaAlimentacao(
-                                                            column,
-                                                            categoria,
-                                                            inclusoesAutorizadas,
-                                                            formValuesAtualizados[
-                                                              `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                            ],
-                                                            formValuesAtualizados,
-                                                          )) ||
-                                                        (ehPeriodoInfantilEmeiDaCemei() &&
-                                                          existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
-                                                            column.dia,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            alteracoesLancheEmergencialAutorizadas,
-                                                            permissoesLancamentosEspeciaisPorDia,
-                                                          )) ||
-                                                        alimentacoesFrequenciaZeroESemObservacaoCEI(
-                                                          formValuesAtualizados,
+                                            {weekColumns.map((column) => {
+                                              const campoDesabilitado =
+                                                desabilitarField(
+                                                  column.dia,
+                                                  row.name,
+                                                  categoria.id,
+                                                  categoria.nome,
+                                                  formValuesAtualizados,
+                                                  mesAnoConsiderado,
+                                                  mesAnoDefault,
+                                                  inclusoesAutorizadas,
+                                                  validacaoDiaLetivo,
+                                                  validacaoSemana,
+                                                  location,
+                                                  valoresPeriodosLancamentos,
+                                                  feriadosNoMes,
+                                                  null,
+                                                  diasParaCorrecao,
+                                                  ehEmeiDaCemeiLocation,
+                                                  ehSolicitacoesAlimentacaoLocation,
+                                                  permissoesLancamentosEspeciaisPorDia,
+                                                  alimentacoesLancamentosEspeciais,
+                                                  ehProgramasEProjetosLocation,
+                                                  dadosValoresInclusoesAutorizadasState,
+                                                  kitLanchesAutorizadas,
+                                                  alteracoesAlimentacaoAutorizadas,
+                                                  ehUltimoDiaLetivoDoAno,
+                                                  calendarioMesConsiderado,
+                                                  ehRecreioNasFerias(),
+                                                  categoriasDeMedicao,
+                                                );
+
+                                              return (
+                                                <div
+                                                  data-testid={`div-botao-add-obs-${column.dia}-${categoria.id}-${row.name}`}
+                                                  key={column.dia}
+                                                  className={`${
+                                                    colunaDesabilitada(column)
+                                                      ? "input-desabilitado"
+                                                      : row.name ===
+                                                          "observacoes"
+                                                        ? "input-habilitado-observacoes"
+                                                        : "input-habilitado"
+                                                  }`}
+                                                >
+                                                  {row.name ===
+                                                  "observacoes" ? (
+                                                    !colunaDesabilitada(
+                                                      column,
+                                                    ) &&
+                                                    exibeBotaoAdicionarObservacao(
+                                                      column.dia,
+                                                    ) && (
+                                                      <Botao
+                                                        texto={textoBotaoObservacao(
+                                                          formValuesAtualizados[
+                                                            `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                          ],
+                                                          valoresObservacoes,
                                                           column.dia,
-                                                          categoria,
-                                                          categoriasDeMedicao,
-                                                          faixaEtaria,
-                                                          ehRecreioNasFerias(),
-                                                        ) ||
-                                                        campoAlimentacoesAutorizadasDiaNaoLetivoCEINaoPreenchidoESemObservacao(
-                                                          inclusoesAutorizadas,
+                                                          categoria.id,
+                                                        )}
+                                                        disabled={desabilitarBotaoColunaObservacoes(
+                                                          location,
+                                                          valoresPeriodosLancamentos,
                                                           column,
                                                           categoria,
                                                           formValuesAtualizados,
-                                                        ) ||
-                                                        campoRefeicaoComRPLAutorizadaESemObservacao(
-                                                          formValuesAtualizados,
-                                                          column,
-                                                          categoria,
-                                                          alteracoesAlimentacaoAutorizadas,
-                                                        ) ||
-                                                        campoDietaComInclusaoAutorizadaSemObservacao(
-                                                          formValuesAtualizados,
-                                                          column,
-                                                          categoria,
-                                                          inclusoesAutorizadas,
-                                                          logQtdDietasAutorizadasCEI,
-                                                        ) ||
-                                                        campoComInclusaoAutorizadaValorZeroESemObservacao(
-                                                          formValuesAtualizados,
-                                                          column,
-                                                          categoria,
-                                                          inclusoesAutorizadas,
-                                                          ehProgramasEProjetosLocation,
-                                                          alteracoesAlimentacaoAutorizadas,
-                                                        ) ||
-                                                        campoLancheComLPRAutorizadaESemObservacao(
-                                                          formValuesAtualizados,
-                                                          column,
-                                                          categoria,
-                                                          alteracoesAlimentacaoAutorizadas,
-                                                        ) ||
-                                                        (!ehEmeiDaCemeiLocation &&
-                                                          frequenciaComSuspensaoAutorizadaPreenchidaESemObservacao(
-                                                            formValuesAtualizados,
-                                                            column,
-                                                            categoria,
-                                                            suspensoesAutorizadas,
-                                                            categoriasDeMedicao,
-                                                          )) ||
-                                                        (ehEmeiDaCemeiLocation &&
-                                                          campoComSuspensaoAutorizadaESemObservacao(
-                                                            formValuesAtualizados,
-                                                            column,
-                                                            categoria,
-                                                            suspensoesAutorizadas,
-                                                          )) ||
-                                                        (ehEmeiDaCemeiLocation &&
-                                                          alimentacoesFrequenciaZeroESemObservacao(
+                                                          row,
+                                                          valoresObservacoes,
+                                                          column.dia,
+                                                          diasParaCorrecao,
+                                                        )}
+                                                        type={
+                                                          BUTTON_TYPE.BUTTON
+                                                        }
+                                                        style={
+                                                          (exibirTooltipAoSalvar &&
+                                                            inputsInclusaoComErro.some(
+                                                              (inputComErro) =>
+                                                                inputComErro.nome ===
+                                                                `${row.name}__dia_${column.dia}__categoria_${categoria.id}`,
+                                                            ) &&
+                                                            botaoAdicionarObrigatorioTabelaAlimentacao(
+                                                              column,
+                                                              categoria,
+                                                              inclusoesAutorizadas,
+                                                              formValuesAtualizados[
+                                                                `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                              ],
+                                                              formValuesAtualizados,
+                                                            )) ||
+                                                          (ehPeriodoInfantilEmeiDaCemei() &&
+                                                            existeAlgumLancheEmergencialAutorizadoTipoAlimentacaoNoDiaSemObservacao(
+                                                              column.dia,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                              alteracoesLancheEmergencialAutorizadas,
+                                                              permissoesLancamentosEspeciaisPorDia,
+                                                            )) ||
+                                                          alimentacoesFrequenciaZeroESemObservacaoCEI(
                                                             formValuesAtualizados,
                                                             column.dia,
                                                             categoria,
                                                             categoriasDeMedicao,
-                                                          )) ||
-                                                        (ehSolicitacoesAlimentacaoLocation &&
-                                                          (campoLancheEmergencialComZeroOuSemObservacao(
+                                                            faixaEtaria,
+                                                            ehRecreioNasFerias(),
+                                                          ) ||
+                                                          campoAlimentacoesAutorizadasDiaNaoLetivoCEINaoPreenchidoESemObservacao(
+                                                            inclusoesAutorizadas,
+                                                            column,
+                                                            categoria,
+                                                            formValuesAtualizados,
+                                                          ) ||
+                                                          campoRefeicaoComRPLAutorizadaESemObservacao(
                                                             formValuesAtualizados,
                                                             column,
                                                             categoria,
                                                             alteracoesAlimentacaoAutorizadas,
                                                           ) ||
-                                                            campoLancheEmergencialSemAutorizacaoSemObservacao(
+                                                          campoDietaComInclusaoAutorizadaSemObservacao(
+                                                            formValuesAtualizados,
+                                                            column,
+                                                            categoria,
+                                                            inclusoesAutorizadas,
+                                                            logQtdDietasAutorizadasCEI,
+                                                          ) ||
+                                                          campoComInclusaoAutorizadaValorZeroESemObservacao(
+                                                            formValuesAtualizados,
+                                                            column,
+                                                            categoria,
+                                                            inclusoesAutorizadas,
+                                                            ehProgramasEProjetosLocation,
+                                                            alteracoesAlimentacaoAutorizadas,
+                                                          ) ||
+                                                          campoLancheComLPRAutorizadaESemObservacao(
+                                                            formValuesAtualizados,
+                                                            column,
+                                                            categoria,
+                                                            alteracoesAlimentacaoAutorizadas,
+                                                          ) ||
+                                                          (!ehEmeiDaCemeiLocation &&
+                                                            frequenciaComSuspensaoAutorizadaPreenchidaESemObservacao(
+                                                              formValuesAtualizados,
+                                                              column,
+                                                              categoria,
+                                                              suspensoesAutorizadas,
+                                                              categoriasDeMedicao,
+                                                            )) ||
+                                                          (ehEmeiDaCemeiLocation &&
+                                                            campoComSuspensaoAutorizadaESemObservacao(
+                                                              formValuesAtualizados,
+                                                              column,
+                                                              categoria,
+                                                              suspensoesAutorizadas,
+                                                            )) ||
+                                                          (ehEmeiDaCemeiLocation &&
+                                                            alimentacoesFrequenciaZeroESemObservacao(
+                                                              formValuesAtualizados,
+                                                              column.dia,
+                                                              categoria,
+                                                              categoriasDeMedicao,
+                                                            )) ||
+                                                          (ehSolicitacoesAlimentacaoLocation &&
+                                                            (campoLancheEmergencialComZeroOuSemObservacao(
                                                               formValuesAtualizados,
                                                               column,
                                                               categoria,
                                                               alteracoesAlimentacaoAutorizadas,
                                                             ) ||
-                                                            camposKitLancheSolicitacoesAlimentacaoESemObservacao(
-                                                              formValuesAtualizados,
-                                                              column,
-                                                              categoria,
-                                                              kitLanchesAutorizadas,
-                                                            ))) ||
-                                                        ((ehEmeiDaCemeiLocation ||
-                                                          ehProgramasEProjetosLocation) &&
-                                                          campoFrequenciaValor0ESemObservacao(
-                                                            column.dia,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            diasFrequenciaZerada,
-                                                            location.state
-                                                              .periodo,
-                                                          )) ||
-                                                        (ehProgramasEProjetosLocation &&
-                                                          repeticaoSobremesaDoceComValorESemObservacao(
-                                                            formValuesAtualizados,
-                                                            column.dia,
-                                                            categoria,
-                                                            diasSobremesaDoce,
-                                                            location,
-                                                          )) ||
-                                                        verificarDiaZerado(
-                                                          column.dia,
-                                                          categoria,
-                                                        ) ||
-                                                        (ehProgramasEProjetosLocation &&
-                                                          habitarBotaoAdicionar(
-                                                            "frequencia",
-                                                            column.dia,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            diasFrequenciaZerada,
-                                                            location.state
-                                                              .periodo,
-                                                          ))
-                                                          ? textoBotaoObservacao(
-                                                              formValuesAtualizados[
-                                                                `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
-                                                              ],
-                                                              valoresObservacoes,
+                                                              campoLancheEmergencialSemAutorizacaoSemObservacao(
+                                                                formValuesAtualizados,
+                                                                column,
+                                                                categoria,
+                                                                alteracoesAlimentacaoAutorizadas,
+                                                              ) ||
+                                                              camposKitLancheSolicitacoesAlimentacaoESemObservacao(
+                                                                formValuesAtualizados,
+                                                                column,
+                                                                categoria,
+                                                                kitLanchesAutorizadas,
+                                                              ))) ||
+                                                          ((ehEmeiDaCemeiLocation ||
+                                                            ehProgramasEProjetosLocation) &&
+                                                            campoFrequenciaValor0ESemObservacao(
                                                               column.dia,
-                                                              categoria.id,
-                                                            ) === "Visualizar"
-                                                            ? BUTTON_STYLE.RED
-                                                            : BUTTON_STYLE.RED_OUTLINE
-                                                          : textoBotaoObservacao(
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                              diasFrequenciaZerada,
+                                                              location.state
+                                                                .periodo,
+                                                            )) ||
+                                                          verificarDiaZerado(
+                                                            column.dia,
+                                                            categoria,
+                                                          ) ||
+                                                          (ehProgramasEProjetosLocation &&
+                                                            (habitarBotaoAdicionar(
+                                                              "frequencia",
+                                                              column.dia,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                              diasFrequenciaZerada,
+                                                              location.state
+                                                                .periodo,
+                                                            ) ||
+                                                              repeticaoSobremesaDoceComValorESemObservacao(
+                                                                formValuesAtualizados,
+                                                                column.dia,
+                                                                categoria,
+                                                                diasSobremesaDoce,
+                                                                location,
+                                                              ) ||
+                                                              obrigarAdiocionarFeriadoProgramasProjetos(
+                                                                column,
+                                                                categoria,
+                                                                formValuesAtualizados,
+                                                              )))
+                                                            ? textoBotaoObservacao(
                                                                 formValuesAtualizados[
                                                                   `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
                                                                 ],
@@ -2978,369 +3028,364 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
                                                                 column.dia,
                                                                 categoria.id,
                                                               ) === "Visualizar"
-                                                            ? BUTTON_STYLE.GREEN
-                                                            : BUTTON_STYLE.GREEN_OUTLINE_WHITE
-                                                      }
-                                                      onClick={() =>
-                                                        onClickBotaoObservacao(
-                                                          column.dia,
-                                                          categoria.id,
-                                                        )
-                                                      }
-                                                    />
-                                                  )
-                                                ) : (
-                                                  <div className="field-values-input">
-                                                    {ehEmeiDaCemeiLocation ||
-                                                    ehSolicitacoesAlimentacaoLocation ||
-                                                    ehProgramasEProjetosLocation ||
-                                                    ehGrupoColaboradores() ? (
-                                                      <>
-                                                        <Field
-                                                          className={`m-2 ${classNameFieldTabelaAlimentacaoEMEI(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                          )}`}
-                                                          component={
-                                                            InputValueMedicao
-                                                          }
-                                                          classNameToNextInput={getClassNameToNextInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          classNameToPrevInput={getClassNameToPrevInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          apenasNumeros
-                                                          name={`${row.name}__dia_${column.dia}__categoria_${categoria.id}`}
-                                                          disabled={desabilitarField(
+                                                              ? BUTTON_STYLE.RED
+                                                              : BUTTON_STYLE.RED_OUTLINE
+                                                            : textoBotaoObservacao(
+                                                                  formValuesAtualizados[
+                                                                    `${row.name}__dia_${column.dia}__categoria_${categoria.id}`
+                                                                  ],
+                                                                  valoresObservacoes,
+                                                                  column.dia,
+                                                                  categoria.id,
+                                                                ) ===
+                                                                "Visualizar"
+                                                              ? BUTTON_STYLE.GREEN
+                                                              : BUTTON_STYLE.GREEN_OUTLINE_WHITE
+                                                        }
+                                                        onClick={() =>
+                                                          onClickBotaoObservacao(
                                                             column.dia,
-                                                            row.name,
                                                             categoria.id,
-                                                            categoria.nome,
-                                                            formValuesAtualizados,
-                                                            mesAnoConsiderado,
-                                                            mesAnoDefault,
-                                                            inclusoesAutorizadas,
-                                                            validacaoDiaLetivo,
-                                                            validacaoSemana,
-                                                            location,
-                                                            valoresPeriodosLancamentos,
-                                                            feriadosNoMes,
-                                                            null,
-                                                            diasParaCorrecao,
-                                                            ehEmeiDaCemeiLocation,
-                                                            ehSolicitacoesAlimentacaoLocation,
-                                                            permissoesLancamentosEspeciaisPorDia,
-                                                            alimentacoesLancamentosEspeciais,
-                                                            ehProgramasEProjetosLocation,
-                                                            dadosValoresInclusoesAutorizadasState,
-                                                            kitLanchesAutorizadas,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            ehUltimoDiaLetivoDoAno,
-                                                            calendarioMesConsiderado,
-                                                            ehRecreioNasFerias(),
-                                                            categoriasDeMedicao,
-                                                          )}
-                                                          defaultValue={defaultValue(
-                                                            column,
-                                                            row,
-                                                          )}
-                                                          numeroDeInclusoesAutorizadas={
-                                                            inclusoesAutorizadas.find(
-                                                              (inclusao) =>
-                                                                column.dia ===
-                                                                String(
-                                                                  inclusao.dia,
-                                                                ),
-                                                            )?.numero_alunos
-                                                          }
-                                                          exibeTooltipFrequenciaAlimentacaoZero={exibirTooltipFrequenciaAlimentacaoZeroESemObservacao(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            categoriasDeMedicao,
-                                                          )}
-                                                          exibeTooltipSuspensoesAutorizadas={exibirTooltipSuspensoesAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            suspensoesAutorizadas,
-                                                          )}
-                                                          exibeTooltipInclusoesAutorizadasComZero={exibeTooltipInclusoesAutorizadasComZero(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            inclusoesAutorizadas,
-                                                            ehProgramasEProjetosLocation,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLPRAutorizadas={exibirTooltipLPRAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialAutorizado={exibirTooltipLancheEmergencialAutorizado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={
-                                                            ehPeriodoInfantilEmeiDaCemei() &&
-                                                            exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
+                                                          )
+                                                        }
+                                                      />
+                                                    )
+                                                  ) : (
+                                                    <div className="field-values-input">
+                                                      {ehEmeiDaCemeiLocation ||
+                                                      ehSolicitacoesAlimentacaoLocation ||
+                                                      ehProgramasEProjetosLocation ||
+                                                      ehGrupoColaboradores() ? (
+                                                        <>
+                                                          <Field
+                                                            className={`m-2 ${classNameFieldTabelaAlimentacaoEMEI(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                            )}`}
+                                                            component={
+                                                              InputValueMedicao
+                                                            }
+                                                            classNameToNextInput={getClassNameToNextInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            classNameToPrevInput={getClassNameToPrevInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            apenasNumeros
+                                                            name={`${row.name}__dia_${column.dia}__categoria_${categoria.id}`}
+                                                            disabled={
+                                                              campoDesabilitado
+                                                            }
+                                                            defaultValue={defaultValue(
+                                                              column,
+                                                              row,
+                                                            )}
+                                                            numeroDeInclusoesAutorizadas={
+                                                              inclusoesAutorizadas.find(
+                                                                (inclusao) =>
+                                                                  column.dia ===
+                                                                  String(
+                                                                    inclusao.dia,
+                                                                  ),
+                                                              )?.numero_alunos
+                                                            }
+                                                            exibeTooltipFrequenciaAlimentacaoZero={exibirTooltipFrequenciaAlimentacaoZeroESemObservacao(
                                                               formValuesAtualizados,
                                                               row,
                                                               column,
                                                               categoria,
-                                                              alteracoesLancheEmergencialAutorizadas,
+                                                              categoriasDeMedicao,
+                                                            )}
+                                                            exibeTooltipSuspensoesAutorizadas={exibirTooltipSuspensoesAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              suspensoesAutorizadas,
+                                                            )}
+                                                            exibeTooltipInclusoesAutorizadasComZero={exibeTooltipInclusoesAutorizadasComZero(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              inclusoesAutorizadas,
+                                                              ehProgramasEProjetosLocation,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLPRAutorizadas={exibirTooltipLPRAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialAutorizado={exibirTooltipLancheEmergencialAutorizado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialAutorizadoTipoAlimentacao={
+                                                              ehPeriodoInfantilEmeiDaCemei() &&
+                                                              exibirTooltipLancheEmergencialAutorizadoTipoAlimentacao(
+                                                                formValuesAtualizados,
+                                                                row,
+                                                                column,
+                                                                categoria,
+                                                                alteracoesLancheEmergencialAutorizadas,
+                                                                permissoesLancamentosEspeciaisPorDia,
+                                                              )
+                                                            }
+                                                            exibeTooltipLancheEmergencialNaoAutorizado={exibirTooltipLancheEmergencialNaoAutorizado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipLancheEmergencialZeroAutorizadoJustificado={exibirTooltipLancheEmergencialZeroAutorizadoJustificado(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                              validacaoDiaLetivo,
+                                                            )}
+                                                            exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas={exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              kitLanchesAutorizadas,
+                                                            )}
+                                                            exibeTooltipKitLancheSolAlimentacoes={exibirTooltipKitLancheSolAlimentacoes(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              kitLanchesAutorizadas,
+                                                            )}
+                                                            exibeTooltipPadraoRepeticaoDiasSobremesaDoce={
+                                                              ehProgramasEProjetosLocation &&
+                                                              exibirTooltipPadraoRepeticaoDiasSobremesaDoce(
+                                                                formValuesAtualizados,
+                                                                row,
+                                                                column,
+                                                                categoria,
+                                                                diasSobremesaDoce,
+                                                                location,
+                                                              )
+                                                            }
+                                                            exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero={
+                                                              ehProgramasEProjetosLocation &&
+                                                              exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero(
+                                                                formValuesAtualizados,
+                                                                row,
+                                                                column,
+                                                                categoria,
+                                                                diasSobremesaDoce,
+                                                                location,
+                                                              )
+                                                            }
+                                                            exibirTooltipPeriodosZeradosNoProgramasProjetos={exibirTooltipPeriodosZeradosNoProgramasProjetos(
+                                                              row.name,
+                                                              column.dia,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                              diasFrequenciaZerada,
+                                                              location.state
+                                                                .periodo,
+                                                            )}
+                                                            exibirTooltipFeriado={verificaFeriadoProgramasProjetos(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              campoDesabilitado,
+                                                              ehProgramasEProjetosLocation,
+                                                              validacaoDiaLetivo,
+                                                              formValuesAtualizados,
+                                                            )}
+                                                            validate={fieldValidationsTabelasEmeidaCemei(
+                                                              row.name,
+                                                              column.dia,
+                                                              categoria.id,
+                                                              categoria.nome,
+                                                            )}
+                                                            inputOnChange={(
+                                                              e,
+                                                            ) => {
+                                                              const value =
+                                                                e.target.value;
+
+                                                              onChangeInput(
+                                                                value,
+                                                                previousValue,
+                                                                form.getState()
+                                                                  .errors,
+                                                                form.getState()
+                                                                  .values,
+                                                                column.dia,
+                                                                categoria,
+                                                                column,
+                                                                row,
+                                                                form,
+                                                              );
+
+                                                              setPreviousValue(
+                                                                value,
+                                                              );
+                                                            }}
+                                                          />
+                                                        </>
+                                                      ) : (
+                                                        <>
+                                                          <Field
+                                                            className={`m-2 ${classNameFieldTabelaAlimentacao(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                            )}`}
+                                                            component={
+                                                              InputValueMedicao
+                                                            }
+                                                            classNameToNextInput={getClassNameToNextInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            classNameToPrevInput={getClassNameToPrevInput(
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              index,
+                                                            )}
+                                                            apenasNumeros
+                                                            name={`${row.name}__faixa_${row.uuid}__dia_${column.dia}__categoria_${categoria.id}`}
+                                                            disabled={desabilitarField(
+                                                              column.dia,
+                                                              row.name,
+                                                              categoria.id,
+                                                              categoria.nome,
+                                                              formValuesAtualizados,
+                                                              mesAnoConsiderado,
+                                                              mesAnoDefault,
+                                                              inclusoesAutorizadas,
+                                                              validacaoDiaLetivo,
+                                                              validacaoSemana,
+                                                              location,
+                                                              valoresPeriodosLancamentos,
+                                                              feriadosNoMes,
+                                                              row.uuid,
+                                                              diasParaCorrecao,
+                                                              ehEmeiDaCemeiLocation,
+                                                              ehSolicitacoesAlimentacaoLocation,
                                                               permissoesLancamentosEspeciaisPorDia,
-                                                            )
-                                                          }
-                                                          exibeTooltipLancheEmergencialNaoAutorizado={exibirTooltipLancheEmergencialNaoAutorizado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipLancheEmergencialZeroAutorizadoJustificado={exibirTooltipLancheEmergencialZeroAutorizadoJustificado(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            validacaoDiaLetivo,
-                                                          )}
-                                                          exibeTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas={exibirTooltipQtdKitLancheMenorSolAlimentacoesAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            kitLanchesAutorizadas,
-                                                          )}
-                                                          exibeTooltipKitLancheSolAlimentacoes={exibirTooltipKitLancheSolAlimentacoes(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            kitLanchesAutorizadas,
-                                                          )}
-                                                          exibeTooltipPadraoRepeticaoDiasSobremesaDoce={
-                                                            ehProgramasEProjetosLocation &&
-                                                            exibirTooltipPadraoRepeticaoDiasSobremesaDoce(
+                                                              alimentacoesLancamentosEspeciais,
+                                                              ehProgramasEProjetosLocation,
+                                                              dadosValoresInclusoesAutorizadasState,
+                                                              kitLanchesAutorizadas,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                              ehUltimoDiaLetivoDoAno,
+                                                              calendarioMesConsiderado,
+                                                              ehRecreioNasFerias(),
+                                                              categoriasDeMedicao,
+                                                            )}
+                                                            defaultValue={defaultValue(
+                                                              column,
+                                                              row,
+                                                            )}
+                                                            exibeTooltipFrequenciaAlimentacaoZero={exibirTooltipFrequenciaAlimentacaoZeroESemObservacaoCEI(
                                                               formValuesAtualizados,
                                                               row,
                                                               column,
                                                               categoria,
-                                                              diasSobremesaDoce,
-                                                              location,
-                                                            )
-                                                          }
-                                                          exibeTooltipRepeticaoDiasSobremesaDoceDiferenteZero={
-                                                            ehProgramasEProjetosLocation &&
-                                                            exibirTooltipRepeticaoDiasSobremesaDoceDiferenteZero(
+                                                              categoriasDeMedicao,
+                                                              faixaEtaria,
+                                                              ehRecreioNasFerias(),
+                                                            )}
+                                                            exibeTooltipDietasInclusaoDiaNaoLetivoCEI={exibirTooltipDietasInclusaoDiaNaoLetivoCEI(
+                                                              inclusoesAutorizadas,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                            )}
+                                                            exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
                                                               formValuesAtualizados,
                                                               row,
                                                               column,
                                                               categoria,
-                                                              diasSobremesaDoce,
-                                                              location,
-                                                            )
-                                                          }
-                                                          exibirTooltipPeriodosZeradosNoProgramasProjetos={exibirTooltipPeriodosZeradosNoProgramasProjetos(
-                                                            row.name,
-                                                            column.dia,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                            diasFrequenciaZerada,
-                                                            location.state
-                                                              .periodo,
-                                                          )}
-                                                          validate={fieldValidationsTabelasEmeidaCemei(
-                                                            row.name,
-                                                            column.dia,
-                                                            categoria.id,
-                                                            categoria.nome,
-                                                          )}
-                                                          inputOnChange={(
-                                                            e,
-                                                          ) => {
-                                                            const value =
-                                                              e.target.value;
-
-                                                            onChangeInput(
-                                                              value,
-                                                              previousValue,
-                                                              form.getState()
-                                                                .errors,
-                                                              form.getState()
-                                                                .values,
+                                                              alteracoesAlimentacaoAutorizadas,
+                                                            )}
+                                                            exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI={exibirTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI(
+                                                              inclusoesAutorizadas,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              formValuesAtualizados,
+                                                            )}
+                                                            exibeTooltipSuspensoesAutorizadasCEI={exibirTooltipSuspensoesAutorizadasCEI(
+                                                              formValuesAtualizados,
+                                                              row,
+                                                              column,
+                                                              categoria,
+                                                              suspensoesAutorizadas,
+                                                            )}
+                                                            validate={fieldValidationsTabelasCEI(
+                                                              row.name,
                                                               column.dia,
                                                               categoria,
-                                                              column,
-                                                              row,
-                                                              form,
-                                                            );
+                                                              categoria.nome,
+                                                              row.uuid,
+                                                            )}
+                                                            inputOnChange={(
+                                                              e,
+                                                            ) => {
+                                                              const value =
+                                                                e.target.value;
 
-                                                            setPreviousValue(
-                                                              value,
-                                                            );
-                                                          }}
-                                                        />
-                                                      </>
-                                                    ) : (
-                                                      <>
-                                                        <Field
-                                                          className={`m-2 ${classNameFieldTabelaAlimentacao(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                          )}`}
-                                                          component={
-                                                            InputValueMedicao
-                                                          }
-                                                          classNameToNextInput={getClassNameToNextInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          classNameToPrevInput={getClassNameToPrevInput(
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            index,
-                                                          )}
-                                                          apenasNumeros
-                                                          name={`${row.name}__faixa_${row.uuid}__dia_${column.dia}__categoria_${categoria.id}`}
-                                                          disabled={desabilitarField(
-                                                            column.dia,
-                                                            row.name,
-                                                            categoria.id,
-                                                            categoria.nome,
-                                                            formValuesAtualizados,
-                                                            mesAnoConsiderado,
-                                                            mesAnoDefault,
-                                                            inclusoesAutorizadas,
-                                                            validacaoDiaLetivo,
-                                                            validacaoSemana,
-                                                            location,
-                                                            valoresPeriodosLancamentos,
-                                                            feriadosNoMes,
-                                                            row.uuid,
-                                                            diasParaCorrecao,
-                                                            ehEmeiDaCemeiLocation,
-                                                            ehSolicitacoesAlimentacaoLocation,
-                                                            permissoesLancamentosEspeciaisPorDia,
-                                                            alimentacoesLancamentosEspeciais,
-                                                            ehProgramasEProjetosLocation,
-                                                            dadosValoresInclusoesAutorizadasState,
-                                                            kitLanchesAutorizadas,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                            ehUltimoDiaLetivoDoAno,
-                                                            calendarioMesConsiderado,
-                                                            ehRecreioNasFerias(),
-                                                            categoriasDeMedicao,
-                                                          )}
-                                                          defaultValue={defaultValue(
-                                                            column,
-                                                            row,
-                                                          )}
-                                                          exibeTooltipFrequenciaAlimentacaoZero={exibirTooltipFrequenciaAlimentacaoZeroESemObservacaoCEI(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            categoriasDeMedicao,
-                                                            faixaEtaria,
-                                                            ehRecreioNasFerias(),
-                                                          )}
-                                                          exibeTooltipDietasInclusaoDiaNaoLetivoCEI={exibirTooltipDietasInclusaoDiaNaoLetivoCEI(
-                                                            inclusoesAutorizadas,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                          )}
-                                                          exibeTooltipRPLAutorizadas={exibirTooltipRPLAutorizadas(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            alteracoesAlimentacaoAutorizadas,
-                                                          )}
-                                                          exibeTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI={exibirTooltipAlimentacoesAutorizadasDiaNaoLetivoCEI(
-                                                            inclusoesAutorizadas,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            formValuesAtualizados,
-                                                          )}
-                                                          exibeTooltipSuspensoesAutorizadasCEI={exibirTooltipSuspensoesAutorizadasCEI(
-                                                            formValuesAtualizados,
-                                                            row,
-                                                            column,
-                                                            categoria,
-                                                            suspensoesAutorizadas,
-                                                          )}
-                                                          validate={fieldValidationsTabelasCEI(
-                                                            row.name,
-                                                            column.dia,
-                                                            categoria,
-                                                            categoria.nome,
-                                                            row.uuid,
-                                                          )}
-                                                          inputOnChange={(
-                                                            e,
-                                                          ) => {
-                                                            const value =
-                                                              e.target.value;
+                                                              onChangeInput(
+                                                                value,
+                                                                previousValue,
+                                                                form.getState()
+                                                                  .errors,
+                                                                form.getState()
+                                                                  .values,
+                                                                column.dia,
+                                                                categoria,
+                                                                column,
+                                                                row,
+                                                                form,
+                                                              );
 
-                                                            onChangeInput(
-                                                              value,
-                                                              previousValue,
-                                                              form.getState()
-                                                                .errors,
-                                                              form.getState()
-                                                                .values,
-                                                              column.dia,
-                                                              categoria,
-                                                              column,
-                                                              row,
-                                                              form,
-                                                            );
-
-                                                            setPreviousValue(
-                                                              value,
-                                                            );
-                                                          }}
-                                                        />
-                                                      </>
-                                                    )}
-                                                  </div>
-                                                )}
-                                              </div>
-                                            ))}
+                                                              setPreviousValue(
+                                                                value,
+                                                              );
+                                                            }}
+                                                          />
+                                                        </>
+                                                      )}
+                                                    </div>
+                                                  )}
+                                                </div>
+                                              );
+                                            })}
                                           </div>
                                         </Fragment>
                                       );

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -1307,9 +1307,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
           );
         setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
         setExibirTooltip(bloquearBotao);
-      }
-
-      if (categoriasDeMedicao.length > 0) {
+      } else if (categoriasDeMedicao.length > 0) {
         const bloquearBotao = weekColumns.some((week) =>
           obrigarAdiocionarFeriadoProgramasProjetos(
             week,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -251,6 +251,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
   const [listaDiasZerados, setListaDiasZerados] = useState([]);
   const [diasFrequenciaZerada, setDiasFrequenciaZeradas] = useState(null);
   const [faixasAtivasPorTipo, setFaixasAtivasPorTipo] = useState({});
+  const [formErrorsAtualizados, setFormErrorsAtualizados] = useState({});
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -1284,6 +1285,9 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
   ]);
 
   useEffect(() => {
+    const temErrosFormulario =
+      Object.keys(formErrorsAtualizados || {}).length > 0;
+
     if (
       formValuesAtualizados &&
       formValuesAtualizados["periodo_escolar"] === "Programas e Projetos" &&
@@ -1301,7 +1305,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             null,
             weekColumns,
           );
-        setDisableBotaoSalvarLancamentos(bloquearBotao);
+        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
         setExibirTooltip(bloquearBotao);
       }
 
@@ -1315,8 +1319,8 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             formValuesAtualizados,
           ),
         );
-        setDisableBotaoSalvarLancamentos(bloquearBotao);
-        setExibirTooltip(bloquearBotao);
+        setDisableBotaoSalvarLancamentos(bloquearBotao || temErrosFormulario);
+        setExibirTooltip(bloquearBotao || temErrosFormulario);
       }
     }
   }, [
@@ -1324,6 +1328,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
     diasFrequenciaZerada,
     weekColumns,
     categoriasDeMedicao,
+    formErrorsAtualizados,
   ]);
 
   const temDiaZeradoNaSemana =
@@ -2603,12 +2608,13 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             render={({ handleSubmit, form, errors }) => (
               <form onSubmit={handleSubmit}>
                 <FormSpy
-                  subscription={{ values: true, active: true }}
+                  subscription={{ values: true, active: true, errors: true }}
                   onChange={(changes) => {
                     setFormValuesAtualizados({
                       week: semanaSelecionada,
                       ...changes.values,
                     });
+                    setFormErrorsAtualizados(changes.errors || {});
                   }}
                 />
                 <div className="card mt-3">


### PR DESCRIPTION
**Este pull request**
Implementa exibição e validações relacionadas ao tooltip de feriado no bloco de Programas e Projetos (CEI e EMEI):
- Cria exibição de toast com base em validação das férias.
- Ajusta bloqueio de salvar lançamentos.
- Ajusta obrigatoriedade de adicionar observações com base em validação férias.

Referência no Azure: [AB#148146](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148146)