### PR TITLE
Feature/151719 criar placeholder no campo embalagem e rotulagem

### DIFF
--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/InfoAcondicionamentoNaoPereciveis/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/InfoAcondicionamentoNaoPereciveis/index.tsx
@@ -389,10 +389,10 @@ export default ({
           <div className="col">
             <Field
               component={TextArea}
-              label="Descrever o Material e o Sistema de Vedação da Embalagem Secundária:"
+              label="Especificar o Material utilizado na Embalagem Secundária e qual será o Sistema de Vedação:"
               name={`sistema_vedacao_embalagem_secundaria`}
               className="textarea-ficha-tecnica"
-              placeholder="Digite as informações da embalagem secundária"
+              placeholder="Ex: Material da embalagem secundária: Caixa de Papelão e Sistema de vedação: Fita Adesiva"
               required
               validate={required}
             />

--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/InfoAcondicionamentoPereciveis/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/InfoAcondicionamentoPereciveis/index.tsx
@@ -410,10 +410,10 @@ export default ({
           <div className="col">
             <Field
               component={TextArea}
-              label="Descrever o Material e o Sistema de Vedação da Embalagem Secundária:"
+              label="Especificar o Material utilizado na Embalagem Secundária e qual será o Sistema de Vedação:"
               name={`sistema_vedacao_embalagem_secundaria`}
               className="textarea-ficha-tecnica"
-              placeholder="Digite as informações da embalagem secundária"
+              placeholder="Ex: Material da embalagem secundária: Caixa de Papelão e Sistema de vedação: Fita Adesiva"
               required
               validate={required}
             />


### PR DESCRIPTION
 ### Referência azure:
- [AB#151719](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/151719)

Atualiza o texto de orientação do campo de embalagem secundária na seção Embalagem e Rotulagem e atualiza o placeholder com um exemplo de preenchimento.