### PR TITLE
fix(149136): ajusta exibição do período nos cards autorizados

### DIFF
--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/InformacoesAluno.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/InformacoesAluno.jsx
@@ -35,13 +35,17 @@ const InformacoesAluno = ({
   tipoSolicitacao,
   dietaEspecial,
   card,
+  ehAutorizadaTemporariamente,
 }) => {
   const [fotoAlunoSrc, setFotoAlunoSrc] = useState(null);
   const [criadoRf, setCriadoRf] = useState(null);
   const [deletandoImagem, setDeletandoImagem] = useState(false);
   const [atualizandoImagem, setAtualizandoImagem] = useState(false);
   const inputRef = useRef(null);
-  const exibirPeriodo = card === "autorizadas" && aluno.periodo;
+  const exibirPeriodo =
+    ["autorizadas", "autorizado"].includes(card) &&
+    !ehAutorizadaTemporariamente &&
+    aluno.periodo;
 
   async function getFoto() {
     setAtualizandoImagem(true);

--- a/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
+++ b/src/components/screens/DietaEspecial/Relatorio/componentes/CorpoRelatorio/index.jsx
@@ -67,6 +67,9 @@ const CorpoRelatorio = ({
     ? ehCanceladaSegundoStep(dietaEspecial)
     : false;
 
+  const ehAutorizadaTemporariamente =
+    card === "autorizadas-temp" || Boolean(dietaEspecial.dieta_alterada);
+
   const downloadAnexo = (url) => {
     const a = document.createElement("a");
     a.href = url;
@@ -433,6 +436,7 @@ const CorpoRelatorio = ({
             tipoSolicitacao={dietaEspecial.tipo_solicitacao}
             dietaEspecial={dietaEspecial}
             card={card}
+            ehAutorizadaTemporariamente={ehAutorizadaTemporariamente}
           />
           {solicitacaoVigenteAtiva &&
             ["pendentes-aut"].includes(card) &&


### PR DESCRIPTION
### Referência azure:
- [AB#149136](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149136)

**Ajuste realizado**

Após reporte da QA, foi ajustada a exibição do período do aluno para contemplar também o card **autorizado**, além do card **autorizadas**.

Dieta especial > Painel de solicitações > Card autorizadas > Ver mais 