### PR TITLE
Feature/148657 integracao kit lanche recreio nas ferias

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/CEMEI/medicao_recreio_nas_ferias.test.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/CEMEI/medicao_recreio_nas_ferias.test.jsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { ToastContainer } from "react-toastify";
 import { MODULO_GESTAO, PERFIL, TIPO_PERFIL } from "src/constants/shared";
@@ -58,9 +58,11 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Renderiza Mediçã
     mock.onGet("/periodos-escolares/inclusao-continua-por-mes/").reply(200, {
       periodos: null,
     });
-    mock
-      .onGet("/escola-solicitacoes/kit-lanches-autorizadas/")
-      .reply(200, { results: [] });
+    mock.onGet("/escola-solicitacoes/kit-lanches-autorizadas/").reply(200, {
+      results: [
+        { dia: "17", numero_alunos: 80, kit_lanche_id_externo: "6CD6E" },
+      ],
+    });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
       .reply(200, { results: [] });
@@ -123,5 +125,13 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Renderiza Mediçã
       screen.getByText("Recreio nas Férias - 4 a 14 anos"),
     ).toBeInTheDocument();
     expect(screen.getByText("Colaboradores")).toBeInTheDocument();
+  });
+
+  it("Renderiza período Solicitações de Alimentação no recreio para EMEI da CEMEI quando há kit lanche autorizado", async () => {
+    await waitFor(() => {
+      expect(
+        screen.getByText("Solicitações de Alimentação - Infantil"),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/EMEF/medicao_recreio_nas_ferias.test.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/EMEF/medicao_recreio_nas_ferias.test.jsx
@@ -65,9 +65,11 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Renderiza Medição
     mock.onGet("/periodos-escolares/inclusao-continua-por-mes/").reply(200, {
       periodos: { MANHA: "5067e137-e5f3-4876-a63f-7f58cce93f33" },
     });
-    mock
-      .onGet("/escola-solicitacoes/kit-lanches-autorizadas/")
-      .reply(200, { results: [] });
+    mock.onGet("/escola-solicitacoes/kit-lanches-autorizadas/").reply(200, {
+      results: [
+        { dia: "06", numero_alunos: 10, kit_lanche_id_externo: "0B9FF" },
+      ],
+    });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
       .reply(200, { results: [] });
@@ -135,6 +137,14 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Renderiza Medição
   it("Renderiza períodos Recreio nas Férias e Colaboradores", () => {
     expect(screen.getByText("Recreio nas Férias")).toBeInTheDocument();
     expect(screen.getByText("Colaboradores")).toBeInTheDocument();
+  });
+
+  it("Renderiza período Solicitações de Alimentação durante recreio quando há kit lanche autorizado", () => {
+    return waitFor(() => {
+      expect(
+        screen.getByText("Solicitações de Alimentação"),
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/CardLancamento/index.jsx
@@ -152,8 +152,7 @@ export const CardLancamento = ({
           frequenciasDietasEscolaSemAlunoRegular:
             frequenciasDietasEscolaSemAlunoRegular,
           periodoEspecifico: periodoEspecifico,
-          recreioNasFerias:
-            solicitacaoMedicaoInicial.recreio_nas_ferias !== null,
+          recreioNasFerias: solicitacaoMedicaoInicial.recreio_nas_ferias?.uuid,
           ...location.state,
         },
       },

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -636,22 +636,21 @@ export const LancamentoPorPeriodo = ({
                   errosAoSalvar={errosAoSalvar}
                 />
               )}
-              {solicitacoesKitLanchesAutorizadas &&
-                solicitacoesKitLanchesAutorizadas.length > 0 && (
-                  <CardLancamento
-                    grupo="Solicitações de Alimentação"
-                    cor={CORES[5]}
-                    tipos_alimentacao={["Kit Lanche", "Lanche Emergencial"]}
-                    periodoSelecionado={periodoSelecionado}
-                    solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
-                    objSolicitacaoMIFinalizada={objSolicitacaoMIFinalizada}
-                    ehGrupoSolicitacoesDeAlimentacao={true}
-                    quantidadeAlimentacoesLancadas={
-                      quantidadeAlimentacoesLancadas
-                    }
-                    errosAoSalvar={errosAoSalvar}
-                  />
-                )}
+              {solicitacoesKitLanchesAutorizadas?.length > 0 && (
+                <CardLancamento
+                  grupo="Solicitações de Alimentação"
+                  cor={CORES[5]}
+                  tipos_alimentacao={["Kit Lanche", "Lanche Emergencial"]}
+                  periodoSelecionado={periodoSelecionado}
+                  solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
+                  objSolicitacaoMIFinalizada={objSolicitacaoMIFinalizada}
+                  ehGrupoSolicitacoesDeAlimentacao={true}
+                  quantidadeAlimentacoesLancadas={
+                    quantidadeAlimentacoesLancadas
+                  }
+                  errosAoSalvar={errosAoSalvar}
+                />
+              )}
             </>
           )}
 

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -141,11 +141,17 @@ export const LancamentoPorPeriodo = ({
   const getSolicitacoesKitLanchesAutorizadasAsync = async () => {
     const escola_uuid = escolaInstituicao.uuid;
     const tipo_solicitacao = "Kit Lanche";
+    const recreioNasFeriasUuid =
+      typeof solicitacaoMedicaoInicial?.recreio_nas_ferias === "string"
+        ? solicitacaoMedicaoInicial.recreio_nas_ferias
+        : solicitacaoMedicaoInicial?.recreio_nas_ferias?.uuid ||
+          new URLSearchParams(window.location.search).get("recreio_nas_ferias");
     const response = await getSolicitacoesKitLanchesAutorizadasEscola({
       escola_uuid,
       mes,
       ano,
       tipo_solicitacao,
+      recreio_nas_ferias: recreioNasFeriasUuid,
     });
     if (response.status === HTTP_STATUS.OK) {
       setSolicitacoesKitLanchesAutorizadas(response.data.results);
@@ -630,6 +636,22 @@ export const LancamentoPorPeriodo = ({
                   errosAoSalvar={errosAoSalvar}
                 />
               )}
+              {solicitacoesKitLanchesAutorizadas &&
+                solicitacoesKitLanchesAutorizadas.length > 0 && (
+                  <CardLancamento
+                    grupo="Solicitações de Alimentação"
+                    cor={CORES[5]}
+                    tipos_alimentacao={["Kit Lanche", "Lanche Emergencial"]}
+                    periodoSelecionado={periodoSelecionado}
+                    solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
+                    objSolicitacaoMIFinalizada={objSolicitacaoMIFinalizada}
+                    ehGrupoSolicitacoesDeAlimentacao={true}
+                    quantidadeAlimentacoesLancadas={
+                      quantidadeAlimentacoesLancadas
+                    }
+                    errosAoSalvar={errosAoSalvar}
+                  />
+                )}
             </>
           )}
 

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
@@ -76,7 +76,16 @@ export const CardLancamentoCEI = ({
   };
 
   const quantidadeAlimentacao = (nomeAlimentacao) => {
-    const alimentacao = nomeAlimentacao
+    const nomeFormatado =
+      typeof nomeAlimentacao === "string"
+        ? nomeAlimentacao
+        : nomeAlimentacao?.nome;
+
+    if (!nomeFormatado) {
+      return 0;
+    }
+
+    const alimentacao = nomeFormatado
       .normalize("NFD")
       .replace(/[\u0300-\u036f]/g, "")
       .toLowerCase()
@@ -104,7 +113,9 @@ export const CardLancamentoCEI = ({
       "Recreio nas Férias - 4 a 14 anos",
     ].includes(textoCabecalho)
   ) {
-    let copyTiposAlimentacao = deepCopy(tiposAlimentacao);
+    let copyTiposAlimentacao = deepCopy(tiposAlimentacao).map((alimentacao) =>
+      typeof alimentacao === "string" ? { nome: alimentacao } : alimentacao,
+    );
     if (periodoPermissoes) {
       copyTiposAlimentacao = copyTiposAlimentacao.concat(
         periodoPermissoes.alimentacoes.map((alimentacao) => ({

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
@@ -179,8 +179,7 @@ export const CardLancamentoCEI = ({
           periodosInclusaoContinua: periodosInclusaoContinua,
           grupo,
           solicitacaoMedicaoInicial: solicitacaoMedicaoInicial,
-          recreioNasFerias:
-            solicitacaoMedicaoInicial.recreio_nas_ferias !== null,
+          recreioNasFerias: solicitacaoMedicaoInicial.recreio_nas_ferias?.uuid,
           ...location.state,
         },
       },

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
@@ -297,11 +297,19 @@ export const LancamentoPorPeriodoCEI = ({
     if (ehEscolaTipoCEMEI(escolaInstituicao)) {
       const escola_uuid = escolaInstituicao.uuid;
       const tipo_solicitacao = "Kit Lanche";
+      const recreioNasFeriasUuid =
+        typeof solicitacaoMedicaoInicial?.recreio_nas_ferias === "string"
+          ? solicitacaoMedicaoInicial.recreio_nas_ferias
+          : solicitacaoMedicaoInicial?.recreio_nas_ferias?.uuid ||
+            new URLSearchParams(window.location.search).get(
+              "recreio_nas_ferias",
+            );
       const response = await getSolicitacoesKitLanchesAutorizadasEscola({
         escola_uuid,
         mes,
         ano,
         tipo_solicitacao,
+        recreio_nas_ferias: recreioNasFeriasUuid,
       });
       if (response.status === HTTP_STATUS.OK) {
         setSolicitacoesKitLanchesAutorizadas(response.data.results);
@@ -654,6 +662,31 @@ export const LancamentoPorPeriodoCEI = ({
                     grupo="Colaboradores"
                   />
                 )}
+                {recreioNasFeriasDaMedicaoEMEIdaCEMEI(
+                  solicitacaoMedicaoInicial,
+                ) &&
+                  solicitacoesKitLanchesAutorizadas &&
+                  solicitacoesKitLanchesAutorizadas.length > 0 && (
+                    <CardLancamentoCEI
+                      textoCabecalho={"Solicitações de Alimentação"}
+                      cor={CORES[5]}
+                      solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
+                      escolaInstituicao={escolaInstituicao}
+                      quantidadeAlimentacoesLancadas={
+                        quantidadeAlimentacoesLancadas
+                      }
+                      periodoSelecionado={periodoSelecionado}
+                      periodosEscolaCemeiComAlunosEmei={
+                        periodosEscolaCemeiComAlunosEmei
+                      }
+                      tiposAlimentacao={[
+                        { nome: "Kit Lanche" },
+                        { nome: "Lanche Emergencial" },
+                      ]}
+                      errosAoSalvar={errosAoSalvar}
+                      grupo="Solicitações de Alimentação"
+                    />
+                  )}
               </>
             )}
             <div className="mt-4">

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -923,12 +923,14 @@ export const getSolicitacoesKitLanchesAutorizadasAsync = async (
   escolaUuuid,
   mes,
   ano,
+  recreio_nas_ferias = undefined,
 ) => {
   const params = {};
   params["escola_uuid"] = escolaUuuid;
   params["tipo_solicitacao"] = "Kit Lanche";
   params["mes"] = mes;
   params["ano"] = ano;
+  params["recreio_nas_ferias"] = recreio_nas_ferias;
   const responseKitLanchesAutorizadas =
     await getSolicitacoesKitLanchesAutorizadasEscola(params);
   if (responseKitLanchesAutorizadas.status === HTTP_STATUS.OK) {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -562,7 +562,18 @@ export default () => {
 
       const tiposAlimentacaoInclusaoContinua =
         getTiposAlimentacaoInclusoesContinuas(response_inclusoes_autorizadas);
-      const cloneTiposAlimentacao = deepCopy(tipos_alimentacao);
+      const cloneTiposAlimentacao = deepCopy(tipos_alimentacao).map(
+        (alimentacao) => {
+          if (typeof alimentacao === "string") {
+            return { nome: alimentacao };
+          }
+
+          return {
+            ...alimentacao,
+            nome: alimentacao?.nome ?? alimentacao?.name ?? "",
+          };
+        },
+      );
 
       const tiposAlimentacaoFormatadas = cloneTiposAlimentacao
         .filter((alimentacao) => alimentacao.nome !== "Lanche Emergencial")
@@ -1142,6 +1153,7 @@ export default () => {
             escola.uuid,
             mes,
             ano,
+            location.state.recreioNasFerias,
           );
         setKitLanchesAutorizadas(response_kit_lanches_autorizadas);
 

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
@@ -789,12 +789,14 @@ export const getSolicitacoesKitLanchesAutorizadasAsync = async (
   escolaUuuid,
   mes,
   ano,
+  recreioNasFerias = undefined,
 ) => {
   const params = {};
   params["escola_uuid"] = escolaUuuid;
   params["tipo_solicitacao"] = "Kit Lanche";
   params["mes"] = mes;
   params["ano"] = ano;
+  params["recreio_nas_ferias"] = recreioNasFerias;
   const responseKitLanchesAutorizadas =
     await getSolicitacoesKitLanchesAutorizadasEscola(params);
   if (responseKitLanchesAutorizadas.status === HTTP_STATUS.OK) {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
@@ -62,9 +62,13 @@ export const formatarPayloadPeriodoLancamentoCeiCemei = (
   arrayCategoriesValues
     .filter(([key]) => !key.includes("observacoes"))
     .forEach((arr) => {
+      const extrairNumeros = (texto) => texto?.match(/\d/g)?.join("");
       const keySplitted = arr[0].split("__");
       const categoria = keySplitted.pop();
-      const idCategoria = categoria.match(/\d/g).join("");
+      const idCategoria = extrairNumeros(categoria);
+      if (!idCategoria) {
+        return;
+      }
       let dia = null;
       const nome_campo = keySplitted[0];
 
@@ -74,7 +78,11 @@ export const formatarPayloadPeriodoLancamentoCeiCemei = (
         ehProgramasEProjetosLocation ||
         ehGrupoColaboradores
       ) {
-        dia = keySplitted[1].match(/\d/g).join("");
+        const diaParte = keySplitted.find((parte) => parte.includes("dia_"));
+        dia = extrairNumeros(diaParte);
+        if (!dia) {
+          return;
+        }
         return valoresMedicao.push({
           dia: dia,
           valor: ["<p></p>\n", ""].includes(arr[1]) ? 0 : arr[1],
@@ -82,8 +90,15 @@ export const formatarPayloadPeriodoLancamentoCeiCemei = (
           categoria_medicao: idCategoria,
         });
       } else {
-        dia = keySplitted[2].match(/\d/g).join("");
-        const uuid_faixa_etaria = keySplitted[1].replace("faixa_", "");
+        const diaParte = keySplitted.find((parte) => parte.includes("dia_"));
+        dia = extrairNumeros(diaParte);
+        const faixaParte = keySplitted.find((parte) =>
+          parte.includes("faixa_"),
+        );
+        const uuid_faixa_etaria = faixaParte?.replace("faixa_", "") || null;
+        if (!dia) {
+          return;
+        }
         return valoresMedicao.push({
           dia: dia,
           valor: ["<p></p>\n", ""].includes(arr[1]) ? 0 : arr[1],

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -438,6 +438,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             escola.uuid,
             mes,
             ano,
+            location.state.recreioNasFerias,
           );
         setKitLanchesAutorizadas(response_kit_lanches_autorizadas);
 
@@ -1172,6 +1173,16 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
       ...dadosValoresForaDoMes,
       semanaSelecionada,
     });
+
+    const possuiValoresPreenchidosSolicitacoes =
+      ehSolicitacoesAlimentacaoLocation &&
+      Object.keys(dadosValoresKitLanchesAutorizadas).length > 0;
+
+    if (possuiValoresPreenchidosSolicitacoes) {
+      setDisableBotaoSalvarLancamentos(false);
+      setExibirTooltip(false);
+    }
+
     setLoading(false);
   };
 
@@ -2581,7 +2592,11 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
     if (
       ehRecreioNasFerias() &&
       !(ehGrupoColaboradores() || ehRecreioEmeiDaCemei()) &&
-      !(nomeCategoria === "ALIMENTAÇÃO" || linha.nome === "Observações")
+      !(
+        nomeCategoria === "ALIMENTAÇÃO" ||
+        nomeCategoria.includes("SOLICITAÇÕES") ||
+        linha.nome === "Observações"
+      )
     ) {
       return (
         faixasAtivasPorTipo?.[nomeCategoria]?.includes(linha.uuid) ?? false


### PR DESCRIPTION
# Este PR:
- renderiza em tela o bloco Solicitações de Alimentação no Lançamento de Medição Inicial de Recreio nas férias, caso exista algum kit lanche autorizado da escola passada como parâmetro entre `data_inicio` e `data_fim` do recreio.
  - implementa atualização para EMEFs e EMEI da CEMEI

### Referência azure:
- [AB#148657](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148657)