### PR TITLE
fix(151324): corrige filtros da busca de parametrizacao financeira

### DIFF
--- a/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/__tests__/cadastro_parametrizacao.test.jsx
+++ b/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/__tests__/cadastro_parametrizacao.test.jsx
@@ -429,4 +429,15 @@ describe("Testes formulário de cadastro - Parametrização Financeira", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("ao selecionar edital, deve limpar o campo lote", async () => {
+    setSelect("edital-select", "557d1c87-ea6c-4911-8876-2a133f754ea1");
+
+    await waitFor(() => {
+      const loteSelect = screen
+        .getByTestId("lote-select")
+        .querySelector("select");
+      expect(loteSelect.value).toBe("");
+    });
+  });
 });

--- a/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/components/Filtros/index.tsx
+++ b/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/components/Filtros/index.tsx
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
-import { Field, FormSpy } from "react-final-form";
+import { Field, FormSpy, useForm } from "react-final-form";
 import { FormApi } from "final-form";
 import { required } from "src/helpers/fieldValidators";
 import { Select } from "src/components/Shareable/Select";
@@ -35,6 +35,9 @@ export default (props: Props) => {
   const [showCopiar, setShowCopiar] = useState(false);
 
   const ehCadastro = props.ehCadastro === true;
+  const formContext = useForm();
+  const filterView = useView({ form: formContext });
+  const view = ehCadastro ? (props as Cadastro).view : filterView;
 
   const onChangeCopiar = async () => {
     if (!ehCadastro) return;
@@ -59,8 +62,6 @@ export default (props: Props) => {
     <div className="row">
       <FormSpy subscription={{ values: true }}>
         {({ values }) => {
-          const view = ehCadastro ? props.view : undefined;
-          const form = ehCadastro ? props.form : undefined;
           const uuidParametrizacao = ehCadastro
             ? props.uuidParametrizacao
             : null;
@@ -79,7 +80,7 @@ export default (props: Props) => {
                   required={ehCadastro}
                   disabled={!!uuidParametrizacao}
                   onChangeEffect={(e: ChangeEvent<HTMLInputElement>) => {
-                    if (ehCadastro && form) view.onChangeEdital(e.target.value);
+                    view.onChangeEdital(e.target.value);
                   }}
                 />
               </div>
@@ -96,7 +97,7 @@ export default (props: Props) => {
                   required={ehCadastro}
                   disabled={!!uuidParametrizacao}
                   onChangeEffect={(e: ChangeEvent<HTMLInputElement>) => {
-                    if (ehCadastro && form) view.onChangeLote(e.target.value);
+                    view.onChangeLote(e.target.value);
                   }}
                 />
               </div>
@@ -112,8 +113,7 @@ export default (props: Props) => {
                   validate={ehCadastro ? required : undefined}
                   required={ehCadastro}
                   onChangeEffect={(e: ChangeEvent<HTMLInputElement>) => {
-                    if (ehCadastro && form)
-                      view.onChangeTiposUnidades(e.target.value);
+                    view.onChangeTiposUnidades(e.target.value);
                   }}
                   disabled={!!uuidParametrizacao}
                 />

--- a/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/components/Filtros/view.ts
+++ b/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/AdicionarParametrizacaoFinanceira/components/Filtros/view.ts
@@ -32,14 +32,14 @@ import {
 } from "src/configs/constants";
 
 type Props = {
-  setGrupoSelecionado: Dispatch<SetStateAction<string>>;
-  setEditalSelecionado: Dispatch<SetStateAction<string>>;
-  setLoteSelecionado: Dispatch<SetStateAction<string>>;
-  setFaixasEtarias: Dispatch<SetStateAction<Array<any>>>;
-  setTiposAlimentacao: Dispatch<SetStateAction<Array<any>>>;
-  setParametrizacao: Dispatch<SetStateAction<ParametrizacaoFinanceiraPayload>>;
-  uuidParametrizacao: string | null;
-  form: FormApi<any, any>;
+  setGrupoSelecionado?: Dispatch<SetStateAction<string>>;
+  setEditalSelecionado?: Dispatch<SetStateAction<string>>;
+  setLoteSelecionado?: Dispatch<SetStateAction<string>>;
+  setFaixasEtarias?: Dispatch<SetStateAction<Array<any>>>;
+  setTiposAlimentacao?: Dispatch<SetStateAction<Array<any>>>;
+  setParametrizacao?: Dispatch<SetStateAction<ParametrizacaoFinanceiraPayload>>;
+  uuidParametrizacao?: string | null;
+  form?: FormApi<any, any>;
 };
 
 export default ({
@@ -82,9 +82,12 @@ export default ({
     }
   };
 
-  const getLotesAsync = async () => {
+  const getLotesAsync = async (editalUuid?: string) => {
     try {
-      const { data } = await getLotesSimples();
+      const params = editalUuid
+        ? { contratos_do_lote__edital__uuid: editalUuid }
+        : null;
+      const { data } = await getLotesSimples(params);
       const lotes = data.results;
       const lotesOrdenados = lotes.sort((loteA, loteB) => {
         return loteA.diretoria_regional.nome < loteB.diretoria_regional.nome;
@@ -139,7 +142,7 @@ export default ({
   const getFaixasEtariasAsync = async () => {
     try {
       const { data } = await getFaixasEtarias();
-      setFaixasEtarias(data.results);
+      setFaixasEtarias?.(data.results);
     } catch {
       toastError(
         "Erro ao carregar faixas etárias. Tente novamente mais tarde.",
@@ -191,7 +194,7 @@ export default ({
         tabelas: dadosTabelas,
       };
 
-      setParametrizacao(parametrizacao);
+      setParametrizacao?.(parametrizacao);
     } catch {
       toastError(
         "Erro ao carregar parametrização financeira. Tente novamente mais tarde.",
@@ -204,13 +207,21 @@ export default ({
   }, []);
 
   const onChangeEdital = (edital: string) => {
-    form.change("edital", edital);
-    setEditalSelecionado(editais.find((e) => e.uuid === edital).nome);
+    form?.change("edital", edital);
+    form?.change("lote", null);
+    setLoteSelecionado?.("");
+    if (edital) {
+      setEditalSelecionado?.(editais.find((e) => e.uuid === edital).nome);
+      getLotesAsync(edital);
+    } else {
+      setEditalSelecionado?.("");
+      getLotesAsync();
+    }
   };
 
   const onChangeLote = (lote: string) => {
-    form.change("lote", lote);
-    setLoteSelecionado(lotes.find((e) => e.uuid === lote).nome);
+    form?.change("lote", lote);
+    setLoteSelecionado?.(lotes.find((e) => e.uuid === lote).nome);
   };
 
   const getGruposPendentes = async (carregamento = true) => {
@@ -301,7 +312,7 @@ export default ({
   };
 
   const onChangeTiposUnidades = (grupo: string) => {
-    form.change("grupo_unidade_escolar", grupo);
+    form?.change("grupo_unidade_escolar", grupo);
     const selecionado = gruposUnidadesOpcoes.find((e) => e.uuid === grupo).nome;
     setGrupoSelecionado(selecionado);
 
@@ -320,7 +331,7 @@ export default ({
 
   const inicializouRef = useRef(false);
   useEffect(() => {
-    if (!uuidParametrizacao || carregando || !form) return;
+    if (!uuidParametrizacao || carregando) return;
     if (inicializouRef.current) return;
 
     const values = form.getState().values;

--- a/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/__tests__/index.test.jsx
+++ b/src/components/screens/LancamentoInicial/ParametrizacaoFinanceira/__tests__/index.test.jsx
@@ -144,4 +144,45 @@ describe("Testes da interface de Listagem - Parametrização Financeira", () => 
       expect(screen.getAllByText("04").length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  it("deve carregar opções dos selects de filtro", async () => {
+    await waitFor(() => {
+      const editalSelect = screen
+        .getByTestId("edital-select")
+        .querySelector("select");
+      expect(editalSelect).not.toBeNull();
+      expect(editalSelect.options.length).toBeGreaterThan(1);
+      expect(editalSelect.options[1].text).toBe("1");
+
+      const loteSelect = screen
+        .getByTestId("lote-select")
+        .querySelector("select");
+      expect(loteSelect).not.toBeNull();
+      expect(loteSelect.options.length).toBeGreaterThan(1);
+
+      const grupoSelect = screen
+        .getByTestId("grupo-unidade-select")
+        .querySelector("select");
+      expect(grupoSelect).not.toBeNull();
+      expect(grupoSelect.options.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("ao selecionar edital, deve resetar campo lote", async () => {
+    await waitFor(() => {
+      const editalSelect = screen
+        .getByTestId("edital-select")
+        .querySelector("select");
+      expect(editalSelect.options.length).toBeGreaterThan(1);
+    });
+
+    setSelect("edital-select", "752c11a3-b4fe-4f1c-b9af-61d42f0a6b56");
+
+    await waitFor(() => {
+      const loteSelect = screen
+        .getByTestId("lote-select")
+        .querySelector("select");
+      expect(loteSelect.value).toBe("");
+    });
+  });
 });


### PR DESCRIPTION
Este PR:
- corrige filtros que nao estavam carregando na parametrizacao financeira
- corrige lógica de filtrar lote/unidade quando selecionar edital

[AB#151324](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/151324)