### PR TITLE
Feature/150971 painel de aprovacoes exibir cronogramas cadastrados em verde

### DIFF
--- a/src/components/Shareable/CardCronograma/CardCronograma.jsx
+++ b/src/components/Shareable/CardCronograma/CardCronograma.jsx
@@ -12,21 +12,35 @@ export const CardCronograma = ({
   href,
   exibirTooltip = false,
 }) => {
+  const ehPontoAPonto = (solicitation) =>
+    Boolean(solicitation.ponto_a_ponto) ||
+    solicitation.tipo_entrega === "PONTO_A_PONTO";
+
+  const getClasseSolicitacao = (solicitation) => {
+    const classes = ["data"];
+
+    if (solicitation.programa_leve_leite) {
+      classes.push("programa-leve-leite");
+    }
+
+    if (ehPontoAPonto(solicitation)) {
+      classes.push("ponto-a-ponto");
+    }
+
+    return classes.join(" ");
+  };
+
   const renderSolicitations = (solicitations, exibirTooltip) => {
     return exibirTooltip
       ? solicitations.slice(0, 5).map((solicitation, key) => {
-          const EPontoAPonto = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <Tooltip
               placement="topLeft"
               key={key}
               title={solicitation.fullText}
             >
-              <NavLink key={key} to={solicitation.link}>
-                <p
-                  key={key}
-                  className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${EPontoAPonto ? "ponto-a-ponto" : ""}`}
-                >
+              <NavLink to={solicitation.link}>
+                <p className={getClasseSolicitacao(solicitation)}>
                   {solicitation.text}
                   <span className="float-end">{solicitation.date}</span>
                 </p>
@@ -35,13 +49,9 @@ export const CardCronograma = ({
           );
         })
       : solicitations.slice(0, 5).map((solicitation, key) => {
-          const EPontoAPonto = solicitation.tipo_entrega === "PONTO_A_PONTO";
           return (
             <NavLink key={key} to={solicitation.link}>
-              <p
-                key={key}
-                className={`data ${solicitation.programa_leve_leite ? "programa-leve-leite" : ""} ${EPontoAPonto ? "ponto-a-ponto" : ""}`}
-              >
+              <p className={getClasseSolicitacao(solicitation)}>
                 {solicitation.text}
                 <span className="float-end">{solicitation.date}</span>
               </p>
@@ -66,7 +76,7 @@ export const CardCronograma = ({
 
   return (
     <div className={`card card-panel-cronograma card-colored ${cardType}`}>
-      <div className={`card-title-status ajuste-icones`}>
+      <div className="card-title-status ajuste-icones">
         <div>
           <i className={"fas " + icon} />
           {cardTitle}

--- a/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
@@ -23,7 +23,9 @@ export default ({
           <div className="card-listagem-solicitacoes">
             {solicitacoes &&
               solicitacoes.map((value, key) => {
-                const ehPontoAPonto = value.tipo_entrega === "PONTO_A_PONTO";
+                const ehPontoAPonto =
+                  Boolean(value.ponto_a_ponto) ||
+                  value.tipo_entrega === "PONTO_A_PONTO";
 
                 const classeDestaque = ehPontoAPonto
                   ? "categoria-ponto-a-ponto"

--- a/src/components/screens/PreRecebimento/PainelAprovacoes/index.jsx
+++ b/src/components/screens/PreRecebimento/PainelAprovacoes/index.jsx
@@ -103,6 +103,7 @@ export default () => {
       link: gerarLinkCronograma(item, alteracao),
       status: item.status,
       programa_leve_leite: item.programa_leve_leite,
+      ponto_a_ponto: item.ponto_a_ponto,
     }));
   };
 

--- a/src/components/screens/SolicitacoesCronogramaStatusGenerico/index.jsx
+++ b/src/components/screens/SolicitacoesCronogramaStatusGenerico/index.jsx
@@ -42,6 +42,7 @@ export const SolicitacoesCronogramaStatusGenerico = ({ ...props }) => {
       data: item.log_mais_recente,
       link: `/${PRE_RECEBIMENTO}/${DETALHE_CRONOGRAMA}?uuid=${item.uuid}`,
       programa_leve_leite: item.programa_leve_leite,
+      ponto_a_ponto: item.ponto_a_ponto,
     }));
   };
 
@@ -51,6 +52,7 @@ export const SolicitacoesCronogramaStatusGenerico = ({ ...props }) => {
       data: item.log_mais_recente,
       link: `/${PRE_RECEBIMENTO}/${DETALHAR_ALTERACAO_CRONOGRAMA}?uuid=${item.uuid}`,
       programa_leve_leite: item.programa_leve_leite,
+      ponto_a_ponto: item.ponto_a_ponto,
     }));
   };
 

--- a/src/components/screens/__tests__/PainelAprovacoes/constants.test.jsx
+++ b/src/components/screens/__tests__/PainelAprovacoes/constants.test.jsx
@@ -1,0 +1,86 @@
+import {
+  CARD_SOLICITACOES_ALTERACOES_ABASTECIMENTO,
+  CARD_VISAO_CRONOGRAMA_SOLICITACOES_ALTERACOES_EM_ANALISE,
+  CARD_SOLICITACOES_ALTERACOES_DILOG,
+  CARD_SOLICITACOES_ALTERACOES_CODAE,
+  CARD_SOLICITACOES_APROVADAS_ABASTECIMENTO,
+  CARD_SOLICITACOES_REPROVADAS_ABASTECIMENTO,
+  CARD_SOLICITACOES_APROVADAS_DILOG,
+  CARD_SOLICITACOES_REPROVADAS_DILOG,
+  cards_alteracao_abastecimento,
+  cards_alteracao_dilog,
+  cards_alteracao_visao_cronograma,
+} from "../../PreRecebimento/PainelAprovacoes/constants";
+
+describe("constants do Painel de Aprovações", () => {
+  test("Deve configurar o card de solicitações de alterações do abastecimento", () => {
+    expect(CARD_SOLICITACOES_ALTERACOES_ABASTECIMENTO).toEqual({
+      id: "Solicitações de Alterações",
+      titulo: "Solicitações de Alterações",
+      icon: "fa-exclamation-triangle",
+      style: "card-solicitacoes-alteracoes",
+      incluir_status: ["CRONOGRAMA_CIENTE"],
+      href: "/abastecimento/solicitacoes-alteracoes",
+    });
+  });
+
+  test("Deve configurar o card de solicitações de alterações em análise na visão cronograma", () => {
+    expect(CARD_VISAO_CRONOGRAMA_SOLICITACOES_ALTERACOES_EM_ANALISE).toEqual({
+      id: "Solicitações de Alterações",
+      titulo: "Solicitações de Alterações",
+      icon: "fa-exclamation-triangle",
+      style: "card-solicitacoes-alteracoes",
+      incluir_status: ["EM_ANALISE"],
+      href: "/cronograma/solicitacoes-alteracoes",
+    });
+  });
+
+  test("Deve configurar o card de solicitações de alterações da DILOG com status aprovados e reprovados pelo abastecimento", () => {
+    expect(CARD_SOLICITACOES_ALTERACOES_DILOG.incluir_status).toEqual([
+      "APROVADO_DILOG_ABASTECIMENTO",
+      "REPROVADO_DILOG_ABASTECIMENTO",
+    ]);
+
+    expect(CARD_SOLICITACOES_ALTERACOES_DILOG.href).toBe(
+      "/dilog/solicitacoes-alteracoes",
+    );
+  });
+
+  test("Deve configurar o card de alterações CODAE", () => {
+    expect(CARD_SOLICITACOES_ALTERACOES_CODAE).toEqual({
+      id: "Alterações CODAE",
+      titulo: "Alterações CODAE",
+      icon: "fa-info-circle",
+      style: "card-alteracoes-codae",
+      incluir_status: ["ALTERACAO_ENVIADA_FORNECEDOR", "FORNECEDOR_CIENTE"],
+      href: "/cronograma/alteracoes-codae",
+    });
+  });
+
+  test("Deve montar os cards de alteração do abastecimento na ordem esperada", () => {
+    expect(cards_alteracao_abastecimento).toEqual([
+      CARD_SOLICITACOES_ALTERACOES_ABASTECIMENTO,
+      CARD_SOLICITACOES_APROVADAS_ABASTECIMENTO,
+      CARD_SOLICITACOES_REPROVADAS_ABASTECIMENTO,
+      CARD_SOLICITACOES_ALTERACOES_CODAE,
+    ]);
+  });
+
+  test("Deve montar os cards de alteração da DILOG na ordem esperada", () => {
+    expect(cards_alteracao_dilog).toEqual([
+      CARD_SOLICITACOES_ALTERACOES_DILOG,
+      CARD_SOLICITACOES_APROVADAS_DILOG,
+      CARD_SOLICITACOES_REPROVADAS_DILOG,
+      CARD_SOLICITACOES_ALTERACOES_CODAE,
+    ]);
+  });
+
+  test("Deve montar os cards de alteração da visão cronograma na ordem esperada", () => {
+    expect(cards_alteracao_visao_cronograma).toEqual([
+      CARD_VISAO_CRONOGRAMA_SOLICITACOES_ALTERACOES_EM_ANALISE,
+      CARD_SOLICITACOES_APROVADAS_DILOG,
+      CARD_SOLICITACOES_REPROVADAS_DILOG,
+      CARD_SOLICITACOES_ALTERACOES_CODAE,
+    ]);
+  });
+});

--- a/src/components/screens/__tests__/PainelAprovacoes/index.test.jsx
+++ b/src/components/screens/__tests__/PainelAprovacoes/index.test.jsx
@@ -1,0 +1,235 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+import PainelAprovacoes from "../../PreRecebimento/PainelAprovacoes";
+
+import {
+  getDashboardCronograma,
+  getDashboardCronogramaComFiltros,
+  getDashboardSolicitacoesAlteracao,
+  getDashboardSolicitacoesAlteracaoComFiltros,
+} from "src/services/cronograma.service";
+
+jest.mock("antd", () => ({
+  Spin: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("src/components/Shareable/CardCronograma/CardCronograma", () => ({
+  __esModule: true,
+  default: ({ cardTitle, solicitations }) => (
+    <div data-testid={`card-${cardTitle}`}>
+      <span>{cardTitle}</span>
+      {solicitations.map((solicitation) => (
+        <div
+          key={solicitation.link}
+          data-testid="solicitacao-card"
+          data-ponto-a-ponto={String(solicitation.ponto_a_ponto)}
+          data-programa-leve-leite={String(solicitation.programa_leve_leite)}
+          data-link={solicitation.link}
+        >
+          {solicitation.text}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("src/components/Shareable/Input/InputText", () => {
+  return ({ input, placeholder, inputOnChange }) => (
+    <input
+      placeholder={placeholder}
+      value={input?.value || ""}
+      onChange={(event) => {
+        input?.onChange?.(event);
+        inputOnChange?.(event);
+      }}
+    />
+  );
+});
+
+jest.mock("src/helpers/utilities", () => ({
+  parseDataHoraBrToMoment: jest.fn((data) => data),
+  comparaObjetosMoment: jest.fn((dataA, dataB) => dataA.localeCompare(dataB)),
+  truncarString: jest.fn((texto) => texto || ""),
+}));
+
+jest.mock("src/services/cronograma.service", () => ({
+  getDashboardCronograma: jest.fn(),
+  getDashboardCronogramaComFiltros: jest.fn(),
+  getDashboardSolicitacoesAlteracao: jest.fn(),
+  getDashboardSolicitacoesAlteracaoComFiltros: jest.fn(),
+}));
+
+const responseCronograma = {
+  data: {
+    results: [
+      {
+        status: "ASSINADO_E_ENVIADO_AO_FORNECEDOR",
+        dados: [
+          {
+            uuid: "11111111-1111-4111-8111-111111111111",
+            numero: "151/2024A",
+            produto: "CAQUI",
+            empresa: "Fornecedor Teste",
+            log_mais_recente: "06/07/2026",
+            status: "Aguardando Assinatura",
+            programa_leve_leite: false,
+            ponto_a_ponto: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const responseSolicitacaoAlteracao = {
+  data: {
+    results: [
+      {
+        status: "EM_ANALISE",
+        dados: [
+          {
+            uuid: "22222222-2222-4222-8222-222222222222",
+            cronograma: "072/2023",
+            produto: "CAQUI",
+            empresa: "Empresa do Luis Zimmermann",
+            log_mais_recente: "02/01/2024",
+            status: "Em análise",
+            programa_leve_leite: false,
+            ponto_a_ponto: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  localStorage.setItem("perfil", JSON.stringify("DILOG_CRONOGRAMA"));
+
+  getDashboardCronograma.mockResolvedValue(responseCronograma);
+  getDashboardCronogramaComFiltros.mockResolvedValue(responseCronograma);
+  getDashboardSolicitacoesAlteracao.mockResolvedValue(
+    responseSolicitacaoAlteracao,
+  );
+  getDashboardSolicitacoesAlteracaoComFiltros.mockResolvedValue(
+    responseSolicitacaoAlteracao,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+  localStorage.clear();
+  jest.useRealTimers();
+});
+
+describe("PainelAprovacoes", () => {
+  test("Deve buscar cronogramas e solicitações de alteração ao carregar a tela", async () => {
+    render(<PainelAprovacoes />);
+
+    await waitFor(() => {
+      expect(getDashboardCronograma).toHaveBeenCalledTimes(1);
+      expect(getDashboardSolicitacoesAlteracao).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("Deve formatar cronograma preservando ponto_a_ponto", async () => {
+    render(<PainelAprovacoes />);
+
+    const solicitacao = await screen.findByText(
+      "151/2024A / CAQUI / Fornecedor Teste",
+    );
+
+    expect(solicitacao).toHaveAttribute("data-ponto-a-ponto", "true");
+    expect(solicitacao).toHaveAttribute("data-programa-leve-leite", "false");
+    expect(solicitacao).toHaveAttribute(
+      "data-link",
+      "/pre-recebimento/detalhe-cronograma?uuid=11111111-1111-4111-8111-111111111111",
+    );
+  });
+
+  test("Deve formatar solicitação de alteração preservando ponto_a_ponto", async () => {
+    render(<PainelAprovacoes />);
+
+    const solicitacao = await screen.findByText(
+      "072/2023 / CAQUI / Empresa do Luis Zimmermann",
+    );
+
+    expect(solicitacao).toHaveAttribute("data-ponto-a-ponto", "true");
+    expect(solicitacao).toHaveAttribute("data-programa-leve-leite", "false");
+    expect(solicitacao).toHaveAttribute(
+      "data-link",
+      "/pre-recebimento/detalhe-alteracao-cronograma?uuid=22222222-2222-4222-8222-222222222222",
+    );
+  });
+
+  test("Deve filtrar cronogramas quando o campo possuir mais de dois caracteres", async () => {
+    jest.useFakeTimers();
+
+    render(<PainelAprovacoes />);
+
+    await waitFor(() => {
+      expect(getDashboardCronograma).toHaveBeenCalledTimes(1);
+    });
+
+    const inputNumeroCronograma =
+      screen.getAllByPlaceholderText("N° do Cronograma")[0];
+
+    fireEvent.change(inputNumeroCronograma, {
+      target: { value: "151" },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(getDashboardCronogramaComFiltros).toHaveBeenCalledTimes(1);
+    });
+
+    expect(getDashboardCronogramaComFiltros).toHaveBeenCalledWith(
+      expect.objectContaining({
+        numero_cronograma: "151",
+      }),
+    );
+  });
+
+  test("Deve filtrar solicitações de alteração quando o campo possuir mais de dois caracteres", async () => {
+    jest.useFakeTimers();
+
+    render(<PainelAprovacoes />);
+
+    await waitFor(() => {
+      expect(getDashboardSolicitacoesAlteracao).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("Nome do Fornecedor"), {
+      target: { value: "Luis" },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(getDashboardSolicitacoesAlteracaoComFiltros).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    expect(getDashboardSolicitacoesAlteracaoComFiltros).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nome_fornecedor: "Luis",
+      }),
+    );
+  });
+});

--- a/src/components/screens/__tests__/SolicitacoesCronogramaStatusGenerico/index.test.jsx
+++ b/src/components/screens/__tests__/SolicitacoesCronogramaStatusGenerico/index.test.jsx
@@ -1,0 +1,347 @@
+import "@testing-library/jest-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+import { SolicitacoesCronogramaStatusGenerico } from "../../SolicitacoesCronogramaStatusGenerico";
+
+jest.mock("antd", () => ({
+  Spin: ({ children }) => <>{children}</>,
+}));
+
+jest.mock("src/components/Shareable/CardListarSolicitacoesCronograma", () => ({
+  __esModule: true,
+  default: ({ solicitacoes }) => (
+    <div data-testid="card-listar-solicitacoes">
+      {solicitacoes?.map((solicitacao) => (
+        <div
+          key={solicitacao.link}
+          data-testid="solicitacao-formatada"
+          data-ponto-a-ponto={String(solicitacao.ponto_a_ponto)}
+          data-programa-leve-leite={String(solicitacao.programa_leve_leite)}
+        >
+          {solicitacao.texto}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock("src/components/Shareable/Paginacao", () => ({
+  Paginacao: ({ onChange, total, pageSize, current }) => (
+    <button
+      type="button"
+      data-testid="paginacao"
+      data-total={total}
+      data-page-size={pageSize}
+      data-current={current}
+      onClick={() => onChange(2)}
+    >
+      Paginar
+    </button>
+  ),
+}));
+
+jest.mock("src/components/Shareable/Input/InputText", () => {
+  return ({ input, placeholder, inputOnChange }) => (
+    <input
+      placeholder={placeholder}
+      value={input?.value || ""}
+      onChange={(event) => {
+        input?.onChange?.(event);
+        inputOnChange?.(event);
+      }}
+    />
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllMocks();
+  jest.useRealTimers();
+});
+
+describe("SolicitacoesCronogramaStatusGenerico", () => {
+  const propsPadrao = {
+    getSolicitacoesComFiltros: jest.fn(),
+    params: {
+      status: "EM_ANALISE",
+      offset: 0,
+      limit: 10,
+    },
+    limit: 10,
+    titulo: "Solicitações",
+    icone: "fa-calendar",
+    cardType: "tipo-mock",
+  };
+
+  const responseCronograma = {
+    status: 200,
+    data: {
+      results: [
+        {
+          total: 1,
+          dados: [
+            {
+              uuid: "11111111-1111-4111-8111-111111111111",
+              numero: "151/2024A",
+              produto: "CAQUI",
+              empresa: "Fornecedor Teste",
+              log_mais_recente: "06/07/2026",
+              programa_leve_leite: false,
+              ponto_a_ponto: true,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const responseSolicitacaoAlteracao = {
+    status: 200,
+    data: {
+      results: [
+        {
+          total: 1,
+          dados: [
+            {
+              uuid: "22222222-2222-4222-8222-222222222222",
+              cronograma: "072/2023",
+              empresa: "Empresa do Luis Zimmermann",
+              log_mais_recente: "02/01/2024",
+              programa_leve_leite: false,
+              ponto_a_ponto: true,
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  test("Deve carregar solicitações ao montar a tela", async () => {
+    const getSolicitacoes = jest.fn().mockResolvedValue(responseCronograma);
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        alteracao={false}
+      />,
+    );
+
+    const solicitacao = await screen.findByTestId("solicitacao-formatada");
+
+    expect(getSolicitacoes).toHaveBeenCalledTimes(1);
+    expect(solicitacao).toHaveTextContent(
+      "151/2024A - CAQUI - Fornecedor Teste",
+    );
+    expect(solicitacao).toHaveAttribute("data-ponto-a-ponto", "true");
+  });
+
+  test("Deve formatar solicitações de alteração preservando o campo ponto_a_ponto", async () => {
+    const getSolicitacoes = jest
+      .fn()
+      .mockResolvedValue(responseSolicitacaoAlteracao);
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        alteracao={true}
+      />,
+    );
+
+    const solicitacao = await screen.findByTestId("solicitacao-formatada");
+
+    expect(solicitacao).toHaveTextContent(
+      "072/2023 - Empresa do Luis Zimmermann",
+    );
+    expect(solicitacao).toHaveAttribute("data-ponto-a-ponto", "true");
+    expect(solicitacao).toHaveAttribute("data-programa-leve-leite", "false");
+  });
+
+  test("Deve filtrar quando algum campo possuir mais de dois caracteres", async () => {
+    jest.useFakeTimers();
+
+    const getSolicitacoes = jest
+      .fn()
+      .mockResolvedValue(responseSolicitacaoAlteracao);
+
+    const getSolicitacoesComFiltros = jest.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        results: [
+          {
+            total: 1,
+            dados: [
+              {
+                uuid: "33333333-3333-4333-8333-333333333333",
+                cronograma: "073/2023",
+                empresa: "Fornecedor Filtrado",
+                log_mais_recente: "03/01/2024",
+                programa_leve_leite: false,
+                ponto_a_ponto: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        getSolicitacoesComFiltros={getSolicitacoesComFiltros}
+        alteracao={true}
+      />,
+    );
+
+    await screen.findByText("072/2023 - Empresa do Luis Zimmermann");
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Pesquisar por Nome do Fornecedor"),
+      {
+        target: { value: "Fornecedor" },
+      },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(getSolicitacoesComFiltros).toHaveBeenCalledTimes(1);
+    });
+
+    expect(
+      await screen.findByText("073/2023 - Fornecedor Filtrado"),
+    ).toBeInTheDocument();
+  });
+
+  test("Deve limpar o filtro e buscar novamente sem filtros quando o campo voltar a ter menos de três caracteres", async () => {
+    jest.useFakeTimers();
+
+    const getSolicitacoes = jest
+      .fn()
+      .mockResolvedValue(responseSolicitacaoAlteracao);
+
+    const getSolicitacoesComFiltros = jest.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        results: [
+          {
+            total: 1,
+            dados: [
+              {
+                uuid: "44444444-4444-4444-8444-444444444444",
+                cronograma: "074/2023",
+                empresa: "Fornecedor Filtrado",
+                log_mais_recente: "04/01/2024",
+                programa_leve_leite: false,
+                ponto_a_ponto: true,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        getSolicitacoesComFiltros={getSolicitacoesComFiltros}
+        alteracao={true}
+      />,
+    );
+
+    await screen.findByText("072/2023 - Empresa do Luis Zimmermann");
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Pesquisar por Nome do Fornecedor"),
+      {
+        target: { value: "Fornecedor" },
+      },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(getSolicitacoesComFiltros).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Pesquisar por Nome do Fornecedor"),
+      {
+        target: { value: "" },
+      },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    await waitFor(() => {
+      expect(getSolicitacoes).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("Deve buscar a próxima página ao alterar a paginação", async () => {
+    const getSolicitacoes = jest
+      .fn()
+      .mockResolvedValue(responseSolicitacaoAlteracao);
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        alteracao={true}
+      />,
+    );
+
+    await screen.findByText("072/2023 - Empresa do Luis Zimmermann");
+
+    fireEvent.click(screen.getByTestId("paginacao"));
+
+    await waitFor(() => {
+      expect(getSolicitacoes).toHaveBeenCalledTimes(2);
+    });
+
+    expect(screen.getByTestId("paginacao")).toHaveAttribute(
+      "data-current",
+      "2",
+    );
+  });
+
+  test("Deve exibir mensagem de erro quando a busca de solicitações falhar", async () => {
+    const getSolicitacoes = jest.fn().mockResolvedValue({
+      status: 500,
+      data: "Erro ao carregar solicitações",
+    });
+
+    render(
+      <SolicitacoesCronogramaStatusGenerico
+        {...propsPadrao}
+        getSolicitacoes={getSolicitacoes}
+        alteracao={true}
+      />,
+    );
+
+    expect(
+      await screen.findByText("Erro ao carregar solicitações"),
+    ).toBeInTheDocument();
+
+    expect(getSolicitacoes).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByTestId("card-listar-solicitacoes"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
 ### Referência azure:
- [AB#150971](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/150971)

### Alterações no Frontend

Foi ajustada a regra de destaque visual dos cronogramas ponto a ponto no Painel de Aprovações, garantindo que os cards sejam exibidos em verde quando o item possuir `ponto_a_ponto: true` ou `tipo_entrega: "PONTO_A_PONTO"`.

Também foi incluído o repasse do campo `ponto_a_ponto` nas formatações dos cards, tanto na listagem principal quanto na tela de **Ver Mais**, mantendo o mesmo comportamento visual em todos os cards.