### PR TITLE
Feature/149379 integracao lanche emergencial recreio nas ferias

### DIFF
--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/TabelaLancamentosPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/components/TabelaLancamentosPeriodo/index.jsx
@@ -885,6 +885,10 @@ export const TabelaLancamentosPeriodo = ({ ...props }) => {
                 mesSolicitacao,
                 anoSolicitacao,
                 periodoGrupo.nome_periodo_grupo,
+                false,
+                new URLSearchParams(window.location.search).get(
+                  "recreio_nas_ferias",
+                ),
               );
             setAlteracoesAlimentacaoAutorizadas(
               response_alteracoes_alimentacao_autorizadas,

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/CEMEI/medicao_recreio_nas_ferias.test.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/CEMEI/medicao_recreio_nas_ferias.test.jsx
@@ -17,8 +17,15 @@ import mock from "src/services/_mock";
 
 describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Renderiza Medição com Recreio nas Ferias", () => {
   const escolaUuid = mockMeusDadosEscolaCEMEI.vinculo_atual.instituicao.uuid;
+  let paramsRequisicaoAlteracoes;
 
   beforeEach(async () => {
+    paramsRequisicaoAlteracoes = undefined;
+    mock.reset();
+    mock.onGet("/notificacoes/").reply(200, { results: [] });
+    mock
+      .onGet("/notificacoes/quantidade-nao-lidos/")
+      .reply(200, { quantidade_nao_lidos: 0 });
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosEscolaCEMEI);
     mock
       .onGet(`/escolas-simples/${escolaUuid}/`)
@@ -65,7 +72,10 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Renderiza Mediçã
     });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
-      .reply(200, { results: [] });
+      .reply((config) => {
+        paramsRequisicaoAlteracoes = config.params;
+        return [200, { results: [] }];
+      });
     mock
       .onGet(
         "/medicao-inicial/solicitacao-medicao-inicial/quantidades-alimentacoes-lancadas-periodo-grupo/",
@@ -128,6 +138,134 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Renderiza Mediçã
   });
 
   it("Renderiza período Solicitações de Alimentação no recreio para EMEI da CEMEI quando há kit lanche autorizado", async () => {
+    await waitFor(() => {
+      expect(
+        screen.getByText("Solicitações de Alimentação - Infantil"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("requisita lanches emergenciais com recreio_nas_ferias para EMEI da CEMEI em recreio", async () => {
+    await waitFor(() => {
+      expect(paramsRequisicaoAlteracoes).toEqual(
+        expect.objectContaining({
+          recreio_nas_ferias: "cd27796f-9dbf-4e36-ac14-c44f23d41cd4",
+          eh_lanche_emergencial: true,
+        }),
+      );
+    });
+  });
+});
+
+describe("Teste <LancamentoMedicaoInicial> - Usuário CEMEI - Recreio com lanche emergencial autorizado", () => {
+  const escolaUuid = mockMeusDadosEscolaCEMEI.vinculo_atual.instituicao.uuid;
+
+  beforeEach(async () => {
+    mock.reset();
+    mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosEscolaCEMEI);
+    mock.onGet("/notificacoes/").reply(200, { results: [] });
+    mock
+      .onGet("/notificacoes/quantidade-nao-lidos/")
+      .reply(200, { quantidade_nao_lidos: 0 });
+    mock
+      .onGet(`/escolas-simples/${escolaUuid}/`)
+      .reply(200, mockEscolaSimplesCEMEI);
+    mock
+      .onGet("/medicao-inicial/recreio-nas-ferias/")
+      .reply(200, mockRecreioNasFeriasCEMEIDezembro2025);
+    mock
+      .onGet(
+        `/vinculos-tipo-alimentacao-u-e-periodo-escolar/escola/${escolaUuid}/`,
+      )
+      .reply(200, mockGetVinculosTipoAlimentacaoPorEscolaCEMEI);
+    mock
+      .onGet("/solicitacao-medicao-inicial/solicitacoes-lancadas/")
+      .reply(200, []);
+    mock
+      .onGet(
+        "/medicao-inicial/solicitacao-medicao-inicial/periodos-escola-cemei-com-alunos-emei/",
+      )
+      .reply(200, {
+        results: ["Infantil INTEGRAL"],
+      });
+    mock
+      .onGet(
+        "/medicao-inicial/permissao-lancamentos-especiais/periodos-permissoes-lancamentos-especiais-mes-ano/",
+      )
+      .reply(200, { results: [] });
+    mock
+      .onGet("/medicao-inicial/solicitacao-medicao-inicial/")
+      .replyOnce(200, mockSolicitacaoMedicaoRecreioNasFeriasDezembro2025CEMEI);
+    mock
+      .onGet("/dias-calendario/")
+      .reply(200, mockDiasCalendarioDezembro2025CEMEI);
+    mock
+      .onGet("/medicao-inicial/tipo-contagem-alimentacao/")
+      .reply(200, mockGetTiposDeContagemAlimentacao);
+    mock.onGet("/periodos-escolares/inclusao-continua-por-mes/").reply(200, {
+      periodos: null,
+    });
+    mock.onGet("/escola-solicitacoes/kit-lanches-autorizadas/").reply(200, {
+      results: [],
+    });
+    mock
+      .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
+      .reply(200, {
+        results: [
+          {
+            dia: "17",
+            numero_alunos: 80,
+            inclusao_id_externo: "6CD6E",
+            motivo: "Lanche Emergencial",
+            periodos_escolares: ["MANHA"],
+            tipos_alimentacao_de: ["Refeição", "Lanche"],
+          },
+        ],
+      });
+    mock
+      .onGet(
+        "/medicao-inicial/solicitacao-medicao-inicial/quantidades-alimentacoes-lancadas-periodo-grupo/",
+      )
+      .reply(200, { results: [] });
+    mock.onGet("/matriculados-no-mes/").reply(200, []);
+    mock.onGet(`/historico-escola/${escolaUuid}/`).reply(200, {
+      nome: mockEscolaSimplesCEMEI.nome,
+      tipo_unidade: mockEscolaSimplesCEMEI.tipo_unidade,
+    });
+
+    const search = `?mes=12&ano=2025&recreio_nas_ferias=cd27796f-9dbf-4e36-ac14-c44f23d41cd4`;
+    window.history.pushState({}, "", search);
+
+    Object.defineProperty(global, "localStorage", { value: localStorageMock });
+    localStorage.setItem("nome_instituicao", `"CEMEI SUZANA CAMPOS TAUIL"`);
+    localStorage.setItem("tipo_perfil", TIPO_PERFIL.ESCOLA);
+    localStorage.setItem("perfil", PERFIL.DIRETOR_UE);
+    localStorage.setItem("modulo_gestao", MODULO_GESTAO.TERCEIRIZADA);
+    localStorage.setItem("eh_cemei", "true");
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosEscolaCEMEI,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <LancamentoMedicaoInicialPage />
+            <ToastContainer />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("Renderiza período Solicitações de Alimentação no recreio para EMEI da CEMEI quando há lanche emergencial autorizado", async () => {
     await waitFor(() => {
       expect(
         screen.getByText("Solicitações de Alimentação - Infantil"),

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/EMEF/medicao_recreio_nas_ferias.test.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/__tests__/EMEF/medicao_recreio_nas_ferias.test.jsx
@@ -27,8 +27,11 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Renderiza Medição
     mockMeusDadosEscolaEMEFPericles.vinculo_atual.instituicao.uuid;
   const solicitacaoMedicaoInicialUuid =
     mockSolicitacaoMedicaoRecreioNasFeriasDezembro2025EMEF[0].uuid;
+  let paramsRequisicaoAlteracoes;
 
   beforeEach(async () => {
+    paramsRequisicaoAlteracoes = undefined;
+    mock.reset();
     mock
       .onGet("/usuarios/meus-dados/")
       .reply(200, mockMeusDadosEscolaEMEFPericles);
@@ -72,7 +75,10 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Renderiza Medição
     });
     mock
       .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
-      .reply(200, { results: [] });
+      .reply((config) => {
+        paramsRequisicaoAlteracoes = config.params;
+        return [200, { results: [] }];
+      });
     mock
       .onGet("/escola-solicitacoes/inclusoes-etec-autorizadas/")
       .reply(200, { results: [] });
@@ -141,6 +147,140 @@ describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Renderiza Medição
 
   it("Renderiza período Solicitações de Alimentação durante recreio quando há kit lanche autorizado", () => {
     return waitFor(() => {
+      expect(
+        screen.getByText("Solicitações de Alimentação"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("requisita lanches emergenciais com recreio_nas_ferias quando a medição é de recreio", async () => {
+    await waitFor(() => {
+      expect(paramsRequisicaoAlteracoes).toEqual(
+        expect.objectContaining({
+          recreio_nas_ferias: "0e3cdb48-3a82-47e6-9263-300d478c6934",
+          eh_lanche_emergencial: true,
+        }),
+      );
+    });
+  });
+});
+
+describe("Teste <LancamentoMedicaoInicial> - Usuário EMEF - Recreio com lanche emergencial autorizado", () => {
+  const escolaUuid =
+    mockMeusDadosEscolaEMEFPericles.vinculo_atual.instituicao.uuid;
+  const solicitacaoMedicaoInicialUuid =
+    mockSolicitacaoMedicaoRecreioNasFeriasDezembro2025EMEF[0].uuid;
+
+  beforeEach(async () => {
+    mock.reset();
+    mock
+      .onGet("/usuarios/meus-dados/")
+      .reply(200, mockMeusDadosEscolaEMEFPericles);
+    mock.onGet("/notificacoes/").reply(200, { results: [] });
+    mock
+      .onGet("/notificacoes/quantidade-nao-lidos/")
+      .reply(200, { quantidade_nao_lidos: 0 });
+    mock
+      .onGet(`/escolas-simples/${escolaUuid}/`)
+      .reply(200, mockEscolaSimplesEMEF);
+    mock
+      .onGet("/medicao-inicial/recreio-nas-ferias/")
+      .reply(200, mockRecreioNasFeriasEMEFDezembro2025);
+    mock
+      .onGet("/solicitacao-medicao-inicial/solicitacoes-lancadas/")
+      .reply(200, []);
+    mock
+      .onGet(
+        `/vinculos-tipo-alimentacao-u-e-periodo-escolar/escola/${escolaUuid}/`,
+      )
+      .reply(200, mockVinculosTipoAlimentacaoPeriodoEscolarEMEF);
+    mock
+      .onGet(
+        "/medicao-inicial/permissao-lancamentos-especiais/periodos-permissoes-lancamentos-especiais-mes-ano/",
+      )
+      .reply(200, { results: [] });
+    mock
+      .onGet("/medicao-inicial/solicitacao-medicao-inicial/")
+      .replyOnce(200, mockSolicitacaoMedicaoRecreioNasFeriasDezembro2025EMEF);
+    mock.onGet("/dias-calendario/").reply(200, mockDiasCalendarioEMEFMaio2025);
+    mock
+      .onGet("/medicao-inicial/tipo-contagem-alimentacao/")
+      .reply(200, mockGetTiposDeContagemAlimentacao);
+    mock.onGet("/periodos-escolares/inclusao-continua-por-mes/").reply(200, {
+      periodos: { MANHA: "5067e137-e5f3-4876-a63f-7f58cce93f33" },
+    });
+    mock.onGet("/escola-solicitacoes/kit-lanches-autorizadas/").reply(200, {
+      results: [],
+    });
+    mock
+      .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
+      .reply(200, {
+        results: [
+          {
+            dia: "06",
+            numero_alunos: 10,
+            inclusao_id_externo: "0B9FF",
+            motivo: "Lanche Emergencial",
+            periodos_escolares: ["MANHA"],
+            tipos_alimentacao_de: ["Refeição", "Lanche"],
+          },
+        ],
+      });
+    mock
+      .onGet("/escola-solicitacoes/inclusoes-etec-autorizadas/")
+      .reply(200, { results: [] });
+    mock
+      .onGet(
+        "/vinculos-tipo-alimentacao-u-e-periodo-escolar/vinculos-inclusoes-evento-especifico-autorizadas/",
+      )
+      .reply(200, []);
+    mock
+      .onGet(
+        `/medicao-inicial/solicitacao-medicao-inicial/${solicitacaoMedicaoInicialUuid}/ceu-gestao-frequencias-dietas/`,
+      )
+      .reply(200, []);
+    mock
+      .onGet(
+        "/medicao-inicial/solicitacao-medicao-inicial/quantidades-alimentacoes-lancadas-periodo-grupo/",
+      )
+      .reply(200, quantidadesAlimentacaoesLancadasPeriodoGrupoEMEFMaio2025);
+
+    const search = `?mes=12&ano=2025&recreio_nas_ferias=0e3cdb48-3a82-47e6-9263-300d478c6934`;
+    window.history.pushState({}, "", search);
+
+    Object.defineProperty(global, "localStorage", { value: localStorageMock });
+    localStorage.setItem(
+      "nome_instituicao",
+      `"EMEF PERICLES EUGENIO DA SILVA RAMOS"`,
+    );
+    localStorage.setItem("tipo_perfil", TIPO_PERFIL.ESCOLA);
+    localStorage.setItem("perfil", PERFIL.DIRETOR_UE);
+    localStorage.setItem("modulo_gestao", MODULO_GESTAO.TERCEIRIZADA);
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosEscolaEMEFPericles,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <LancamentoMedicaoInicialPage />
+            <ToastContainer />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>,
+      );
+    });
+  });
+
+  it("Renderiza período Solicitações de Alimentação durante recreio quando há lanche emergencial autorizado", async () => {
+    await waitFor(() => {
       expect(
         screen.getByText("Solicitações de Alimentação"),
       ).toBeInTheDocument();

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -653,7 +653,9 @@ export const LancamentoPorPeriodo = ({
                   errosAoSalvar={errosAoSalvar}
                 />
               )}
-              {solicitacoesKitLanchesAutorizadas?.length > 0 && (
+              {(solicitacoesKitLanchesAutorizadas?.length > 0 ||
+                solicitacoesAlteracaoLancheEmergencialAutorizadas?.length > 0 ||
+                temLancheEmergencialDiarioAtivo) && (
                 <CardLancamento
                   grupo="Solicitações de Alimentação"
                   cor={CORES[5]}

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodo/index.jsx
@@ -166,11 +166,19 @@ export const LancamentoPorPeriodo = ({
   const getSolicitacoesAlteracaoLancheEmergencialAutorizadasAsync =
     async () => {
       const params = {};
+      const recreioNasFeriasUuid =
+        typeof solicitacaoMedicaoInicial?.recreio_nas_ferias === "string"
+          ? solicitacaoMedicaoInicial.recreio_nas_ferias
+          : solicitacaoMedicaoInicial?.recreio_nas_ferias?.uuid ||
+            new URLSearchParams(window.location.search).get(
+              "recreio_nas_ferias",
+            );
       params["escola_uuid"] = escolaInstituicao.uuid;
       params["tipo_solicitacao"] = "Alteração";
       params["mes"] = mes;
       params["ano"] = ano;
       params["eh_lanche_emergencial"] = true;
+      params["recreio_nas_ferias"] = recreioNasFeriasUuid;
       const response =
         await getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola(params);
       if (response.status === HTTP_STATUS.OK) {

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
@@ -325,11 +325,19 @@ export const LancamentoPorPeriodoCEI = ({
     async () => {
       if (ehEscolaTipoCEMEI(escolaInstituicao)) {
         const params = {};
+        const recreioNasFeriasUuid =
+          typeof solicitacaoMedicaoInicial?.recreio_nas_ferias === "string"
+            ? solicitacaoMedicaoInicial.recreio_nas_ferias
+            : solicitacaoMedicaoInicial?.recreio_nas_ferias?.uuid ||
+              new URLSearchParams(window.location.search).get(
+                "recreio_nas_ferias",
+              );
         params["escola_uuid"] = escolaInstituicao.uuid;
         params["tipo_solicitacao"] = "Alteração";
         params["mes"] = mes;
         params["ano"] = ano;
         params["eh_lanche_emergencial"] = true;
+        params["recreio_nas_ferias"] = recreioNasFeriasUuid;
         const response =
           await getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola(params);
         if (response.status === HTTP_STATUS.OK) {

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
@@ -673,8 +673,12 @@ export const LancamentoPorPeriodoCEI = ({
                 {recreioNasFeriasDaMedicaoEMEIdaCEMEI(
                   solicitacaoMedicaoInicial,
                 ) &&
-                  solicitacoesKitLanchesAutorizadas &&
-                  solicitacoesKitLanchesAutorizadas.length > 0 && (
+                  ((solicitacoesKitLanchesAutorizadas &&
+                    solicitacoesKitLanchesAutorizadas.length > 0) ||
+                    (solicitacoesAlteracaoLancheEmergencialAutorizadas &&
+                      solicitacoesAlteracaoLancheEmergencialAutorizadas.length >
+                        0) ||
+                    temLancheEmergencialDiarioAtivo) && (
                     <CardLancamentoCEI
                       textoCabecalho={"Solicitações de Alimentação"}
                       cor={CORES[5]}

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -489,7 +489,8 @@ export const desabilitarField = (
       (!temLancheEmergencialAutorizadoNoDia &&
         !temLancheEmergencialDiarioAtivoNoDia &&
         rowName === "lanche_emergencial") ||
-      (!validacaoDiaLetivoLancheEmergencial(dia) &&
+      (temLancheEmergencialDiarioAtivoNoDia &&
+        !validacaoDiaLetivoLancheEmergencial(dia) &&
         rowName === "lanche_emergencial") ||
       validacaoSemana(dia) ||
       (mesConsiderado === mesAtual &&

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -904,6 +904,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   ano,
   nomePeriodoEscolar,
   ehLancheEmergencial = false,
+  recreioNasFerias = undefined,
 ) => {
   const params = {};
   params["escola_uuid"] = escolaUuuid;
@@ -911,6 +912,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   params["mes"] = mes;
   params["ano"] = ano;
   params["eh_lanche_emergencial"] = ehLancheEmergencial;
+  params["recreio_nas_ferias"] = recreioNasFerias;
   if (nomePeriodoEscolar) {
     params["nome_periodo_escolar"] = nomePeriodoEscolar;
   }

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -2444,6 +2444,7 @@ export default () => {
         categoria,
         column,
         value,
+        row,
       ) ||
       exibirTooltipRPLAutorizadas(
         formValuesAtualizados,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -543,6 +543,15 @@ export default () => {
 
       const mes = format(mesAnoSelecionado, "MM");
       const ano = getYear(mesAnoSelecionado);
+      const recreioNasFeriasUuid =
+        typeof location?.state?.solicitacaoMedicaoInicial
+          ?.recreio_nas_ferias === "string"
+          ? location.state.solicitacaoMedicaoInicial.recreio_nas_ferias
+          : location?.state?.solicitacaoMedicaoInicial?.recreio_nas_ferias
+              ?.uuid ||
+            new URLSearchParams(window.location.search).get(
+              "recreio_nas_ferias",
+            );
 
       let response_inclusoes_autorizadas = [];
       response_inclusoes_autorizadas =
@@ -1078,6 +1087,8 @@ export default () => {
             mes,
             ano,
             periodo.periodo_escolar.nome,
+            false,
+            recreioNasFeriasUuid,
           );
         setAlteracoesAlimentacaoAutorizadas(
           response_alteracoes_alimentacao_autorizadas,
@@ -1090,6 +1101,7 @@ export default () => {
             ano,
             periodo.periodo_escolar.nome,
             true,
+            recreioNasFeriasUuid,
           );
         setAlteracoesLancheEmergencialAutorizadas(
           response_alteracoes_lanche_emergencial_autorizadas,
@@ -1180,6 +1192,7 @@ export default () => {
             ano,
             undefined,
             true,
+            recreioNasFeriasUuid,
           );
         setAlteracoesAlimentacaoAutorizadas(
           response_alteracoes_alimentacao_autorizadas,

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/validacoes.jsx
@@ -1780,8 +1780,10 @@ export const campoComKitLancheAutorizadoMenorQueSolicitadoESemObservacaoOuMaiorQ
     categoria,
     column,
     value,
+    row,
   ) => {
     if (categoria.nome !== "SOLICITAÇÕES DE ALIMENTAÇÃO") return false;
+    if (row.name !== "kit_lanche") return false;
     let erro = false;
 
     for (let diaDaSemana of diasDaSemanaSelecionada) {

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/helper.jsx
@@ -780,6 +780,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   ano,
   nomePeriodoEscolar,
   ehLancheEmergencial = false,
+  recreioNasFerias = undefined,
 ) => {
   const params = {};
   params["escola_uuid"] = escolaUuuid;
@@ -787,6 +788,7 @@ export const getSolicitacoesAlteracoesAlimentacaoAutorizadasAsync = async (
   params["mes"] = mes;
   params["ano"] = ano;
   params["eh_lanche_emergencial"] = ehLancheEmergencial;
+  params["recreio_nas_ferias"] = recreioNasFerias;
   if (nomePeriodoEscolar) {
     params["nome_periodo_escolar"] = nomePeriodoEscolar;
   }

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicialCEI/index.jsx
@@ -369,6 +369,16 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
       setDiasSobremesaDoce(response_sobremesa_doce);
 
       let response_inclusoes_autorizadas = [];
+      const recreioNasFeriasUuid =
+        typeof location?.state?.solicitacaoMedicaoInicial
+          ?.recreio_nas_ferias === "string"
+          ? location.state.solicitacaoMedicaoInicial.recreio_nas_ferias
+          : location?.state?.solicitacaoMedicaoInicial?.recreio_nas_ferias
+              ?.uuid ||
+            new URLSearchParams(window.location.search).get(
+              "recreio_nas_ferias",
+            );
+
       response_inclusoes_autorizadas =
         await getSolicitacoesInclusaoAutorizadasAsync(
           escola.uuid,
@@ -404,6 +414,8 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
           mes,
           ano,
           ehSolicitacoesAlimentacaoLocation ? undefined : periodo,
+          false,
+          recreioNasFeriasUuid,
         );
       setAlteracoesAlimentacaoAutorizadas(
         response_alteracoes_alimentacao_autorizadas,
@@ -417,6 +429,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             ano,
             ehSolicitacoesAlimentacaoLocation ? undefined : periodo,
             true,
+            recreioNasFeriasUuid,
           );
         setAlteracoesLancheEmergencialAutorizadas(
           response_alteracoes_lanche_emergencial_autorizadas,
@@ -451,6 +464,7 @@ export const PeriodoLancamentoMedicaoInicialCEI = () => {
             ano,
             undefined,
             true,
+            recreioNasFeriasUuid,
           );
         setAlteracoesAlimentacaoAutorizadas(
           response_alteracoes_alimentacao_autorizadas,


### PR DESCRIPTION
# Este PR:
- exibe o bloco de "Solicitações de Alimentação" em um Lançamento de Medição Inicial de Recreio nas Férias se houver
- implementa testes unitários para a nova regra

### Referência azure:
- [AB#149379](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149379)