### PR TITLE
Feature/151310 restrige permissao ocorrencia nutrimanifestacao

### DIFF
--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/DRE/solicita_correcao_no_formulario_sem_ocorrencia.test.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/DRE/solicita_correcao_no_formulario_sem_ocorrencia.test.jsx
@@ -75,11 +75,11 @@ describe("Teste Conferência de Lançamentos - Usuário DRE - Solicitação corr
     });
   });
 
-  it("Renderiza botão `Solicitar correção no formulário`", async () => {
+  it("Renderiza botão `Solicitar correção no formulário` sem estar habilitado", async () => {
     const span = screen.getByText("Solicitar correção no formulário");
     const botao = span.closest("button");
 
     expect(botao).toBeInTheDocument();
-    expect(botao).toBeEnabled();
+    expect(botao).not.toBeEnabled();
   });
 });

--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/NutriManifestacao/botoesOcorrencias.test.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/NutriManifestacao/botoesOcorrencias.test.jsx
@@ -1,0 +1,182 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ToastContainer } from "react-toastify";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import { mockGetTipoAlimentacao } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao";
+import { localStorageMock } from "src/mocks/localStorageMock";
+import { mockCategoriasMedicao } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/categoriasMedicao";
+import { mockDiasCalendarioSetembro2025CMCT } from "src/mocks/medicaoInicial/PeriodoLancamentoMedicaoInicial/CMCT/Setembro2025/diasCalendario";
+import { mockMeusDadosNutriSupervisao } from "src/mocks/meusDados/nutri-supervisao";
+import { mockGetVinculosTipoAlimentacaoPorEscola } from "src/mocks/cadastroTipoAlimentacao.service/mockGetVinculosTipoAlimentacaoPorEscola";
+import { mockPeriodosGruposMedicaoCMCTSetembro2025 } from "src/mocks/services/medicaoInicial/solicitacaoMedicaoinicial.service/CMCT/Setembro2025/periodosGruposMedicao";
+import { mockSolicitacaoMedicaoInicialCMCTSetembro2025 } from "src/mocks/services/medicaoInicial/solicitacaoMedicaoinicial.service/CMCT/Setembro2025/solicitacaoMedicaoInicial";
+import { mockValoresMedicaoComDietas } from "src/mocks/services/medicaoInicial/valoresMedicao.service/Setembro2025/valoresMedicaoComDietas";
+import { mockOcorrenciaAprovadaPelaDRE } from "src/mocks/medicaoInicial/ConferenciaDeLancamentos/mockOcorrencias";
+import { ConferenciaDosLancamentosPage } from "src/pages/LancamentoMedicaoInicial/ConferenciaDosLancamentosPage";
+import mock from "src/services/_mock";
+
+jest.mock("src/components/Shareable/CKEditorField", () => ({
+  __esModule: true,
+  default: () => <textarea data-testid="ckeditor-mock" name="ckeditor-mock" />,
+}));
+
+jest.mock(
+  "src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper",
+  () => ({
+    ...jest.requireActual(
+      "src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/helper",
+    ),
+    getPermissoesLancamentosEspeciaisMesAnoPorPeriodoAsync: jest.fn(() =>
+      Promise.resolve({
+        alimentacoes_lancamentos_especiais: [
+          { name: "ALMOÇO", uuid: "uuid-almoco" },
+          { name: "LANCHE", uuid: "uuid-lanche" },
+        ],
+        data_inicio_permissoes: "2023-10-01",
+      }),
+    ),
+  }),
+);
+
+describe("Teste Conferência de Lançamentos - Usuário NUTRI MANIFESTAÇÃO - Renderização botões ocorrências", () => {
+  const escolaUuid = mockSolicitacaoMedicaoInicialCMCTSetembro2025.escola_uuid;
+  const solicitacaoUuid = mockSolicitacaoMedicaoInicialCMCTSetembro2025.uuid;
+
+  beforeEach(() => {
+    Object.defineProperty(global, "localStorage", { value: localStorageMock });
+    localStorage.setItem("tipo_perfil", TIPO_PERFIL.NUTRICAO_MANIFESTACAO);
+    localStorage.setItem("perfil", PERFIL.NUTRI);
+
+    const search = `?uuid=${solicitacaoUuid}`;
+    window.history.pushState({}, "", search);
+
+    mock
+      .onGet("/usuarios/meus-dados/")
+      .reply(200, mockMeusDadosNutriSupervisao);
+    mock
+      .onGet(
+        "/medicao-inicial/solicitacao-medicao-inicial/periodos-grupos-medicao/",
+      )
+      .reply(200, mockPeriodosGruposMedicaoCMCTSetembro2025);
+    mock
+      .onGet("/medicao-inicial/medicao/feriados-no-mes-com-nome/")
+      .reply(200, {
+        results: [{ dia: "07", feriado: "Dia da Independência do Brasil" }],
+      });
+    mock
+      .onGet("/dias-calendario/")
+      .reply(200, mockDiasCalendarioSetembro2025CMCT);
+    mock
+      .onGet("/medicao-inicial/dias-sobremesa-doce/lista-dias/")
+      .reply(200, []);
+    mock
+      .onGet(
+        `/vinculos-tipo-alimentacao-u-e-periodo-escolar/escola/${escolaUuid}/`,
+      )
+      .reply(200, mockGetVinculosTipoAlimentacaoPorEscola);
+    mock
+      .onGet(
+        "/vinculos-tipo-alimentacao-u-e-periodo-escolar/vinculos-inclusoes-evento-especifico-autorizadas/",
+      )
+      .reply(200, []);
+    mock
+      .onGet("/medicao-inicial/categorias-medicao/")
+      .reply(200, mockCategoriasMedicao);
+    mock.onGet("/tipos-alimentacao/").reply(200, mockGetTipoAlimentacao);
+    mock.onGet("/escola-solicitacoes/inclusoes-autorizadas/").reply(200, {
+      results: [],
+    });
+    mock
+      .onGet("/escola-solicitacoes/alteracoes-alimentacao-autorizadas/")
+      .reply(200, {
+        results: [],
+      });
+    mock.onGet("/escolas-solicitacoes/suspensoes-autorizadas/").reply(200, {
+      results: [],
+    });
+    mock.onGet("/periodos-escolares/inclusao-continua-por-mes/").reply(200, {
+      periodos: { TARDE: "20bd9ca9-d499-456a-bd86-fb8f297947d6" },
+    });
+    mock
+      .onGet("/medicao-inicial/valores-medicao/")
+      .reply(200, mockValoresMedicaoComDietas);
+  });
+
+  const setup = async () => {
+    await act(async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: "/",
+              state: {
+                ano: "2025",
+                escolaUuid: escolaUuid,
+                mes: "09",
+              },
+            },
+          ]}
+          future={{
+            v7_startTransition: true,
+            v7_relativeSpatPath: true,
+          }}
+        >
+          <ToastContainer />
+          <ConferenciaDosLancamentosPage />
+        </MemoryRouter>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Carregando/i)).not.toBeInTheDocument();
+    });
+  };
+
+  it("deve renderizar o botão 'Solicitar correção no formulário' habilitado", async () => {
+    mock
+      .onGet(`/medicao-inicial/solicitacao-medicao-inicial/${solicitacaoUuid}/`)
+      .reply(200, {
+        ...mockSolicitacaoMedicaoInicialCMCTSetembro2025,
+        status: "MEDICAO_CORRIGIDA_PARA_CODAE",
+      });
+
+    await setup();
+
+    const botaoSolicitar = screen
+      .getByText("Solicitar correção no formulário")
+      .closest("button");
+
+    expect(botaoSolicitar).toBeInTheDocument();
+    expect(botaoSolicitar).toBeEnabled();
+  });
+
+  it("deve renderizar o botão 'Aprovar Formulários' habilitado", async () => {
+    mock
+      .onGet(`/medicao-inicial/solicitacao-medicao-inicial/${solicitacaoUuid}/`)
+      .reply(200, {
+        ...mockSolicitacaoMedicaoInicialCMCTSetembro2025,
+        ocorrencia: mockOcorrenciaAprovadaPelaDRE,
+        com_ocorrencias: true,
+        status: "MEDICAO_APROVADA_PELA_DRE",
+      });
+
+    await setup();
+
+    const btnExpandir = document.querySelector(".visualizar-ocorrencias");
+    fireEvent.click(btnExpandir);
+
+    const botaoAprovar = screen
+      .getByText("Aprovar formulário")
+      .closest("button");
+
+    expect(botaoAprovar).toBeInTheDocument();
+    expect(botaoAprovar).toBeEnabled();
+  });
+});

--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
@@ -988,6 +988,7 @@ export const ConferenciaDosLancamentos = () => {
                                         type={BUTTON_TYPE.BUTTON}
                                         style={BUTTON_STYLE.GREEN_OUTLINE_WHITE}
                                         disabled={
+                                          !usuarioEhCODAENutriManifestacao() ||
                                           (ocorrencia?.status ===
                                             "MEDICAO_CORRECAO_SOLICITADA" &&
                                             !solicitacao?.com_ocorrencias) ||
@@ -1010,6 +1011,7 @@ export const ConferenciaDosLancamentos = () => {
                                           type={BUTTON_TYPE.BUTTON}
                                           style={BUTTON_STYLE.GREEN}
                                           disabled={
+                                            !usuarioEhCODAENutriManifestacao() ||
                                             desabilitarAprovarOcorrenciaCODAE ||
                                             desabilitarAprovarOcorrenciaDRE
                                           }


### PR DESCRIPTION
**Este pull request**
- Bloqueia botões de aprovar e solicitar correção na interface de conferência de lançamentos para usuários diferentes de Nutri manifestação.
- Ajusta e implementa testes referente a implementação.

Referência no Azure: [AB#151310](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/151310)