### PR TITLE
Feature/150352 identificar layouts de flv

### DIFF
--- a/src/components/Shareable/CardCronograma/CardCronograma.jsx
+++ b/src/components/Shareable/CardCronograma/CardCronograma.jsx
@@ -16,6 +16,9 @@ export const CardCronograma = ({
     Boolean(solicitation.ponto_a_ponto) ||
     solicitation.tipo_entrega === "PONTO_A_PONTO";
 
+  const ehFichaTecnicaFlv = (solicitation) =>
+    Boolean(solicitation.eh_ficha_tecnica_flv);
+
   const getClasseSolicitacao = (solicitation) => {
     const classes = ["data"];
 
@@ -27,6 +30,9 @@ export const CardCronograma = ({
       classes.push("ponto-a-ponto");
     }
 
+    if (ehFichaTecnicaFlv(solicitation)) {
+      classes.push("eh-ficha-tecnica-flv");
+    }
     return classes.join(" ");
   };
 

--- a/src/components/Shareable/CardCronograma/style.scss
+++ b/src/components/Shareable/CardCronograma/style.scss
@@ -99,3 +99,7 @@
 .ponto-a-ponto {
   color: $green !important;
 }
+
+.eh-ficha-tecnica-flv{
+  color: $green !important;
+}

--- a/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/index.jsx
@@ -23,12 +23,13 @@ export default ({
           <div className="card-listagem-solicitacoes">
             {solicitacoes &&
               solicitacoes.map((value, key) => {
-                const ehPontoAPonto =
+                const ehPontoAPontoOuFlv =
                   Boolean(value.ponto_a_ponto) ||
-                  value.tipo_entrega === "PONTO_A_PONTO";
+                  value.tipo_entrega === "PONTO_A_PONTO" ||
+                  value.eh_ficha_tecnica_flv;
 
-                const classeDestaque = ehPontoAPonto
-                  ? "categoria-ponto-a-ponto"
+                const classeDestaque = ehPontoAPontoOuFlv
+                  ? "categoria-na-cor-verde"
                   : value.programa_leve_leite
                     ? "programa-leve-leite"
                     : "";

--- a/src/components/Shareable/CardListarSolicitacoesCronograma/style.scss
+++ b/src/components/Shareable/CardListarSolicitacoesCronograma/style.scss
@@ -83,6 +83,6 @@
   color: #086397 !important;
 }
 
-.categoria-ponto-a-ponto {
+.categoria-na-cor-verde {
   color: $green !important;
 }

--- a/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
+++ b/src/components/Shareable/__tests__/CardCronograma/CardCronograma.test.jsx
@@ -34,6 +34,16 @@ describe("CardCronograma", () => {
     programa_leve_leite: true,
   };
 
+  const solicitacaoFichaTecnicaFlv = {
+    text: "Solicitação Ficha Técnica FLV",
+    date: "2024-05-23",
+    link: "/mock-link",
+    fullText: "Texto completo Ficha Técnica FLV",
+    programa_leve_leite: false,
+    tipo_entrega: "ARMAZEM",
+    eh_ficha_tecnica_flv: true,
+  };
+
   test("Deve aplicar a classe 'ponto-a-ponto' quando o tipo de entrega for Ponto a Ponto", () => {
     render(
       <MemoryRouter>
@@ -99,5 +109,61 @@ describe("CardCronograma", () => {
 
     expect(paragraph).toHaveClass("programa-leve-leite");
     expect(paragraph).toHaveClass("ponto-a-ponto");
+  });
+
+  test("Deve aplicar a classe 'eh-ficha-tecnica-flv' quando a solicitação for de ficha técnica FLV", () => {
+    render(
+      <MemoryRouter>
+        <CardCronograma
+          cardTitle="Cronograma"
+          cardType="tipo-mock"
+          solicitations={[solicitacaoFichaTecnicaFlv]}
+          icon="fa-calendar"
+          loading={false}
+          href="/mock-href"
+          exibirTooltip={false}
+        />
+      </MemoryRouter>,
+    );
+
+    const paragraph = screen
+      .getByText("Solicitação Ficha Técnica FLV")
+      .closest("p");
+
+    expect(paragraph).toHaveClass("eh-ficha-tecnica-flv");
+    expect(paragraph).not.toHaveClass("ponto-a-ponto");
+    expect(paragraph).not.toHaveClass("programa-leve-leite");
+  });
+
+  test("Deve renderizar solicitações com tooltip e aplicar a classe de ficha técnica FLV", () => {
+    render(
+      <MemoryRouter>
+        <CardCronograma
+          cardTitle="Cronograma"
+          cardType="tipo-mock"
+          solicitations={[solicitacaoFichaTecnicaFlv]}
+          icon="fa-calendar"
+          loading={false}
+          href="/mock-href"
+          exibirTooltip={true}
+        />
+      </MemoryRouter>,
+    );
+
+    const paragraph = screen
+      .getByText("Solicitação Ficha Técnica FLV")
+      .closest("p");
+
+    expect(paragraph).toHaveClass("eh-ficha-tecnica-flv");
+    expect(paragraph).not.toHaveClass("ponto-a-ponto");
+    expect(paragraph).not.toHaveClass("programa-leve-leite");
+
+    expect(screen.getByText("2024-05-23")).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("link", {
+        name: /Solicitação Ficha Técnica FLV/i,
+      }),
+    ).toHaveAttribute("href", "/mock-link");
   });
 });

--- a/src/components/Shareable/__tests__/CardListarScolicitacoesCronograma/index.test.jsx
+++ b/src/components/Shareable/__tests__/CardListarScolicitacoesCronograma/index.test.jsx
@@ -26,7 +26,7 @@ describe("CardListarSolicitacoesCronograma", () => {
           solicitacoes={solicitacoesMock}
           exibirTooltip={false}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText("Cronograma")).toBeInTheDocument();
@@ -48,12 +48,40 @@ describe("CardListarSolicitacoesCronograma", () => {
           solicitacoes={solicitacoesMock}
           exibirTooltip={true}
         />
-      </MemoryRouter>
+      </MemoryRouter>,
     );
 
     expect(screen.getByText("Solicitação 1")).toBeInTheDocument();
 
     const tooltipSpan = screen.getByText("Solicitação 1");
     expect(tooltipSpan.closest("div")?.getAttribute("title")).toBeNull();
+  });
+  test("Aplica classe verde quando solicitação é de ficha técnica FLV", () => {
+    const solicitacoesFlvMock = [
+      {
+        ...solicitacoesMock[0],
+        eh_ficha_tecnica_flv: true,
+      },
+    ];
+
+    render(
+      <MemoryRouter>
+        <CardListarSolicitacoesCronograma
+          titulo="Cronograma"
+          tipo="azul"
+          icone="fa-clock"
+          solicitacoes={solicitacoesFlvMock}
+          exibirTooltip={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Solicitação 1")).toHaveClass(
+      "categoria-na-cor-verde",
+    );
+
+    expect(screen.getByText("2024-05-23 14:00")).toHaveClass(
+      "categoria-na-cor-verde",
+    );
   });
 });

--- a/src/components/screens/PreRecebimento/PainelLayoutEmbalagem/__tests__/DILOGABASTECIMENTO/painel.test.jsx
+++ b/src/components/screens/PreRecebimento/PainelLayoutEmbalagem/__tests__/DILOGABASTECIMENTO/painel.test.jsx
@@ -15,6 +15,17 @@ import { mockDashboardLayoutDeEmbalagemDILOGABASTECIMENTO } from "src/mocks/serv
 import { mockDashboardLayoutDeEmbalagemFiltradoDILOGABASTECIMENTO } from "src/mocks/services/layoutDeEmbalagem.service/DILOGABASTECIMENTO/dashboardFiltrado";
 import { PainelLayoutEmbalagemPage } from "src/pages/PreRecebimento/PainelLayoutEmbalagemPage";
 import mock from "src/services/_mock";
+import {
+  ANALISAR_LAYOUT_EMBALAGEM,
+  DETALHAR_LAYOUT_EMBALAGEM,
+  DETALHAR_LAYOUT_EMBALAGEM_SOLICITACAO_ALTERACAO,
+} from "src/configs/constants";
+import { usuarioPodeAnalisarLayoutEmbalagem } from "src/helpers/utilities";
+
+jest.mock("src/helpers/utilities", () => ({
+  ...jest.requireActual("src/helpers/utilities"),
+  usuarioPodeAnalisarLayoutEmbalagem: jest.fn(),
+}));
 
 describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () => {
   beforeEach(async () => {
@@ -24,7 +35,7 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
     mock
       .onGet("/layouts-de-embalagem/dashboard/")
       .reply(200, mockDashboardLayoutDeEmbalagemDILOGABASTECIMENTO);
-
+    usuarioPodeAnalisarLayoutEmbalagem.mockReturnValue(false);
     Object.defineProperty(global, "localStorage", { value: localStorageMock });
     localStorage.setItem("tipo_perfil", TIPO_PERFIL.PRE_RECEBIMENTO);
     localStorage.setItem("perfil", PERFIL.DILOG_ABASTECIMENTO);
@@ -46,7 +57,7 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
           >
             <PainelLayoutEmbalagemPage />
           </MeusDadosContext.Provider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
   });
@@ -60,17 +71,17 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
   it("Renderiza paineis", () => {
     expect(screen.getByText("Pendentes de Aprovação")).toBeInTheDocument();
     expect(
-      screen.getByText("FT015 / CAJUINA / JP Alimentos LTDA")
+      screen.getByText("FT015 / CAJUINA / JP Alimentos LTDA"),
     ).toBeInTheDocument();
 
     expect(screen.getByText("Aprovados")).toBeInTheDocument();
     expect(
-      screen.getByText("FT040 / FORMIGA / JP Alimentos LTDA")
+      screen.getByText("FT040 / FORMIGA / JP Alimentos LTDA"),
     ).toBeInTheDocument();
 
     expect(screen.getByText("Enviados para Correção")).toBeInTheDocument();
     expect(
-      screen.getByText("FT039 / ARROZ TIPO I / Empresa do Luis Zimm...")
+      screen.getByText("FT039 / ARROZ TIPO I / Empresa do Luis Zimm..."),
     ).toBeInTheDocument();
   });
 
@@ -80,7 +91,7 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
     });
     expect(linkPendenteAprovacao).toHaveAttribute(
       "href",
-      expect.stringContaining("detalhe-layout-embalagem")
+      expect.stringContaining("detalhe-layout-embalagem"),
     );
 
     const linkAprovados = screen.getByRole("link", {
@@ -88,7 +99,7 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
     });
     expect(linkAprovados).toHaveAttribute(
       "href",
-      expect.stringContaining("detalhe-layout-embalagem")
+      expect.stringContaining("detalhe-layout-embalagem"),
     );
 
     const linkEnviadosParaCorrecao = screen.getByRole("link", {
@@ -96,13 +107,13 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
     });
     expect(linkEnviadosParaCorrecao).toHaveAttribute(
       "href",
-      expect.stringContaining("detalhe-layout-embalagem")
+      expect.stringContaining("detalhe-layout-embalagem"),
     );
   });
 
   it("testa busca por nº do cronograma", async () => {
     const divInputBuscaPorNumeroCronograma = screen.getByTestId(
-      "div-input-numero-cronograma"
+      "div-input-numero-cronograma",
     );
     const inputElement =
       divInputBuscaPorNumeroCronograma.querySelector("input");
@@ -117,14 +128,14 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
 
     await waitFor(() => {
       expect(
-        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos")
+        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos"),
       ).not.toBeInTheDocument();
     });
   });
 
   it("testa busca por nome do produto", async () => {
     const divInputBuscaPorNomeProduto = screen.getByTestId(
-      "div-input-nome-produto"
+      "div-input-nome-produto",
     );
     const inputElement = divInputBuscaPorNomeProduto.querySelector("input");
     await waitFor(() => {
@@ -138,14 +149,14 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
 
     await waitFor(() => {
       expect(
-        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos")
+        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos"),
       ).not.toBeInTheDocument();
     });
   });
 
   it("testa busca por nome do fornecedor", async () => {
     const divInputBuscaPorNomeFornecedor = screen.getByTestId(
-      "div-input-nome-fornecedor"
+      "div-input-nome-fornecedor",
     );
     const inputElement = divInputBuscaPorNomeFornecedor.querySelector("input");
     await waitFor(() => {
@@ -159,8 +170,93 @@ describe("Teste Painel Layout de Embalagens - Usuário DILOG_ABASTECIMENTO", () 
 
     await waitFor(() => {
       expect(
-        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos")
+        screen.queryByText("FT006 - BOLO INDIVIDUAL - JP Alimentos"),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("Renderiza hrefs de análise, solicitação de alteração e detalhe quando usuário pode analisar", async () => {
+    usuarioPodeAnalisarLayoutEmbalagem.mockReturnValue(true);
+
+    const divInputBuscaPorNomeProduto = screen.getByTestId(
+      "div-input-nome-produto",
+    );
+    const inputElement = divInputBuscaPorNomeProduto.querySelector("input");
+
+    fireEvent.change(inputElement, {
+      target: { value: "CAJUINA" },
+    });
+
+    await waitFor(() => {
+      const linkPendenteAprovacao = screen.getByRole("link", {
+        name: /FT015\s*\/\s*CAJUINA\s*\/\s*JP Alimentos LTDA/i,
+      });
+
+      expect(linkPendenteAprovacao).toHaveAttribute(
+        "href",
+        expect.stringContaining(ANALISAR_LAYOUT_EMBALAGEM),
+      );
+    });
+
+    const linkEnviadosParaCorrecao = screen.getByRole("link", {
+      name: /FT039\s*\/\s*ARROZ TIPO I\s*\/\s*Empresa do Luis Zimm.../i,
+    });
+
+    expect(linkEnviadosParaCorrecao).toHaveAttribute(
+      "href",
+      expect.stringContaining(DETALHAR_LAYOUT_EMBALAGEM_SOLICITACAO_ALTERACAO),
+    );
+
+    const linkAprovados = screen.getByRole("link", {
+      name: /FT040\s*\/\s*FORMIGA\s*\/\s*JP Alimentos LTDA/i,
+    });
+
+    expect(linkAprovados).toHaveAttribute(
+      "href",
+      expect.stringContaining(DETALHAR_LAYOUT_EMBALAGEM),
+    );
+  });
+
+  it("Filtra layouts e depois remove o filtro quando valor fica menor que três caracteres", async () => {
+    mock.resetHistory();
+
+    mock
+      .onGet("/layouts-de-embalagem/dashboard/")
+      .reply(200, mockDashboardLayoutDeEmbalagemFiltradoDILOGABASTECIMENTO);
+
+    const divInputBuscaPorNomeProduto = screen.getByTestId(
+      "div-input-nome-produto",
+    );
+    const inputElement = divInputBuscaPorNomeProduto.querySelector("input");
+
+    fireEvent.change(inputElement, {
+      target: { value: "CAJUINA" },
+    });
+
+    await waitFor(() => {
+      expect(
+        mock.history.get.filter(
+          (request) => request.url === "/layouts-de-embalagem/dashboard/",
+        ),
+      ).toHaveLength(1);
+    });
+
+    mock.resetHistory();
+
+    mock
+      .onGet("/layouts-de-embalagem/dashboard/")
+      .reply(200, mockDashboardLayoutDeEmbalagemDILOGABASTECIMENTO);
+
+    fireEvent.change(inputElement, {
+      target: { value: "CA" },
+    });
+
+    await waitFor(() => {
+      expect(
+        mock.history.get.filter(
+          (request) => request.url === "/layouts-de-embalagem/dashboard/",
+        ),
+      ).toHaveLength(1);
     });
   });
 });

--- a/src/components/screens/PreRecebimento/PainelLayoutEmbalagem/index.jsx
+++ b/src/components/screens/PreRecebimento/PainelLayoutEmbalagem/index.jsx
@@ -68,6 +68,7 @@ export default () => {
       link: gerarLinkLayout(item),
       status: item.status,
       programa_leve_leite: item.programa_leve_leite,
+      eh_ficha_tecnica_flv: item.eh_ficha_tecnica_flv,
     }));
   };
 

--- a/src/components/screens/SolicitacoesLayoutStatusGenerico/index.jsx
+++ b/src/components/screens/SolicitacoesLayoutStatusGenerico/index.jsx
@@ -36,6 +36,7 @@ export const SolicitacoesLayoutStatusGenerico = ({ ...props }) => {
       data: item.log_mais_recente.slice(0, 10),
       link: `${urlBaseItem}?uuid=${item.uuid}`,
       programa_leve_leite: item.programa_leve_leite,
+      eh_ficha_tecnica_flv: item.eh_ficha_tecnica_flv,
     }));
   };
 


### PR DESCRIPTION
### Referência azure:
- [AB#150352](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/151904)

> - Aplica destaque visual verde nos cards de Layout de Embalagem quando **eh_ficha_tecnica_flv** for verdadeiro.
> - Mantém o comportamento já existente para Ponto a Ponto e Programa Leve Leite.
> - Adiciona testes unitários para cobrir a nova condição visual.