### PR TITLE
Feature/148816 ajuste alimentacoes recreio

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/RecreioNasFerias/tiposAlimetacaoRecreio.test.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/RecreioNasFerias/tiposAlimetacaoRecreio.test.jsx
@@ -11,7 +11,12 @@ const recreioCEIMock = {
   unidades_participantes: [
     {
       tipos_alimentacao: {
-        colaboradores: [{ nome: "Lanche 4h" }, { nome: "Lanche" }],
+        colaboradores: [
+          { nome: "Refeição" },
+          { nome: "Lanche 4h" },
+          { nome: "Lanche" },
+          { nome: "Sobremesa" },
+        ],
         inscritos: [
           { nome: "Lanche" },
           { nome: "Refeição" },
@@ -61,18 +66,26 @@ describe("tiposAlimentacaoRecreio", () => {
     it("retorna inscritos quando colaboradores=false", () => {
       const result = tiposAlimentacaoRecreio(solicitacao, escola);
 
-      expect(result).toEqual(
-        recreioCEIMock.unidades_participantes[0].tipos_alimentacao.inscritos,
-      );
+      expect(result.map((item) => item.nome)).toEqual([
+        "Lanche",
+        "Refeição",
+        "Sobremesa",
+        "Colação",
+        "Refeição da tarde",
+        "Desjejum",
+        "Almoço",
+      ]);
     });
 
     it("retorna colaboradores quando colaboradores=true", () => {
       const result = tiposAlimentacaoRecreio(solicitacao, escola, true);
 
-      expect(result).toEqual(
-        recreioCEIMock.unidades_participantes[0].tipos_alimentacao
-          .colaboradores,
-      );
+      expect(result.map((item) => item.nome)).toEqual([
+        "Lanche",
+        "Refeição",
+        "Sobremesa",
+        "Lanche 4h",
+      ]);
     });
   });
 
@@ -87,9 +100,7 @@ describe("tiposAlimentacaoRecreio", () => {
 
       const result = tiposAlimentacaoRecreio(solicitacao, escola);
 
-      expect(result).toEqual(
-        recreioCEMEIMock.unidades_participantes[0].tipos_alimentacao.inscritos,
-      );
+      expect(result.map((item) => item.nome)).toEqual(["Lanche", "Refeição"]);
     });
 
     it("retorna infantil ordenado quando tipo EMEI", () => {
@@ -97,23 +108,13 @@ describe("tiposAlimentacaoRecreio", () => {
 
       const result = tiposAlimentacaoRecreio(solicitacao, escola);
 
-      const expected = [
-        ...recreioCEMEIMock.unidades_participantes[1].tipos_alimentacao
-          .infantil,
-      ].sort((a, b) => a.nome.localeCompare(b.nome));
-
-      expect(result).toEqual(expected);
+      expect(result.map((item) => item.nome)).toEqual(["Lanche", "Sobremesa"]);
     });
 
     it("retorna colaboradores ordenados quando colaboradores=true", () => {
       const result = tiposAlimentacaoRecreio(solicitacao, escola, true);
 
-      const expected = [
-        ...recreioCEMEIMock.unidades_participantes[0].tipos_alimentacao
-          .colaboradores,
-      ].sort((a, b) => a.nome.localeCompare(b.nome));
-
-      expect(result).toEqual(expected);
+      expect(result.map((item) => item.nome)).toEqual(["Lanche", "Sobremesa"]);
     });
   });
 });

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -50,6 +50,7 @@ import {
   verificaSeEnviarCorrecaoDisabled,
 } from "./helpers";
 
+import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
 export const LancamentoPorPeriodo = ({
   escolaInstituicao,
   periodosEscolaSimples,
@@ -430,6 +431,13 @@ export const LancamentoPorPeriodo = ({
     }
   };
 
+  const ordenarTiposAlimentacao = (tipos) =>
+    [...tipos].sort(
+      (a, b) =>
+        (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+        (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+    );
+
   return (
     <div>
       {erroAPI && <div>{erroAPI}</div>}
@@ -603,10 +611,10 @@ export const LancamentoPorPeriodo = ({
               <CardLancamento
                 grupo="Recreio nas Férias"
                 cor={CORES[10]}
-                tipos_alimentacao={
+                tipos_alimentacao={ordenarTiposAlimentacao(
                   recreioNasFeriasDaMedicao(solicitacaoMedicaoInicial)
-                    .unidades_participantes[0].tipos_alimentacao.inscritos
-                }
+                    .unidades_participantes[0].tipos_alimentacao.inscritos,
+                )}
                 periodoSelecionado={periodoSelecionado}
                 solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
                 objSolicitacaoMIFinalizada={objSolicitacaoMIFinalizada}
@@ -617,10 +625,11 @@ export const LancamentoPorPeriodo = ({
                 <CardLancamento
                   grupo="Colaboradores"
                   cor={CORES[11]}
-                  tipos_alimentacao={
+                  tipos_alimentacao={ordenarTiposAlimentacao(
                     recreioNasFeriasDaMedicao(solicitacaoMedicaoInicial)
-                      .unidades_participantes[0].tipos_alimentacao.colaboradores
-                  }
+                      .unidades_participantes[0].tipos_alimentacao
+                      .colaboradores,
+                  )}
                   periodoSelecionado={periodoSelecionado}
                   solicitacaoMedicaoInicial={solicitacaoMedicaoInicial}
                   objSolicitacaoMIFinalizada={objSolicitacaoMIFinalizada}

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/helpers.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/helpers.jsx
@@ -4,6 +4,8 @@ import {
   recreioNasFeriasDaMedicaoEMEIdaCEMEI,
 } from "src/helpers/utilities";
 
+import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
+
 export const ehEmeiDaCemei = (
   escolaInstituicao,
   periodosEscolaCemeiComAlunosEmei,
@@ -58,13 +60,17 @@ export const tiposAlimentacaoRecreio = (
 ) => {
   const recreio = recreioNasFeriasDaMedicao(solicitacaoMedicaoInicial);
   const tipos = recreio.unidades_participantes[0].tipos_alimentacao;
-  const ordenacao = (a, b) => a.nome.localeCompare(b.nome);
+  const ordenacao = (a, b) =>
+    (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+    (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999);
 
   if (!ehEscolaTipoCEMEI(escolaInstituicao)) {
-    return colaboradores ? tipos.colaboradores : tipos.inscritos;
+    return [...(colaboradores ? tipos.colaboradores : tipos.inscritos)].sort(
+      ordenacao,
+    );
   }
 
-  if (colaboradores) return tipos.colaboradores.sort(ordenacao);
+  if (colaboradores) [...tipos.colaboradores].sort(ordenacao);
 
   const tipoUnidade = recreioNasFeriasDaMedicaoEMEIdaCEMEI(
     solicitacaoMedicaoInicial,
@@ -76,6 +82,6 @@ export const tiposAlimentacaoRecreio = (
   )?.tipos_alimentacao;
 
   return tipoUnidade === "CEI"
-    ? tipos_alimentacao.inscritos
-    : tipos_alimentacao.infantil.sort(ordenacao);
+    ? [...tipos_alimentacao.inscritos].sort(ordenacao)
+    : [...tipos_alimentacao.infantil].sort(ordenacao);
 };

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/helpers.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/helpers.jsx
@@ -70,7 +70,7 @@ export const tiposAlimentacaoRecreio = (
     );
   }
 
-  if (colaboradores) [...tipos.colaboradores].sort(ordenacao);
+  if (colaboradores) return [...tipos.colaboradores].sort(ordenacao);
 
   const tipoUnidade = recreioNasFeriasDaMedicaoEMEIdaCEMEI(
     solicitacaoMedicaoInicial,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/ordenacaoAlimentacoes.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/recreioNasFerias/ordenacaoAlimentacoes.test.jsx
@@ -1,0 +1,365 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import { mockCategoriasMedicao } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/categoriasMedicao";
+import {
+  mockLocationStateGrupoRecreioNasFerias,
+  mockLocationStateGrupoColaboradores,
+} from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/RecreioNasFerias/EMEF/mockStateEMEFGrupoRecreio";
+import {
+  mockValoresMedicaoEMEF,
+  mockValoresMedicaoColaboradoresEMEF,
+} from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/RecreioNasFerias/EMEF/valoresMedicaoEMEF";
+import { mockMeusDadosEscolaEMEFPericles } from "src/mocks/meusDados/escolaEMEFPericles";
+import { mockDiasLetivos } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/RecreioNasFerias/EMEF/diasLetivosRecreio";
+import { mockSalvaLancamentoSemana1 } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/RecreioNasFerias/EMEF/mockSalvaLancamentoEMEF";
+import {
+  getCategoriasDeMedicao,
+  getFeriadosNoMes,
+  getValoresPeriodosLancamentos,
+  updateValoresPeriodosLancamentos,
+  getDiasLetivosRecreio,
+  getSolicitacoesInclusoesAutorizadasEscola,
+  getDiasParaCorrecao,
+  getSolicitacoesSuspensoesAutorizadasEscola,
+  getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+  getLogDietasAutorizadasRecreioNasFerias,
+} from "src/services/medicaoInicial/periodoLancamentoMedicao.service";
+import { getListaDiasSobremesaDoce } from "src/services/medicaoInicial/diaSobremesaDoce.service";
+import { mockVinculosTipoAlimentacaoEPeriodoEscolar } from "src/mocks/InclusaoAlimentacao/mockVinculosTipoAlimentacaoEPeriodoescolar";
+import {
+  getTiposDeAlimentacao,
+  getVinculosTipoAlimentacaoPorEscola,
+} from "src/services/cadastroTipoAlimentacao.service";
+import { getMeusDados } from "src/services/perfil.service";
+import PeriodoLancamentoMedicaoInicial from "../..";
+import { ToastContainer } from "react-toastify";
+import { mockLogQuantidadeDietasAutorizadasRecreio } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/RecreioNasFerias/EMEF/mockDietasEspeciais";
+import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
+
+jest.mock("src/services/perfil.service.jsx");
+jest.mock("src/services/medicaoInicial/diaSobremesaDoce.service.jsx");
+jest.mock("src/services/cadastroTipoAlimentacao.service");
+jest.mock("src/services/medicaoInicial/periodoLancamentoMedicao.service");
+
+const awaitServices = async () => {
+  await waitFor(() => {
+    expect(getListaDiasSobremesaDoce).toHaveBeenCalled();
+    expect(getVinculosTipoAlimentacaoPorEscola).toHaveBeenCalled();
+    expect(getSolicitacoesInclusoesAutorizadasEscola).toHaveBeenCalled();
+    expect(getCategoriasDeMedicao).toHaveBeenCalled();
+    expect(getDiasParaCorrecao).toHaveBeenCalled();
+    expect(getValoresPeriodosLancamentos).toHaveBeenCalled();
+    expect(getSolicitacoesSuspensoesAutorizadasEscola).toHaveBeenCalled();
+    expect(
+      getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+    ).toHaveBeenCalled();
+    expect(getDiasLetivosRecreio).toHaveBeenCalled();
+    expect(getFeriadosNoMes).toHaveBeenCalled();
+    expect(getLogDietasAutorizadasRecreioNasFerias).toHaveBeenCalled();
+  });
+};
+
+const mockOrdenadoRecreio = {
+  ...mockLocationStateGrupoRecreioNasFerias,
+  tipos_alimentacao: [
+    ...mockLocationStateGrupoRecreioNasFerias.tipos_alimentacao,
+  ].sort(
+    (a, b) =>
+      (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+      (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+  ),
+};
+
+const mockOrdenadoColaboradores = {
+  ...mockLocationStateGrupoColaboradores,
+  tipos_alimentacao: [
+    ...mockLocationStateGrupoColaboradores.tipos_alimentacao,
+  ].sort(
+    (a, b) =>
+      (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+      (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+  ),
+};
+
+describe("Ordenação alimentações para o Grupo Recreio Nas Férias - EMEF", () => {
+  beforeEach(async () => {
+    getMeusDados.mockResolvedValue({
+      data: mockMeusDadosEscolaEMEFPericles,
+      status: 200,
+    });
+    getListaDiasSobremesaDoce.mockResolvedValue({ data: [], status: 200 });
+    getVinculosTipoAlimentacaoPorEscola.mockResolvedValue({
+      data: mockVinculosTipoAlimentacaoEPeriodoEscolar,
+      status: 200,
+    });
+    getSolicitacoesInclusoesAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+    getCategoriasDeMedicao.mockResolvedValue({
+      data: mockCategoriasMedicao,
+      status: 200,
+    });
+
+    getTiposDeAlimentacao.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+    getValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockValoresMedicaoEMEF,
+      status: 200,
+    });
+    getDiasParaCorrecao.mockResolvedValue({
+      data: [],
+      status: 200,
+    });
+    getSolicitacoesSuspensoesAutorizadasEscola.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getDiasLetivosRecreio.mockResolvedValue({
+      data: mockDiasLetivos,
+      status: 200,
+    });
+    getFeriadosNoMes.mockResolvedValue({
+      data: { results: ["25"] },
+      status: 200,
+    });
+    updateValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockSalvaLancamentoSemana1,
+      status: 200,
+    });
+
+    getLogDietasAutorizadasRecreioNasFerias.mockResolvedValue({
+      data: mockLogQuantidadeDietasAutorizadasRecreio,
+      status: 200,
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[{ pathname: "/", state: mockOrdenadoRecreio }]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <PeriodoLancamentoMedicaoInicial />
+          <ToastContainer />
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("deve exibir as alimentações na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicao.find(
+      (c) => c.nome === "ALIMENTAÇÃO",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha b"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(
+      nomes.indexOf("Refeição 1ª Oferta"),
+    );
+
+    expect(nomes.indexOf("Refeição 1ª Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Refeição"),
+    );
+
+    expect(nomes.indexOf("Repetição Refeição")).toBeLessThan(
+      nomes.indexOf("Sobremesa 1º Oferta"),
+    );
+
+    expect(nomes.indexOf("Sobremesa 1º Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Sobremesa"),
+    );
+
+    expect(nomes.indexOf("Repetição Sobremesa")).toBeLessThan(
+      nomes.indexOf("Lanche 4h"),
+    );
+  });
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO A na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicao.find(
+      (c) => c.nome === "DIETA ESPECIAL - TIPO A",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha b"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO A - ENTERAL / RESTRIÇÃO DE AMINOÁCIDOS na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicao.find(
+      (c) =>
+        c.nome ===
+        "DIETA ESPECIAL - TIPO A - ENTERAL / RESTRIÇÃO DE AMINOÁCIDOS",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha b"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Refeição"));
+
+    expect(nomes.indexOf("Refeição")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO B na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicao.find(
+      (c) => c.nome === "DIETA ESPECIAL - TIPO B",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha b"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+});
+
+describe("Ordenação alimentações para o Grupo Colaboradores - EMEF", () => {
+  beforeEach(async () => {
+    getMeusDados.mockResolvedValue({
+      data: mockMeusDadosEscolaEMEFPericles,
+      status: 200,
+    });
+    getListaDiasSobremesaDoce.mockResolvedValue({ data: [], status: 200 });
+    getVinculosTipoAlimentacaoPorEscola.mockResolvedValue({
+      data: mockVinculosTipoAlimentacaoEPeriodoEscolar,
+      status: 200,
+    });
+    getSolicitacoesInclusoesAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+    getCategoriasDeMedicao.mockResolvedValue({
+      data: mockCategoriasMedicao,
+      status: 200,
+    });
+
+    getTiposDeAlimentacao.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+    getValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockValoresMedicaoColaboradoresEMEF,
+      status: 200,
+    });
+    getDiasParaCorrecao.mockResolvedValue({
+      data: [],
+      status: 200,
+    });
+    getSolicitacoesSuspensoesAutorizadasEscola.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getDiasLetivosRecreio.mockResolvedValue({
+      data: mockDiasLetivos,
+      status: 200,
+    });
+    getFeriadosNoMes.mockResolvedValue({
+      data: { results: ["25"] },
+      status: 200,
+    });
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[{ pathname: "/", state: mockOrdenadoColaboradores }]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <PeriodoLancamentoMedicaoInicial />
+          <ToastContainer />
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("deve exibir as alimentações na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+    const categoria = mockCategoriasMedicao.find(
+      (c) => c.nome === "ALIMENTAÇÃO",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha b"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(
+      nomes.indexOf("Refeição 1ª Oferta"),
+    );
+
+    expect(nomes.indexOf("Refeição 1ª Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Refeição"),
+    );
+
+    expect(nomes.indexOf("Repetição Refeição")).toBeLessThan(
+      nomes.indexOf("Lanche 4h"),
+    );
+  });
+});

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -66,7 +66,11 @@ import {
 } from "src/services/medicaoInicial/periodoLancamentoMedicao.service";
 import { escolaCorrigeMedicao } from "src/services/medicaoInicial/solicitacaoMedicaoInicial.service";
 import { getMeusDados } from "src/services/perfil.service";
-import { ALUNOS_EMEBS, FUNDAMENTAL_EMEBS } from "../constants";
+import {
+  ALUNOS_EMEBS,
+  FUNDAMENTAL_EMEBS,
+  ORDEM_CAMPOS_DIETAS_RECREIO,
+} from "../constants";
 import ModalErro from "./components/ModalErro";
 import ModalObservacaoDiaria from "./components/ModalObservacaoDiaria";
 import ModalSalvarCorrecoes from "./components/ModalSalvarCorrecoes";
@@ -752,7 +756,13 @@ export default () => {
         name: "observacoes",
         uuid: null,
       });
-
+      if (ehRecreioNasFerias()) {
+        rowsDietas.sort(
+          (a, b) =>
+            (ORDEM_CAMPOS_DIETAS_RECREIO[a.nome] ?? 999) -
+            (ORDEM_CAMPOS_DIETAS_RECREIO[b.nome] ?? 999),
+        );
+      }
       setTabelaDietaRows(rowsDietas);
 
       const cloneRowsDietas = deepCopy(rowsDietas);
@@ -773,7 +783,13 @@ export default () => {
           uuid: cloneTiposAlimentacao[indexRefeicaoDieta].uuid,
         });
       }
-
+      if (ehRecreioNasFerias()) {
+        cloneRowsDietas.sort(
+          (a, b) =>
+            (ORDEM_CAMPOS_DIETAS_RECREIO[a.nome] ?? 999) -
+            (ORDEM_CAMPOS_DIETAS_RECREIO[b.nome] ?? 999),
+        );
+      }
       setTabelaDietaEnteralRows(cloneRowsDietas);
 
       rowsSolicitacoesAlimentacao.push(

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
@@ -32,8 +32,6 @@ import {
 import { getMeusDados } from "src/services/perfil.service";
 import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
 
-import preview from "jest-preview";
-
 const mockNavigate = jest.fn();
 
 jest.mock("react-router-dom", () => ({
@@ -145,7 +143,6 @@ describe("Ordenação alimentações para o Grupo Colaboradores - CEI", () => {
 
     fireEvent.click(screen.getByText("Semana 1"));
 
-    preview.debug();
     const categoria = mockCategoriasMedicaoCEI.find(
       (c) => c.nome === "ALIMENTAÇÃO",
     );

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
@@ -1,0 +1,161 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
+
+import { PeriodoLancamentoMedicaoInicialCEI } from "src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI";
+import { mockCategoriasMedicaoCEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/mockCategoriasMedicaoCEI";
+import { mockSalvaLancamentoSemana1Colaboradores } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEI/mockSalvarLancamentos";
+import { mockLocationStateGrupoColaboradores } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEI/mockStateRecreio";
+import { mockValoresMedicaoCEIColaboradores } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEI/mockValoresMedicaoCEI";
+import { mockDiasLetivosColaboradores } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEI/diasLetivosRecreio";
+import { mockMeusDadosEscolaCEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/mockMeusDadosEscolaCEI";
+import { getTiposDeAlimentacao } from "src/services/cadastroTipoAlimentacao.service";
+import { getListaDiasSobremesaDoce } from "src/services/medicaoInicial/diaSobremesaDoce.service";
+import {
+  getCategoriasDeMedicao,
+  getDiasLetivosRecreio,
+  getDiasParaCorrecao,
+  getFeriadosNoMes,
+  getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+  getSolicitacoesInclusoesAutorizadasEscola,
+  getSolicitacoesSuspensoesAutorizadasEscola,
+  getValoresPeriodosLancamentos,
+  updateValoresPeriodosLancamentos,
+} from "src/services/medicaoInicial/periodoLancamentoMedicao.service";
+import { getMeusDados } from "src/services/perfil.service";
+import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
+
+import preview from "jest-preview";
+
+const mockNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock("src/services/perfil.service.jsx");
+jest.mock("src/services/medicaoInicial/diaSobremesaDoce.service.jsx");
+jest.mock("src/services/cadastroTipoAlimentacao.service");
+jest.mock("src/services/medicaoInicial/periodoLancamentoMedicao.service");
+jest.mock("src/services/medicaoInicial/solicitacaoMedicaoInicial.service");
+
+const awaitServices = async () => {
+  await waitFor(() => {
+    expect(getListaDiasSobremesaDoce).toHaveBeenCalled();
+    expect(getSolicitacoesInclusoesAutorizadasEscola).toHaveBeenCalled();
+    expect(getCategoriasDeMedicao).toHaveBeenCalled();
+    expect(getDiasParaCorrecao).toHaveBeenCalled();
+    expect(getValoresPeriodosLancamentos).toHaveBeenCalled();
+    expect(getSolicitacoesSuspensoesAutorizadasEscola).toHaveBeenCalled();
+    expect(
+      getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+    ).toHaveBeenCalled();
+    expect(getDiasLetivosRecreio).toHaveBeenCalled();
+    expect(getFeriadosNoMes).toHaveBeenCalled();
+  });
+};
+
+const mockOrdenadoColaboradores = {
+  ...mockLocationStateGrupoColaboradores,
+  tiposAlimentacao: [
+    ...mockLocationStateGrupoColaboradores.tiposAlimentacao,
+  ].sort(
+    (a, b) =>
+      (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+      (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+  ),
+};
+
+describe("Ordenação alimentações para o Grupo Colaboradores - CEI", () => {
+  beforeEach(async () => {
+    getMeusDados.mockResolvedValue({
+      data: mockMeusDadosEscolaCEI,
+      status: 200,
+    });
+    getListaDiasSobremesaDoce.mockResolvedValue({ data: [], status: 200 });
+    getSolicitacoesInclusoesAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+    getCategoriasDeMedicao.mockResolvedValue({
+      data: mockCategoriasMedicaoCEI,
+      status: 200,
+    });
+
+    getTiposDeAlimentacao.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+    getValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockValoresMedicaoCEIColaboradores,
+      status: 200,
+    });
+    getDiasParaCorrecao.mockResolvedValue({
+      data: [],
+      status: 200,
+    });
+    getSolicitacoesSuspensoesAutorizadasEscola.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getDiasLetivosRecreio.mockResolvedValue({
+      data: mockDiasLetivosColaboradores,
+      status: 200,
+    });
+    getFeriadosNoMes.mockResolvedValue({
+      data: { results: ["12"] },
+      status: 200,
+    });
+    updateValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockSalvaLancamentoSemana1Colaboradores,
+      status: 200,
+    });
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[{ pathname: "/", state: mockOrdenadoColaboradores }]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <PeriodoLancamentoMedicaoInicialCEI />
+          <ToastContainer />
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("deve exibir as alimentações na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    preview.debug();
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) => c.nome === "ALIMENTAÇÃO",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+});

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/ordenacaoAlimentacoes.test.jsx
@@ -1,0 +1,387 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
+import { localStorageMock } from "src/mocks/localStorageMock";
+import { PeriodoLancamentoMedicaoInicialCEI } from "src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI";
+import {
+  mockLocationStateGrupoEmeiDaCEMEI,
+  mockLocationStateGrupoColaboradoresCEMEI,
+} from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEMEI/mockStateRecreio";
+import { getMeusDados } from "src/services/perfil.service";
+import { mockMeusDadosEscolaCEMEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/mockMeusDadosEscolaCEMEI";
+import { mockFaixasEtarias } from "src/mocks/faixaEtaria.service/mockGetFaixasEtarias";
+import { mockCategoriasMedicaoCEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/mockCategoriasMedicaoCEI";
+import { mockDiasLetivosRecreio } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEMEI/diasLetivosRecreio";
+import {
+  mockValoresMedicaoEmeiDaCEMEI,
+  mockValoresMedicaoCEMEIColaboradores,
+} from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEMEI/mockValoresMedicao";
+import { mockSalvaLancamentoSemana1EmeiDaCEMEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEMEI/mockSalvarLancamentos";
+import { mockDietasEspeciaisEmeiDaCEMEI } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicialCEI/RecreioNasFerias/CEMEI/mockDietasEspeciais";
+
+import { getListaDiasSobremesaDoce } from "src/services/medicaoInicial/diaSobremesaDoce.service";
+import {
+  getCategoriasDeMedicao,
+  getDiasLetivosRecreio,
+  getDiasParaCorrecao,
+  getFeriadosNoMes,
+  getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+  getSolicitacoesInclusoesAutorizadasEscola,
+  getSolicitacoesSuspensoesAutorizadasEscola,
+  getValoresPeriodosLancamentos,
+  updateValoresPeriodosLancamentos,
+  getLogDietasAutorizadasRecreioNasFerias,
+} from "src/services/medicaoInicial/periodoLancamentoMedicao.service";
+import { getTiposDeAlimentacao } from "src/services/cadastroTipoAlimentacao.service";
+import { getPermissoesLancamentosEspeciaisMesAnoPorPeriodo } from "src/services/medicaoInicial/permissaoLancamentosEspeciais.service";
+import mock from "src/services/_mock";
+import { ORDEM_ALIMENTACAO_RECREIO } from "src/components/screens/LancamentoInicial/constants";
+
+jest.mock("src/services/perfil.service.jsx");
+jest.mock("src/services/medicaoInicial/diaSobremesaDoce.service.jsx");
+jest.mock("src/services/cadastroTipoAlimentacao.service");
+jest.mock("src/services/medicaoInicial/periodoLancamentoMedicao.service");
+jest.mock("src/services/medicaoInicial/permissaoLancamentosEspeciais.service");
+
+const awaitServices = async () => {
+  await waitFor(() => {
+    expect(getListaDiasSobremesaDoce).toHaveBeenCalled();
+    expect(getSolicitacoesInclusoesAutorizadasEscola).toHaveBeenCalled();
+    expect(getCategoriasDeMedicao).toHaveBeenCalled();
+    expect(getDiasParaCorrecao).toHaveBeenCalled();
+    expect(getValoresPeriodosLancamentos).toHaveBeenCalled();
+    expect(getSolicitacoesSuspensoesAutorizadasEscola).toHaveBeenCalled();
+    expect(
+      getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
+    ).toHaveBeenCalled();
+    expect(getDiasLetivosRecreio).toHaveBeenCalled();
+    expect(getFeriadosNoMes).toHaveBeenCalled();
+    expect(getLogDietasAutorizadasRecreioNasFerias).toHaveBeenCalled;
+  });
+};
+
+const mockOrdenadoRecreio = {
+  ...mockLocationStateGrupoEmeiDaCEMEI,
+  tiposAlimentacao: [
+    ...mockLocationStateGrupoEmeiDaCEMEI.tiposAlimentacao,
+  ].sort(
+    (a, b) =>
+      (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+      (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+  ),
+};
+
+const mockOrdenadoColaboradores = {
+  ...mockLocationStateGrupoColaboradoresCEMEI,
+  tiposAlimentacao: [
+    ...mockLocationStateGrupoColaboradoresCEMEI.tiposAlimentacao,
+  ].sort(
+    (a, b) =>
+      (ORDEM_ALIMENTACAO_RECREIO[a.nome] ?? 999) -
+      (ORDEM_ALIMENTACAO_RECREIO[b.nome] ?? 999),
+  ),
+};
+
+describe("Ordenação alimentações para o para o Grupo Recreio nas Férias - de 4 a 14 anos - CEMEI", () => {
+  beforeEach(async () => {
+    getMeusDados.mockResolvedValue({
+      data: mockMeusDadosEscolaCEMEI,
+      status: 200,
+    });
+    mock.onGet("/faixas-etarias/").reply(200, mockFaixasEtarias);
+
+    getListaDiasSobremesaDoce.mockResolvedValue({ data: [], status: 200 });
+
+    getSolicitacoesInclusoesAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getSolicitacoesSuspensoesAutorizadasEscola.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getCategoriasDeMedicao.mockResolvedValue({
+      data: mockCategoriasMedicaoCEI,
+      status: 200,
+    });
+
+    getDiasLetivosRecreio.mockResolvedValue({
+      data: mockDiasLetivosRecreio,
+      status: 200,
+    });
+    getLogDietasAutorizadasRecreioNasFerias.mockResolvedValue({
+      data: mockDietasEspeciaisEmeiDaCEMEI,
+      status: 200,
+    });
+
+    getValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockValoresMedicaoEmeiDaCEMEI,
+      status: 200,
+    });
+
+    getDiasParaCorrecao.mockResolvedValue({
+      data: [],
+      status: 200,
+    });
+
+    getFeriadosNoMes.mockResolvedValue({
+      data: { results: ["01", "25"] },
+      status: 200,
+    });
+
+    updateValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockSalvaLancamentoSemana1EmeiDaCEMEI,
+      status: 200,
+    });
+
+    getTiposDeAlimentacao.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getPermissoesLancamentosEspeciaisMesAnoPorPeriodo.mockResolvedValue({
+      data: {
+        results: {
+          alimentacoes_lancamentos_especiais: [],
+          permissoes_por_dia: [],
+          data_inicio_permissoes: null,
+        },
+      },
+      status: 200,
+    });
+
+    Object.defineProperty(global, "localStorage", { value: localStorageMock });
+    localStorage.setItem("eh_cemei", "true");
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[{ pathname: "/", state: mockOrdenadoRecreio }]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <PeriodoLancamentoMedicaoInicialCEI />
+          <ToastContainer />
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("deve exibir as alimentações na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) => c.nome === "ALIMENTAÇÃO",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(
+      nomes.indexOf("Refeição 1ª Oferta"),
+    );
+
+    expect(nomes.indexOf("Refeição 1ª Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Refeição"),
+    );
+
+    expect(nomes.indexOf("Repetição Refeição")).toBeLessThan(
+      nomes.indexOf("Sobremesa 1º Oferta"),
+    );
+
+    expect(nomes.indexOf("Sobremesa 1º Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Sobremesa"),
+    );
+
+    expect(nomes.indexOf("Repetição Sobremesa")).toBeLessThan(
+      nomes.indexOf("Lanche 4h"),
+    );
+  });
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO A na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) => c.nome === "DIETA ESPECIAL - TIPO A",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO A - ENTERAL / RESTRIÇÃO DE AMINOÁCIDOS na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) =>
+        c.nome ===
+        "DIETA ESPECIAL - TIPO A - ENTERAL / RESTRIÇÃO DE AMINOÁCIDOS",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Refeição"));
+
+    expect(nomes.indexOf("Refeição")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+
+  it("deve exibir as alimentações da DIETA ESPECIAL - TIPO B na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) => c.nome === "DIETA ESPECIAL - TIPO B",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(nomes.indexOf("Lanche 4h"));
+  });
+});
+
+describe("Ordenação alimentações para o Grupo Colaboradores - CEMEI", () => {
+  beforeEach(async () => {
+    getMeusDados.mockResolvedValue({
+      data: mockMeusDadosEscolaCEMEI,
+      status: 200,
+    });
+    getListaDiasSobremesaDoce.mockResolvedValue({ data: [], status: 200 });
+    getSolicitacoesInclusoesAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+    getCategoriasDeMedicao.mockResolvedValue({
+      data: mockCategoriasMedicaoCEI,
+      status: 200,
+    });
+
+    getTiposDeAlimentacao.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+    getValoresPeriodosLancamentos.mockResolvedValue({
+      data: mockValoresMedicaoCEMEIColaboradores,
+      status: 200,
+    });
+    getDiasParaCorrecao.mockResolvedValue({
+      data: [],
+      status: 200,
+    });
+    getSolicitacoesSuspensoesAutorizadasEscola.mockResolvedValue({
+      data: { data: { results: [] }, status: 200 },
+      status: 200,
+    });
+
+    getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola.mockResolvedValue({
+      data: { results: [] },
+      status: 200,
+    });
+
+    getDiasLetivosRecreio.mockResolvedValue({
+      data: mockDiasLetivosRecreio,
+      status: 200,
+    });
+    getFeriadosNoMes.mockResolvedValue({
+      data: { results: ["01", "25"] },
+      status: 200,
+    });
+
+    Object.defineProperty(global, "localStorage", { value: localStorageMock });
+    localStorage.setItem("eh_cemei", "true");
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[{ pathname: "/", state: mockOrdenadoColaboradores }]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <PeriodoLancamentoMedicaoInicialCEI />
+          <ToastContainer />
+        </MemoryRouter>,
+      );
+    });
+  });
+  it("deve exibir as alimentações na ordem definida para Recreio nas Férias", async () => {
+    await awaitServices();
+
+    fireEvent.click(screen.getByText("Semana 1"));
+    const categoria = mockCategoriasMedicaoCEI.find(
+      (c) => c.nome === "ALIMENTAÇÃO",
+    );
+
+    const blocoAlimentacao = screen.getByTestId(
+      `div-lancamentos-por-categoria-${categoria.uuid}`,
+    );
+
+    const nomes = Array.from(
+      blocoAlimentacao.querySelectorAll(".nome-linha-cei"),
+    ).map((element) => element.textContent?.trim());
+
+    expect(nomes.indexOf("Lanche")).toBeLessThan(
+      nomes.indexOf("Refeição 1ª Oferta"),
+    );
+
+    expect(nomes.indexOf("Refeição 1ª Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Refeição"),
+    );
+
+    expect(nomes.indexOf("Repetição Refeição")).toBeLessThan(
+      nomes.indexOf("Sobremesa 1º Oferta"),
+    );
+
+    expect(nomes.indexOf("Sobremesa 1º Oferta")).toBeLessThan(
+      nomes.indexOf("Repetição Sobremesa"),
+    );
+
+    expect(nomes.indexOf("Repetição Sobremesa")).toBeLessThan(
+      nomes.indexOf("Lanche 4h"),
+    );
+  });
+});

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/regra_liberacao_apontamentos.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/__tests__/CEMEI/RecreioNasFerias/regra_liberacao_apontamentos.test.jsx
@@ -52,7 +52,6 @@ import {
 import { getTiposDeAlimentacao } from "src/services/cadastroTipoAlimentacao.service";
 import mock from "src/services/_mock";
 import { getPermissoesLancamentosEspeciaisMesAnoPorPeriodo } from "src/services/medicaoInicial/permissaoLancamentosEspeciais.service";
-import preview from "jest-preview";
 jest.mock("src/services/perfil.service.jsx");
 jest.mock("src/services/medicaoInicial/diaSobremesaDoce.service.jsx");
 jest.mock("src/services/cadastroTipoAlimentacao.service");
@@ -1868,7 +1867,7 @@ describe("Teste Grupo Recreio nas Férias - de 4 a 14 anos JANEIRO/2026 - CEMEI:
     it("ao clicar na tab `Semana 3`, exibe, nos dias 12 dezembro a 18 janeiro, e verifica os lançamentos", async () => {
       const semana3Element = screen.getByText("Semana 3");
       fireEvent.click(semana3Element);
-      preview.debug();
+
       const VALORES_ESPERADOS = {
         12: {
           dietas: "2",

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -150,6 +150,8 @@ import {
   validacoesFaixasZeradasAlimentacao,
 } from "./validacoes";
 
+import { ORDEM_CAMPOS_DIETAS_RECREIO } from "src/components/screens/LancamentoInicial/constants";
+
 export const PeriodoLancamentoMedicaoInicialCEI = () => {
   const initialStateWeekColumns = [
     { position: 0, dia: "29" },
@@ -624,6 +626,14 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
               response_log_dietas_autorizadas_cei,
               periodoGrupo,
             );
+
+      if (ehRecreioNasFerias() && ehEmeiDaCemeiLocation) {
+        linhasTabelasDietasCEI.sort(
+          (a, b) =>
+            (ORDEM_CAMPOS_DIETAS_RECREIO[a.nome] ?? 999) -
+            (ORDEM_CAMPOS_DIETAS_RECREIO[b.nome] ?? 999),
+        );
+      }
       setTabelaDietaCEIRows(linhasTabelasDietasCEI);
 
       let linhasTabelaDietaEnteral = [];
@@ -632,6 +642,15 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
           tiposAlimentacaoBase,
           linhasTabelasDietasCEI,
         );
+
+        if (ehRecreioNasFerias()) {
+          linhasTabelaDietaEnteral.sort(
+            (a, b) =>
+              (ORDEM_CAMPOS_DIETAS_RECREIO[a.nome] ?? 999) -
+              (ORDEM_CAMPOS_DIETAS_RECREIO[b.nome] ?? 999),
+          );
+        }
+
         setTabelaDietaEnteralRows(linhasTabelaDietaEnteral);
       }
 

--- a/src/components/screens/LancamentoInicial/constants.jsx
+++ b/src/components/screens/LancamentoInicial/constants.jsx
@@ -23,3 +23,19 @@ export const STATUS_RELATORIO_FINANCEIRO = {
   GERADA_MEDICAO_FINAL: "Gerada Medição Final",
   FINALIZADO: "Finalizado",
 };
+
+export const ORDEM_ALIMENTACAO_RECREIO = {
+  Lanche: 1,
+  Refeição: 2,
+  Sobremesa: 3,
+  "Lanche 4h": 4,
+};
+
+export const ORDEM_CAMPOS_DIETAS_RECREIO = {
+  "Dietas Autorizadas": 1,
+  Frequência: 2,
+  Lanche: 3,
+  Refeição: 4,
+  "Lanche 4h": 6,
+  Observações: 7,
+};


### PR DESCRIPTION
Esse pull request:

- Ajusta a ordem de exibição das alimentações na Medição Inicial do grupo Recreio nas Férias

**Referência no Azure:** [AB#148816](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/148816)