### PR TITLE
Feature/149152 pre recebimento regra das fichas tecnicas

### DIFF
--- a/src/components/PreRecebimento/FormEtapa/__tests__/index.test.jsx
+++ b/src/components/PreRecebimento/FormEtapa/__tests__/index.test.jsx
@@ -158,7 +158,7 @@ describe("Testes no componente de FormEtapa - PreRecebimento", () => {
       duplicados: [],
       ehAlteracao: false,
       unidadeMedida: { nome: "UN" },
-      flv_ponto_a_ponto: true,
+      ponto_a_ponto: true,
     };
 
     beforeEach(async () => {

--- a/src/components/PreRecebimento/FormEtapa/index.jsx
+++ b/src/components/PreRecebimento/FormEtapa/index.jsx
@@ -40,7 +40,7 @@ export default ({
   unidadeMedida,
   ehAlteracao = false,
   form,
-  flv_ponto_a_ponto = false,
+  ponto_a_ponto = false,
 }) => {
   const [etapasOptions, setEtapasOptions] = useState([{}]);
   const [desabilitar, setDesabilitar] = useState([]);
@@ -132,7 +132,7 @@ export default ({
 
   const desativaAdicionarEtapa = () => {
     let index = etapas.length - 1;
-    const camposObrigatorios = flv_ponto_a_ponto
+    const camposObrigatorios = ponto_a_ponto
       ? [`etapa_${index}`, `data_programada_${index}`, `quantidade_${index}`]
       : [
           `empenho_${index}`,
@@ -205,7 +205,7 @@ export default ({
                 </div>
               </>
             )}
-            {!flv_ponto_a_ponto ? (
+            {!ponto_a_ponto ? (
               <>
                 <div className="row">
                   {(usuarioEhCronograma() || usuarioEhCodaeDilog()) && (

--- a/src/components/Shareable/CardCronograma/CardCronograma.jsx
+++ b/src/components/Shareable/CardCronograma/CardCronograma.jsx
@@ -15,9 +15,7 @@ export const CardCronograma = ({
   const renderSolicitations = (solicitations, exibirTooltip) => {
     return exibirTooltip
       ? solicitations.slice(0, 5).map((solicitation, key) => {
-          const ehFLV =
-            solicitation.categoria === "FLV" &&
-            solicitation.tipo_entrega === "PONTO_A_PONTO";
+          const isPointToPoint = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <Tooltip
               placement="topLeft"
@@ -27,7 +25,7 @@ export const CardCronograma = ({
               <NavLink key={key} to={solicitation.link}>
                 <p
                   key={key}
-                  className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${ehFLV && "categoria-flv"}`}
+                  className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${isPointToPoint ? "point-to-point" : ""}`}
                 >
                   {solicitation.text}
                   <span className="float-end">{solicitation.date}</span>
@@ -37,14 +35,12 @@ export const CardCronograma = ({
           );
         })
       : solicitations.slice(0, 5).map((solicitation, key) => {
-          const ehFLV =
-            solicitation.categoria === "FLV" &&
-            solicitation.tipo_entrega === "PONTO_A_PONTO";
+          const isPointToPoint = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <NavLink key={key} to={solicitation.link}>
               <p
                 key={key}
-                className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${ehFLV && "categoria-flv"}`}
+                className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${isPointToPoint ? "point-to-point" : ""}`}
               >
                 {solicitation.text}
                 <span className="float-end">{solicitation.date}</span>

--- a/src/components/Shareable/CardCronograma/CardCronograma.jsx
+++ b/src/components/Shareable/CardCronograma/CardCronograma.jsx
@@ -15,7 +15,7 @@ export const CardCronograma = ({
   const renderSolicitations = (solicitations, exibirTooltip) => {
     return exibirTooltip
       ? solicitations.slice(0, 5).map((solicitation, key) => {
-          const isPointToPoint = solicitation.tipo_entrega === "PONTO_A_PONTO";
+          const EPontoAPonto = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <Tooltip
               placement="topLeft"
@@ -25,7 +25,7 @@ export const CardCronograma = ({
               <NavLink key={key} to={solicitation.link}>
                 <p
                   key={key}
-                  className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${isPointToPoint ? "point-to-point" : ""}`}
+                  className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${EPontoAPonto ? "ponto-a-ponto" : ""}`}
                 >
                   {solicitation.text}
                   <span className="float-end">{solicitation.date}</span>
@@ -35,12 +35,12 @@ export const CardCronograma = ({
           );
         })
       : solicitations.slice(0, 5).map((solicitation, key) => {
-          const isPointToPoint = solicitation.tipo_entrega === "PONTO_A_PONTO";
+          const EPontoAPonto = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <NavLink key={key} to={solicitation.link}>
               <p
                 key={key}
-                className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${isPointToPoint ? "point-to-point" : ""}`}
+                className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${EPontoAPonto ? "ponto-a-ponto" : ""}`}
               >
                 {solicitation.text}
                 <span className="float-end">{solicitation.date}</span>

--- a/src/components/Shareable/CardCronograma/style.scss
+++ b/src/components/Shareable/CardCronograma/style.scss
@@ -96,6 +96,6 @@
   color: #086397 !important;
 }
 
-.categoria-flv {
+.point-to-point {
   color: $green !important;
 }

--- a/src/components/Shareable/CardCronograma/style.scss
+++ b/src/components/Shareable/CardCronograma/style.scss
@@ -96,6 +96,6 @@
   color: #086397 !important;
 }
 
-.point-to-point {
+.ponto-a-ponto {
   color: $green !important;
 }

--- a/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
@@ -23,9 +23,13 @@ export default ({
           <div className="card-listagem-solicitacoes">
             {solicitacoes &&
               solicitacoes.map((value, key) => {
-                const ehFLV =
-                  value.categoria === "FLV" &&
-                  value.tipo_entrega === "PONTO_A_PONTO";
+                const ehPontoAPonto = value.tipo_entrega === "PONTO_A_PONTO";
+
+                const classeDestaque = ehPontoAPonto
+                  ? "categoria-ponto-a-ponto"
+                  : value.programa_leve_leite
+                    ? "programa-leve-leite"
+                    : "";
 
                 return (
                   <div key={key} className="row">
@@ -33,25 +37,24 @@ export default ({
                       {exibirTooltip ? (
                         <Tooltip
                           placement="topLeft"
-                          key={key}
                           title={value.textoCompleto}
                         >
-                          <NavLink key={key} to={value.link}>
-                            <p
-                              className={`data ms-4 ${value.programa_leve_leite ? "programa-leve-leite" : ""} ${ehFLV && "categoria-flv"}`}
-                            >{`${value.texto}`}</p>
+                          <NavLink to={value.link}>
+                            <p className={`data ms-4 ${classeDestaque}`}>
+                              {value.texto}
+                            </p>
                           </NavLink>
                         </Tooltip>
                       ) : (
-                        <NavLink key={key} to={value.link}>
-                          <p
-                            className={`data ms-4 ${value.programa_leve_leite ? "programa-leve-leite" : ""} ${ehFLV && "categoria-flv"}`}
-                          >{`${value.texto}`}</p>
+                        <NavLink to={value.link}>
+                          <p className={`data ms-4 ${classeDestaque}`}>
+                            {value.texto}
+                          </p>
                         </NavLink>
                       )}
                     </div>
                     <span
-                      className={`date-time col-3 text-end ${value.programa_leve_leite ? "programa-leve-leite" : ""} ${ehFLV && "categoria-flv"}`}
+                      className={`date-time col-3 text-end ${classeDestaque}`}
                     >
                       {value.data}
                     </span>

--- a/src/components/Shareable/CardListarSolicitacoesCronograma/style.scss
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/style.scss
@@ -83,6 +83,6 @@
   color: #086397 !important;
 }
 
-.categoria-flv {
+.categoria-ponto-a-ponto {
   color: $green !important;
 }

--- a/src/components/Shareable/Sidebar/menus/MenuPreRecebimento.jsx
+++ b/src/components/Shareable/Sidebar/menus/MenuPreRecebimento.jsx
@@ -58,7 +58,7 @@ const MenuPreRecebimento = ({ activeMenu, onSubmenuClick }) => {
         usuarioEhCodaeDilog() ||
         usuarioEhEmpresaFornecedor()) && (
         <LeafItem to={`/${PRE_RECEBIMENTO}/${CRONOGRAMA_SEMANAL_FLV}`}>
-          Cronograma Semanal FLV
+          Cronograma Semanal
         </LeafItem>
       )}
       {(usuarioEhCronograma() ||

--- a/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
+++ b/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
@@ -27,6 +27,13 @@ describe("CardCronograma", () => {
     tipo_entrega: "ARMAZEM",
   };
 
+  const solicitacaoPontoAPontoLeveLeite = {
+    ...solicitacaoPontoAPonto,
+    text: "Solicitação Ponto a Ponto Leve Leite",
+    fullText: "Texto completo Ponto a Ponto Leve Leite",
+    programa_leve_leite: true,
+  };
+
   test("Deve aplicar a classe 'point-to-point' quando o tipo de entrega for Ponto a Ponto", () => {
     render(
       <MemoryRouter>
@@ -47,6 +54,7 @@ describe("CardCronograma", () => {
       .closest("p");
 
     expect(paragraph).toHaveClass("point-to-point");
+    expect(paragraph).not.toHaveClass("programa-leve-leite");
   });
 
   test("Não deve aplicar a classe 'point-to-point' quando o tipo de entrega for Armazém", () => {
@@ -67,5 +75,29 @@ describe("CardCronograma", () => {
     const paragraph = screen.getByText("Solicitação Armazém").closest("p");
 
     expect(paragraph).not.toHaveClass("point-to-point");
+    expect(paragraph).not.toHaveClass("programa-leve-leite");
+  });
+
+  test("Deve aplicar as classes de Ponto a Ponto e Leve Leite quando ambas as condições forem atendidas", () => {
+    render(
+      <MemoryRouter>
+        <CardCronograma
+          cardTitle="Cronograma"
+          cardType="tipo-mock"
+          solicitations={[solicitacaoPontoAPontoLeveLeite]}
+          icon="fa-calendar"
+          loading={false}
+          href="/mock-href"
+          exibirTooltip={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const paragraph = screen
+      .getByText("Solicitação Ponto a Ponto Leve Leite")
+      .closest("p");
+
+    expect(paragraph).toHaveClass("programa-leve-leite");
+    expect(paragraph).toHaveClass("point-to-point");
   });
 });

--- a/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
+++ b/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
@@ -7,32 +7,33 @@ import { CardCronograma } from "../../CardCronograma/CardCronograma";
 afterEach(() => cleanup());
 
 describe("CardCronograma", () => {
-  const solicitacaoFLV = {
-    text: "Solicitação FLV",
+  const solicitacaoPontoAPonto = {
+    text: "Solicitação Ponto a Ponto",
     date: "2024-05-23",
     link: "/mock-link",
-    fullText: "Texto completo FLV",
+    fullText: "Texto completo Ponto a Ponto",
     programa_leve_leite: false,
-    categoria: "FLV",
+    categoria: "PERECIVEIS",
     tipo_entrega: "PONTO_A_PONTO",
   };
 
-  const solicitacaoNaoFLV = {
-    text: "Solicitação Normal",
+  const solicitacaoArmazem = {
+    text: "Solicitação Armazém",
     date: "2024-05-23",
     link: "/mock-link",
-    fullText: "Texto completo Normal",
+    fullText: "Texto completo Armazém",
     programa_leve_leite: false,
-    categoria: "OUTRO",
+    categoria: "FLV",
+    tipo_entrega: "ARMAZEM",
   };
 
-  test("Deve aplicar a classe 'categoria-flv' quando a categoria for FLV", () => {
+  test("Deve aplicar a classe 'point-to-point' quando o tipo de entrega for Ponto a Ponto", () => {
     render(
       <MemoryRouter>
         <CardCronograma
           cardTitle="Cronograma"
           cardType="tipo-mock"
-          solicitations={[solicitacaoFLV]}
+          solicitations={[solicitacaoPontoAPonto]}
           icon="fa-calendar"
           loading={false}
           href="/mock-href"
@@ -41,17 +42,20 @@ describe("CardCronograma", () => {
       </MemoryRouter>,
     );
 
-    const paragraph = screen.getByText("Solicitação FLV").closest("p");
-    expect(paragraph).toHaveClass("categoria-flv");
+    const paragraph = screen
+      .getByText("Solicitação Ponto a Ponto")
+      .closest("p");
+
+    expect(paragraph).toHaveClass("point-to-point");
   });
 
-  test("Não deve aplicar a classe 'categoria-flv' quando a categoria não for FLV", () => {
+  test("Não deve aplicar a classe 'point-to-point' quando o tipo de entrega for Armazém", () => {
     render(
       <MemoryRouter>
         <CardCronograma
           cardTitle="Cronograma"
           cardType="tipo-mock"
-          solicitations={[solicitacaoNaoFLV]}
+          solicitations={[solicitacaoArmazem]}
           icon="fa-calendar"
           loading={false}
           href="/mock-href"
@@ -60,7 +64,8 @@ describe("CardCronograma", () => {
       </MemoryRouter>,
     );
 
-    const paragraph = screen.getByText("Solicitação Normal").closest("p");
-    expect(paragraph).not.toHaveClass("categoria-flv");
+    const paragraph = screen.getByText("Solicitação Armazém").closest("p");
+
+    expect(paragraph).not.toHaveClass("point-to-point");
   });
 });

--- a/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/cadastro_cronograma.test.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/cadastro_cronograma.test.jsx
@@ -28,7 +28,7 @@ describe("Testes da interface de Cadastro de Cronograma", () => {
           uuid: "pp-uuid-123",
           numero: "FT-PP-01",
           produto: { nome: "LARANJA" },
-          flv_ponto_a_ponto: true,
+          ponto_a_ponto: true,
           uuid_empresa: mockListaEmpresas.results[7].uuid,
         },
       ],
@@ -308,7 +308,7 @@ describe("Testes da interface de Cadastro de Cronograma", () => {
       uuid: "pp-uuid-123",
       numero: "FT-PP-01",
       produto: { nome: "LARANJA" },
-      flv_ponto_a_ponto: true,
+      ponto_a_ponto: true,
       marca: { nome: "Marca X" },
     };
 

--- a/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/cadastro_cronograma.test.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/cadastro_cronograma.test.jsx
@@ -28,7 +28,18 @@ describe("Testes da interface de Cadastro de Cronograma", () => {
           uuid: "pp-uuid-123",
           numero: "FT-PP-01",
           produto: { nome: "LARANJA" },
+          categoria: "NAO_PERECIVEIS",
+          tipo_entrega: "PONTO_A_PONTO",
           ponto_a_ponto: true,
+          uuid_empresa: mockListaEmpresas.results[7].uuid,
+        },
+        {
+          uuid: "armazem-uuid-123",
+          numero: "FT-ARMAZEM-01",
+          produto: { nome: "BATATA" },
+          categoria: "FLV",
+          tipo_entrega: "ARMAZEM",
+          ponto_a_ponto: false,
           uuid_empresa: mockListaEmpresas.results[7].uuid,
         },
       ],
@@ -308,6 +319,8 @@ describe("Testes da interface de Cadastro de Cronograma", () => {
       uuid: "pp-uuid-123",
       numero: "FT-PP-01",
       produto: { nome: "LARANJA" },
+      categoria: "NAO_PERECIVEIS",
+      tipo_entrega: "PONTO_A_PONTO",
       ponto_a_ponto: true,
       marca: { nome: "Marca X" },
     };
@@ -362,5 +375,129 @@ describe("Testes da interface de Cadastro de Cronograma", () => {
         screen.queryByText("Programação de Recebimento"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("deve exibir campos de Armazém e Embalagem Secundária quando a ficha FLV não for Ponto a Ponto", async () => {
+    const user = userEvent.setup();
+
+    const fichaArmazem = {
+      uuid: "armazem-uuid-123",
+      numero: "FT-ARMAZEM-01",
+      produto: { nome: "BATATA" },
+      categoria: "FLV",
+      tipo_entrega: "ARMAZEM",
+      ponto_a_ponto: false,
+      marca: { nome: "Marca Armazém" },
+    };
+
+    mock
+      .onGet("/ficha-tecnica/armazem-uuid-123/dados-cronograma/")
+      .reply(200, fichaArmazem);
+
+    const empresa = screen.getByTestId("input-empresa").querySelector("input");
+
+    await user.type(empresa, "Empresa do Luis Zimmermann");
+
+    await act(async () => {
+      fireEvent.mouseDown(
+        screen
+          .getByTestId("select-contrato")
+          .querySelector(".ant-select-selection-search-input"),
+      );
+    });
+
+    const opcaoContrato = await screen.findByText(/LEVE LEITE - PLL/i);
+    await user.click(opcaoContrato);
+
+    const botaoExpandir = screen
+      .getByText("Dados do Produto")
+      .closest(".card-header")
+      .querySelector("button");
+
+    await user.click(botaoExpandir);
+
+    await waitFor(() => {
+      expect(screen.getByText("Ficha Técnica e Produto")).toBeInTheDocument();
+    });
+
+    const selectFichaTecnica = screen
+      .getByTestId("select-div")
+      .querySelector(".ant-select-selection-search-input");
+
+    await act(async () => {
+      fireEvent.mouseDown(selectFichaTecnica);
+    });
+
+    const inputFichaTecnica = screen
+      .getByTestId("select-div")
+      .querySelector("input");
+
+    await user.type(inputFichaTecnica, "FT-ARMAZEM-01");
+
+    const opcoesFichaTecnica = await screen.findAllByText(/FT-ARMAZEM-01/i);
+
+    await user.click(opcoesFichaTecnica[1]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("marca")).toHaveValue("Marca Armazém");
+      expect(screen.getByText("Armazém")).toBeInTheDocument();
+      expect(
+        screen.getByText("Tipo de Embalagem Secundária"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("deve destacar a ficha Ponto a Ponto independentemente da categoria", async () => {
+    const user = userEvent.setup();
+
+    const empresa = screen.getByTestId("input-empresa").querySelector("input");
+
+    await user.type(empresa, "Empresa do Luis Zimmermann");
+
+    await act(async () => {
+      fireEvent.mouseDown(
+        screen
+          .getByTestId("select-contrato")
+          .querySelector(".ant-select-selection-search-input"),
+      );
+    });
+
+    const opcaoContrato = await screen.findByText(/LEVE LEITE - PLL/i);
+    await user.click(opcaoContrato);
+
+    const botaoExpandir = screen
+      .getByText("Dados do Produto")
+      .closest(".card-header")
+      .querySelector("button");
+
+    await user.click(botaoExpandir);
+
+    await waitFor(() => {
+      expect(screen.getByText("Ficha Técnica e Produto")).toBeInTheDocument();
+    });
+
+    const selectFichaTecnica = screen
+      .getByTestId("select-div")
+      .querySelector(".ant-select-selection-search-input");
+
+    await act(async () => {
+      fireEvent.mouseDown(selectFichaTecnica);
+    });
+
+    const inputFichaTecnica = screen
+      .getByTestId("select-div")
+      .querySelector("input");
+
+    await user.type(inputFichaTecnica, "FT-PP-01");
+
+    const elementosFicha = await screen.findAllByText(/FT-PP-01/i);
+
+    const opcaoFicha = elementosFicha
+      .map((elemento) => elemento.closest(".ant-select-item-option"))
+      .find(Boolean);
+
+    expect(opcaoFicha).toBeInTheDocument();
+    expect(opcaoFicha).toHaveClass("verde");
+    expect(opcaoFicha).toHaveClass("font-weight-bold");
   });
 });

--- a/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/editar_rascunho_cronograma.test.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/__tests__/editar_rascunho_cronograma.test.jsx
@@ -28,7 +28,7 @@ describe("Testes da interface de Cadastro de Cronograma - Edição", () => {
           uuid: "pp-uuid-123",
           numero: "FT-PP-01",
           produto: { nome: "LARANJA" },
-          flv_ponto_a_ponto: true,
+          ponto_a_ponto: true,
           uuid_empresa: mockListaEmpresas.results[7].uuid,
         },
       ],

--- a/src/components/screens/PreRecebimento/CadastroCronograma/helpers.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/helpers.jsx
@@ -21,11 +21,11 @@ export const geraOptionsFichasTecnicas = (
       const nomeFormatado = formatarNumeroEProdutoFichaTecnica(ficha);
       return {
         uuid: ficha.uuid,
-        nome: ficha.flv_ponto_a_ponto
+        nome: ficha.ponto_a_ponto
           ? `${nomeFormatado} (PONTO A PONTO)`
           : nomeFormatado,
         programa: ficha.programa,
-        flv_ponto_a_ponto: ficha.flv_ponto_a_ponto,
+        ponto_a_ponto: ficha.ponto_a_ponto,
       };
     });
 
@@ -52,7 +52,7 @@ export const formataPayload = (
   etapas,
   recebimentos,
 ) => {
-  const isPontoAPonto = fichaTecnicaSelecionada?.flv_ponto_a_ponto;
+  const isPontoAPonto = fichaTecnicaSelecionada?.ponto_a_ponto;
   let payload = {};
   payload.cadastro_finalizado = !rascunho;
   payload.ponto_a_ponto = isPontoAPonto;

--- a/src/components/screens/PreRecebimento/CadastroCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/CadastroCronograma/index.jsx
@@ -588,7 +588,7 @@ export default () => {
                                 </label>
                                 <Field
                                   className={`input-cronograma ${
-                                    fichaTecnicaSelecionada?.flv_ponto_a_ponto
+                                    fichaTecnicaSelecionada?.ponto_a_ponto
                                       ? "select-flv"
                                       : ""
                                   }`}
@@ -614,7 +614,7 @@ export default () => {
                                       value={e.nome}
                                       key={e.uuid}
                                       className={
-                                        e.flv_ponto_a_ponto
+                                        e.ponto_a_ponto
                                           ? "verde font-weight-bold"
                                           : ""
                                       }
@@ -641,7 +641,7 @@ export default () => {
                                 />
                               </div>
 
-                              {!fichaTecnicaSelecionada?.flv_ponto_a_ponto && (
+                              {!fichaTecnicaSelecionada?.ponto_a_ponto && (
                                 <>
                                   <div className="row mt-3">
                                     <div className="row">
@@ -726,7 +726,7 @@ export default () => {
                                 </>
                               )}
 
-                              {!fichaTecnicaSelecionada?.flv_ponto_a_ponto ? (
+                              {!fichaTecnicaSelecionada?.ponto_a_ponto ? (
                                 <>
                                   <div className="col-3">
                                     <Field
@@ -764,7 +764,7 @@ export default () => {
                             </div>
 
                             <div className="row mt-3">
-                              {!fichaTecnicaSelecionada?.flv_ponto_a_ponto ? (
+                              {!fichaTecnicaSelecionada?.ponto_a_ponto ? (
                                 <>
                                   <div className="col-4">
                                     <Field
@@ -886,7 +886,7 @@ export default () => {
                               )}
                             </div>
 
-                            {fichaTecnicaSelecionada?.flv_ponto_a_ponto && (
+                            {fichaTecnicaSelecionada?.ponto_a_ponto && (
                               <div className="row mt-3">
                                 <div className="col-4">
                                   <Field
@@ -934,15 +934,15 @@ export default () => {
                               duplicados={duplicados}
                               restante={restante}
                               unidadeMedida={unidadeSelecionada}
-                              flv_ponto_a_ponto={
-                                fichaTecnicaSelecionada?.flv_ponto_a_ponto
+                              ponto_a_ponto={
+                                fichaTecnicaSelecionada?.ponto_a_ponto
                               }
                             />
                           </div>
                         </div>
                       </div>
 
-                      {!fichaTecnicaSelecionada?.flv_ponto_a_ponto && (
+                      {!fichaTecnicaSelecionada?.ponto_a_ponto && (
                         <FormRecebimento
                           values={values}
                           form={form}

--- a/src/components/screens/PreRecebimento/CronogramaEntrega/components/DadosCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/CronogramaEntrega/components/DadosCronograma/index.jsx
@@ -13,7 +13,7 @@ export default ({
   esconderInformacoesAdicionais,
   solicitacaoAlteracaoCronograma,
 }) => {
-  const ehFLVPontoAPonto = cronograma.ficha_tecnica?.flv_ponto_a_ponto;
+  const ehFLVPontoAPonto = cronograma.ficha_tecnica?.ponto_a_ponto;
 
   const enderecoFormatado = (armazem) =>
     armazem?.endereco

--- a/src/components/screens/PreRecebimento/CronogramaEntrega/components/DetalharCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/CronogramaEntrega/components/DetalharCronograma/index.jsx
@@ -116,7 +116,7 @@ export default () => {
 
               <hr className="hr-detalhar" />
 
-              {!cronograma.ficha_tecnica?.flv_ponto_a_ponto && (
+              {!cronograma.ficha_tecnica?.ponto_a_ponto && (
                 <>
                   <div className="row mt-3">
                     <div className="col">

--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Listagem/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Listagem/index.tsx
@@ -116,8 +116,7 @@ const Listagem: React.FC<Props> = ({ objetos, setCarregando }) => {
         </div>
 
         {objetos.map((objeto) => {
-          const classNameVerde = objeto.flv_ponto_a_ponto ? "green" : "";
-
+          const classNameVerde = objeto.ponto_a_ponto ? "green" : "";
           return (
             <>
               <div key={objeto.uuid} className="grid-table body-table">

--- a/src/interfaces/pre_recebimento.interface.ts
+++ b/src/interfaces/pre_recebimento.interface.ts
@@ -173,7 +173,7 @@ export interface FichaTecnica {
   criado_em: string;
   status: string;
   programa: ProgramaChoices;
-  flv_ponto_a_ponto: boolean;
+  ponto_a_ponto: boolean;
 }
 
 export interface InformacoesNutricionaisFichaTecnica {

--- a/src/mocks/cronograma.service/mockGetCronogramaDetalhar.jsx
+++ b/src/mocks/cronograma.service/mockGetCronogramaDetalhar.jsx
@@ -1014,7 +1014,7 @@ export const mockCronogramaFLVPontoAPonto = {
     uuid_empresa: "d0630b2b-8e45-472c-b9c6-90451b60b081",
     pregao_chamada_publica: "123123",
     programa: "ALIMENTACAO_ESCOLAR",
-    flv_ponto_a_ponto: true,
+    ponto_a_ponto: true,
     marca: {
       uuid: "f2921e66-f9b0-4814-ba0a-eba266d5a128",
       nome: "MILANI",

--- a/src/mocks/services/cronograma.service/mockGetRascunhoCronograma.jsx
+++ b/src/mocks/services/cronograma.service/mockGetRascunhoCronograma.jsx
@@ -85,7 +85,7 @@ export const mockGetRascunhoCronograma = {
     uuid_empresa: "d0630b2b-8e45-472c-b9c6-90451b60b081",
     pregao_chamada_publica: "643653",
     programa: "ALIMENTACAO_ESCOLAR",
-    flv_ponto_a_ponto: false,
+    ponto_a_ponto: false,
     marca: {
       uuid: "3b36df9d-184b-4be3-a6d9-d56d1e6096c3",
       nome: "KIKO HORTIFRUTI",

--- a/src/pages/PreRecebimento/CronogramaSemanalFLVPage.tsx
+++ b/src/pages/PreRecebimento/CronogramaSemanalFLVPage.tsx
@@ -7,7 +7,7 @@ import CronogramaSemanalFLV from "src/components/screens/PreRecebimento/Cronogra
 
 const atual = {
   href: `/${PRE_RECEBIMENTO}/${CRONOGRAMA_SEMANAL_FLV}`,
-  titulo: "Cronograma Semanal FLV",
+  titulo: "Cronograma Semanal",
 };
 
 const anteriores = [


### PR DESCRIPTION
 ### Referência azure:
- [AB#149152](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/149152)

Atualiza o frontend para aplicar o fluxo Ponto a Ponto de acordo com o tipo de entrega da ficha técnica, independentemente da categoria do produto. Anteriormente, parte do comportamento estava associado especificamente à categoria FLV. Com o ajuste, qualquer ficha configurada como Ponto a Ponto passa a utilizar corretamente esse fluxo.

**Alterações realizadas**
> - Substituição das referências a flv_ponto_a_ponto por ponto_a_ponto.
> - Aplicação do destaque verde nos cronogramas Ponto a Ponto nos cards.
> - Aplicação do destaque verde nas fichas técnicas Ponto a Ponto no seletor.