### PR TITLE
Feature/151088 permitir edicao endereco ficha tecnica

### DIFF
--- a/src/components/screens/PreRecebimento/FichaTecnica/__tests__/Cadastrar.test.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/__tests__/Cadastrar.test.tsx
@@ -18,13 +18,29 @@ import { mockMeusDadosFornecedor } from "src/mocks/services/perfil.service/mockM
 import { mockEmpresa } from "src/mocks/terceirizada.service/mockGetTerceirizadaUUID";
 import CadastroFichaTecnicaPage from "src/pages/PreRecebimento/FichaTecnica/CadastroFichaTecnicaPage";
 import mock from "src/services/_mock";
+import { getEnderecoPorCEP } from "src/services/cep.service";
 import {
   CATEGORIA_OPTIONS,
   PROGRAMA_OPTIONS,
   TIPO_ENTREGA_OPTIONS,
 } from "../constants";
 
+jest.mock("src/services/cep.service.jsx");
+
+const mockCEP = {
+  cep: "00000-000",
+  logradouro: "Rua Falsa",
+  bairro: "Sumaré",
+  localidade: "São Paulo",
+  uf: "SP",
+};
+
 beforeEach(() => {
+  (getEnderecoPorCEP as jest.Mock).mockResolvedValue({
+    data: mockCEP,
+    status: 200,
+  });
+
   mock
     .onGet(`/cadastro-produtos-edital/lista-completa-logistica/`)
     .reply(200, mockListaProdutosLogistica);
@@ -526,6 +542,55 @@ describe("Carrega página de Cadastro de Ficha técnica", () => {
       const componentesProduto = screen.getByTestId("componentes_produto");
       expect(componentesProduto).toBeInTheDocument();
       expect(componentesProduto.tagName).toBe("TEXTAREA");
+    });
+  });
+
+  describe("Campos de endereço do fabricante", () => {
+    const placeholdersEndereco = [
+      "Digite o endereço",
+      "Digite o Bairro",
+      "Digite a Cidade",
+      "Digite o Estado",
+    ];
+
+    it("não deixa os campos de endereço desabilitados ao carregar o formulário", async () => {
+      await setup();
+
+      placeholdersEndereco.forEach((placeholder) => {
+        const inputs = screen.getAllByPlaceholderText(placeholder);
+        expect(inputs.length).toBeGreaterThan(0);
+        inputs.forEach((input) => expect(input).not.toBeDisabled());
+      });
+    });
+
+    it("permite editar manualmente os campos de endereço", async () => {
+      await setup();
+
+      const inputEndereco =
+        screen.getAllByPlaceholderText("Digite o endereço")[0];
+      fireEvent.change(inputEndereco, {
+        target: { value: "Rua Digitada Manualmente" },
+      });
+      expect(inputEndereco).toHaveValue("Rua Digitada Manualmente");
+    });
+
+    it("mantém os campos de endereço habilitados após a consulta de CEP", async () => {
+      await setup();
+
+      const inputCEP = screen.getAllByPlaceholderText("Digite o CEP")[0];
+      await act(async () => {
+        fireEvent.change(inputCEP, { target: { value: "00000000" } });
+      });
+
+      await waitFor(() => {
+        expect(getEnderecoPorCEP).toHaveBeenCalled();
+      });
+
+      placeholdersEndereco.forEach((placeholder) => {
+        screen
+          .getAllByPlaceholderText(placeholder)
+          .forEach((input) => expect(input).not.toBeDisabled());
+      });
     });
   });
 });

--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/FormFabricante/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/components/FormFabricante/index.tsx
@@ -22,7 +22,6 @@ interface Props {
   setFabricantesCount?: (_count: number) => void;
   fabricantesOptions?: OptionsGenerico[];
   values: Record<string, any>;
-  desabilitaEndereco?: Array<boolean>;
   gerenciaModalCadastroExterno?: () => void;
   somenteLeitura?: boolean;
   ocultarBotaoCadastroFabricante?: boolean;
@@ -33,7 +32,6 @@ const FormFabricante: React.FC<Props> = ({
   setFabricantesCount,
   fabricantesOptions,
   values,
-  desabilitaEndereco,
   somenteLeitura,
   gerenciaModalCadastroExterno,
   ocultarBotaoCadastroFabricante = false,
@@ -145,7 +143,7 @@ const FormFabricante: React.FC<Props> = ({
                 name={`endereco_fabricante_${idx}`}
                 placeholder={somenteLeitura ? "" : "Digite o endereço"}
                 className="input-ficha-tecnica"
-                disabled={somenteLeitura || desabilitaEndereco[idx]}
+                disabled={somenteLeitura}
               />
             </div>
           </div>
@@ -177,7 +175,7 @@ const FormFabricante: React.FC<Props> = ({
                 name={`bairro_fabricante_${idx}`}
                 placeholder={somenteLeitura ? "" : "Digite o Bairro"}
                 className="input-ficha-tecnica"
-                disabled={somenteLeitura || desabilitaEndereco[idx]}
+                disabled={somenteLeitura}
               />
             </div>
           </div>
@@ -189,7 +187,7 @@ const FormFabricante: React.FC<Props> = ({
                 name={`cidade_fabricante_${idx}`}
                 placeholder={somenteLeitura ? "" : "Digite a Cidade"}
                 className="input-ficha-tecnica"
-                disabled={somenteLeitura || desabilitaEndereco[idx]}
+                disabled={somenteLeitura}
               />
             </div>
             <div className="col-4">
@@ -199,7 +197,7 @@ const FormFabricante: React.FC<Props> = ({
                 name={`estado_fabricante_${idx}`}
                 placeholder={somenteLeitura ? "" : "Digite o Estado"}
                 className="input-ficha-tecnica"
-                disabled={somenteLeitura || desabilitaEndereco[idx]}
+                disabled={somenteLeitura}
               />
             </div>
           </div>

--- a/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/index.tsx
+++ b/src/components/screens/PreRecebimento/FichaTecnica/components/Cadastrar/index.tsx
@@ -89,10 +89,6 @@ export default () => {
     useState<TerceirizadaComEnderecoInterface>(
       {} as TerceirizadaComEnderecoInterface,
     );
-  const [desabilitaEndereco, setDesabilitaEndereco] = useState<Array<boolean>>([
-    true,
-    true,
-  ]);
   const [collapse, setCollapse] = useState<CollapseControl>({});
   const [ficha, setFicha] = useState<FichaTecnicaDetalhada>(
     {} as FichaTecnicaDetalhada,
@@ -149,7 +145,7 @@ export default () => {
           <Form
             onSubmit={() => {}}
             initialValues={initialValues}
-            decorators={[cepCalculator(setDesabilitaEndereco)]}
+            decorators={[cepCalculator()]}
             render={({ handleSubmit, values, errors }) => (
               <form onSubmit={handleSubmit}>
                 <StepsSigpae current={stepAtual} items={ITENS_STEPS} />
@@ -337,7 +333,6 @@ export default () => {
                           setFabricantesCount={setFabricantesCount}
                           fabricantesOptions={fabricantesOptions}
                           values={values}
-                          desabilitaEndereco={desabilitaEndereco}
                           gerenciaModalCadastroExterno={() => {
                             gerenciaModalCadastroExterno(
                               "FABRICANTE",

--- a/src/components/screens/PreRecebimento/FichaTecnica/helpers.ts
+++ b/src/components/screens/PreRecebimento/FichaTecnica/helpers.ts
@@ -61,14 +61,15 @@ import {
 } from "./constants";
 
 export const cepCalculator = (
-  setDesabilitaEndereco: React.Dispatch<React.SetStateAction<Array<boolean>>>,
+  setDesabilitaEndereco?: React.Dispatch<React.SetStateAction<Array<boolean>>>,
 ) => {
   const lastCepValues: Record<string, string> = {};
 
   return createDecorator({
     field: /^cep_fabricante_(\d+)$/,
     updates: {
-      dummy: (_, allValues: FichaTecnicaPayload) => {
+      dummy: (_, allValuesGenerico) => {
+        const allValues = allValuesGenerico as FichaTecnicaPayload;
         Object.keys(allValues)
           .filter((key) => key.startsWith("cep_fabricante_"))
           .forEach((field) => {
@@ -76,7 +77,11 @@ export const cepCalculator = (
             if (cep?.length === 9 && cep !== lastCepValues[field]) {
               lastCepValues[field] = cep;
               const index = field.split("_").pop()!;
-              buscaCEP(cep, allValues, setDesabilitaEndereco, index);
+              if (setDesabilitaEndereco) {
+                buscaCEP(cep, allValues, setDesabilitaEndereco, index);
+              } else {
+                buscaCEPSemDesabilitarEndereco(cep, allValues, index);
+              }
             }
           });
 
@@ -115,6 +120,25 @@ export const buscaCEP = async (
       prev[index] = false;
       return prev;
     });
+  }
+};
+
+export const buscaCEPSemDesabilitarEndereco = async (
+  cep: string,
+  values: FichaTecnicaPayload,
+  index: string,
+) => {
+  try {
+    const response = await getEnderecoPorCEP(cep);
+    if (response.status === 200 && !response.data.erro) {
+      const { data } = response;
+      values[`bairro_fabricante_${index}`] = data.bairro;
+      values[`cidade_fabricante_${index}`] = data.localidade;
+      values[`endereco_fabricante_${index}`] = data.logradouro;
+      values[`estado_fabricante_${index}`] = data.uf;
+    }
+  } catch {
+    toastError("Erro ao buscar CEP");
   }
 };
 


### PR DESCRIPTION
# Este PR

 - Habilita edição de campos de endereço no cadastro de Ficha Técnica;
 - Implementa testes unitários para garantir esta alteração.

### Referência Azure

 - [AB#151088](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/151088)