### PR TITLE
Hotfix/152286-medicao-CEMEI-evento-especifico

### DIFF
--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/CardLancamentoCEI/index.jsx
@@ -36,6 +36,7 @@ export const CardLancamentoCEI = ({
   errosAoSalvar,
   periodosInclusaoContinua,
   periodosPermissoesLancamentosEspeciais,
+  inclusoesEventoEspecificoAutorizadas,
 }) => {
   const navigate = useNavigate();
 
@@ -177,6 +178,8 @@ export const CardLancamentoCEI = ({
           uuidPeriodoEscolar: uuidPeriodoEscolar,
           tiposAlimentacao: tiposAlimentacao,
           periodosInclusaoContinua: periodosInclusaoContinua,
+          inclusoesEventoEspecificoAutorizadas:
+            inclusoesEventoEspecificoAutorizadas,
           grupo,
           solicitacaoMedicaoInicial: solicitacaoMedicaoInicial,
           recreioNasFerias: solicitacaoMedicaoInicial.recreio_nas_ferias?.uuid,

--- a/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
+++ b/src/components/screens/LancamentoInicial/LancamentoMedicaoInicial/components/LancamentoPorPeriodoCEI/index.jsx
@@ -25,6 +25,7 @@ import {
   getPeriodosInclusaoContinua,
   getSolicitacoesAlteracoesAlimentacaoAutorizadasEscola,
   getSolicitacoesInclusoesAutorizadasEscola,
+  getSolicitacoesInclusoesEventoEspecificoAutorizadasEscola,
   getSolicitacoesKitLanchesAutorizadasEscola,
   getMatriculadosPeriodo,
 } from "src/services/medicaoInicial/periodoLancamentoMedicao.service";
@@ -94,6 +95,10 @@ export const LancamentoPorPeriodoCEI = ({
     useState(undefined);
   const [inclusoesAutorizadasPP, setInclusoesAutorizadasPP] =
     useState(undefined);
+  const [
+    inclusoesEventoEspecificoAutorizadas,
+    setInclusoesEventoEspecificoAutorizadas,
+  ] = useState(undefined);
   const [
     solicitacoesKitLanchesAutorizadas,
     setSolicitacoesKitLanchesAutorizadas,
@@ -369,11 +374,30 @@ export const LancamentoPorPeriodoCEI = ({
     }
   };
 
+  const getSolicitacoesInclusoesComEventoEspecificoAsync = async () => {
+    if (!ehEscolaTipoCEMEI(escolaInstituicao)) {
+      return;
+    }
+    const escola_uuid = escolaInstituicao.uuid;
+    const tipo_solicitacao = "Inclusão de";
+    const response =
+      await getSolicitacoesInclusoesEventoEspecificoAutorizadasEscola({
+        escola_uuid,
+        mes,
+        ano,
+        tipo_solicitacao,
+      });
+    if (response.status === HTTP_STATUS.OK) {
+      setInclusoesEventoEspecificoAutorizadas(response.data);
+    }
+  };
+
   useEffect(() => {
     if (ehEscolaTipoCEMEI(escolaInstituicao)) {
       getPeriodosInclusaoContinuaAsync();
       getSolicitacoesKitLanchesAutorizadasAsync();
       getSolicitacoesAlteracaoLancheEmergencialAutorizadasAsync();
+      getSolicitacoesInclusoesComEventoEspecificoAsync();
     }
     solicitacaoMedicaoInicial &&
       getQuantidadeAlimentacoesLancadasPeriodoGrupoAsync();
@@ -462,6 +486,16 @@ export const LancamentoPorPeriodoCEI = ({
         ) {
           tiposAlimentacao.push({ nome: nomeExibicao, uuid: null });
         }
+      });
+    }
+
+    if (inclusoesEventoEspecificoAutorizadas?.length > 0) {
+      inclusoesEventoEspecificoAutorizadas.forEach((vinculo) => {
+        vinculo.tipos_alimentacao.forEach((tipo) => {
+          if (!tiposAlimentacao.find((t) => t.nome === tipo.nome)) {
+            tiposAlimentacao.push(tipo);
+          }
+        });
       });
     }
 
@@ -562,6 +596,9 @@ export const LancamentoPorPeriodoCEI = ({
                     tiposAlimentacao={tiposAlimentacaoProgramasEProjetos()}
                     errosAoSalvar={errosAoSalvar}
                     periodosInclusaoContinua={periodosInclusaoContinua}
+                    inclusoesEventoEspecificoAutorizadas={
+                      inclusoesEventoEspecificoAutorizadas
+                    }
                   />
                 )}
                 {((solicitacoesKitLanchesAutorizadas &&

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper.jsx
@@ -817,7 +817,10 @@ export const getSolicitacoesInclusaoAutorizadasAsync = async (
     params["excluir_inclusoes_continuas"] = true;
   }
   if (usuarioEhEscolaCEMEI()) {
-    if (location.state.periodo.includes("Infantil")) {
+    if (
+      location.state.periodo.includes("Infantil") ||
+      location.state.periodo.includes("Programas e Projetos")
+    ) {
       params["cemei_emei"] = true;
     } else {
       params["cemei_cei"] = true;


### PR DESCRIPTION
# Este PR:
- altera parametro para mandar cemei_emei ao invés de cemei_cei quando for programas e projetos
- integra lançamento EMEI da CEMEI com vínculos de evento específico quando precisar deles

### Referência azure:
- [AB#152286](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152286)