### PR TITLE
Feature/149125 data autorizacao relatorio dietas

### DIFF
--- a/src/components/Shareable/Paginacao/style.scss
+++ b/src/components/Shareable/Paginacao/style.scss
@@ -6,13 +6,15 @@
   align-items: center;
 
   .ant-pagination-item {
-    width: 32px;
+    min-width: 32px;
     height: 32px;
+    padding: 0 6px;
     color: #999;
     font-weight: 600;
     background-color: $white;
     border: 1px solid #dadada;
     border-radius: 3px;
+    white-space: nowrap;
 
     &:hover {
       border: 1px solid $green;

--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/__tests__/relatorio_dietas_autorizadas.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/__tests__/relatorio_dietas_autorizadas.test.jsx
@@ -154,6 +154,15 @@ describe("Verifica comportamentos do relatório de dietas autorizadas", () => {
     });
   });
 
+  it("Verifica coluna Data da autorização nos resultados", async () => {
+    setSelect("tipo-gestao-select", TIPO_GESTAO);
+    filtrar();
+    await waitFor(() => {
+      expect(screen.getByText("Data da autorização")).toBeInTheDocument();
+      expect(screen.getAllByText("30/01/2024").length).toBe(10);
+    });
+  });
+
   it("Filtra, clica para visualizar em gráfico e verifica se foi alterado", async () => {
     preencheFiltros();
     filtrar();

--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/ListagemDietas/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/ListagemDietas/index.jsx
@@ -66,6 +66,9 @@ export const ListagemDietas = ({ ...props }) => {
           </div>
           {values.status_selecionado === "AUTORIZADAS" &&
             !usuarioEhEmpresaTerceirizada() && <div>Protocolo</div>}
+          {values.status_selecionado === "AUTORIZADAS" && (
+            <div>Data da autorização</div>
+          )}
           {values.status_selecionado === "CANCELADAS" && (
             <div>Data de cancelamento</div>
           )}
@@ -106,6 +109,9 @@ export const ListagemDietas = ({ ...props }) => {
                           dietaEspecial.protocolo_padrao.nome_protocolo)}
                     </div>
                   )}
+                {values.status_selecionado === "AUTORIZADAS" && (
+                  <div>{dietaEspecial.data_autorizacao}</div>
+                )}
                 {values.status_selecionado === "CANCELADAS" && (
                   <div>{dietaEspecial.data_ultimo_log}</div>
                 )}

--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/ListagemDietas/styles.scss
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/ListagemDietas/styles.scss
@@ -27,11 +27,11 @@
     }
 
     .dietas-autorizadas {
-      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 1fr;
+      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 1fr 0.9fr;
     }
 
     .autorizada-terceirizada {
-      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr;
+      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 0.9fr;
     }
 
     .dietas-canceladas {

--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/components/ListagemDietas/styles.scss
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/components/ListagemDietas/styles.scss
@@ -27,11 +27,11 @@
     }
 
     .dietas-autorizadas {
-      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 1fr;
+      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 1fr 0.9fr;
     }
 
     .autorizada-terceirizada {
-      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr;
+      grid-template-columns: 1fr 1fr 1.2fr 0.8fr 0.8fr 1.2fr 0.9fr;
     }
 
     .dietas-canceladas {

--- a/src/mocks/services/dietaEspecial.service/relatorioDietasEspeciaisTerceirizada.jsx
+++ b/src/mocks/services/dietaEspecial.service/relatorioDietasEspeciaisTerceirizada.jsx
@@ -27,6 +27,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "123 LOCK",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 156,
@@ -64,6 +65,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ALERGIA A CAMARÃO",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 4,
@@ -97,6 +99,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ALERGIA A CAMARÃO",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 5,
@@ -130,6 +133,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "123 LOCK",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 3,
@@ -163,6 +167,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ABCDE 3 TESTE",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 3,
@@ -200,6 +205,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "123 LOCK",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 3,
@@ -233,6 +239,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "DIETA DA SOPA",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 411,
@@ -270,6 +277,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ABCDE 3 TESTE",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 127,
@@ -303,6 +311,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ALERGIA A CAMARÃO",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 156,
@@ -336,6 +345,7 @@ export const mockRelatorioDietasEpeciais = {
       },
       nome_protocolo: "ALERGIA A CAMARÃO",
       data_ultimo_log: null,
+      data_autorizacao: "30/01/2024",
       alergias_intolerancias: [
         {
           id: 127,


### PR DESCRIPTION
# Este PR:
- exibe data_autorizacao no relatorio de dietas autorizadas
- implementa teste unitario para alteração

### Referência azure:
- [AB#149125](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149125)