### PR TITLE
test(151017): valida conversão para uuid

### DIFF
--- a/src/components/screens/Cadastros/EditaisContratosRefatorado/__tests__/helper.test.tsx
+++ b/src/components/screens/Cadastros/EditaisContratosRefatorado/__tests__/helper.test.tsx
@@ -1,0 +1,58 @@
+import { formataEditalContratoParaForm } from "../Cadastro/helper";
+import "@testing-library/jest-dom";
+
+jest.mock("src/helpers/utilities", () => ({
+  deepCopy: jest.fn((value: unknown) => JSON.parse(JSON.stringify(value))),
+}));
+
+const editalContratoMock = {
+  eh_imr: true,
+  contratos: [
+    {
+      terceirizada: {
+        uuid: "8c8c9c4d-6406-4d88-8d6d-7c6c6ef905a1",
+      },
+      diretorias_regionais: [
+        {
+          uuid: "cfd2c975-d8a0-43e5-a513-80ee19c1ef93",
+        },
+        {
+          uuid: "c793ee68-d59a-4ef6-a384-df2c89503f49",
+        },
+      ],
+      lotes: [
+        {
+          uuid: "7c95f2e8-bf0e-46ff-9f4f-95360e4862f3",
+        },
+        {
+          uuid: "31e0e056-06c8-4126-a3e6-3bf1ffde7f3a",
+        },
+      ],
+    },
+  ],
+};
+
+describe("formataEditalContratoParaForm", () => {
+  it("formata terceirizada, diretorias regionais e lotes para uuid", () => {
+    const setSwitchAtivoImrl = jest.fn();
+
+    const result = formataEditalContratoParaForm(
+      editalContratoMock as any,
+      setSwitchAtivoImrl,
+    );
+
+    expect(result.contratos[0].terceirizada).toBe(
+      "8c8c9c4d-6406-4d88-8d6d-7c6c6ef905a1",
+    );
+
+    expect(result.contratos[0].diretorias_regionais).toEqual([
+      "cfd2c975-d8a0-43e5-a513-80ee19c1ef93",
+      "c793ee68-d59a-4ef6-a384-df2c89503f49",
+    ]);
+
+    expect(result.contratos[0].lotes).toEqual([
+      "7c95f2e8-bf0e-46ff-9f4f-95360e4862f3",
+      "31e0e056-06c8-4126-a3e6-3bf1ffde7f3a",
+    ]);
+  });
+});


### PR DESCRIPTION
### Referência azure:
- [AB#151017](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/151017)

Teste do helper ` formataEditalContratoParaForm`

Adiciona teste unitário para validar a formatação dos dados de edital/contrato antes de preencher o formulário.