### PR TITLE
Feature/147369 habilita opcao consolidado cemei

### DIFF
--- a/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/components/ModalRelatorio/__tests__/index.test.jsx
+++ b/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/components/ModalRelatorio/__tests__/index.test.jsx
@@ -420,10 +420,12 @@ describe("Testes de comportamento para componente - ModalRelatorio Consolidado d
 
   it("nao permite selecionar um grupo 2 e não habilita o botão de gerar relatório", () => {
     const radio = screen.getByLabelText("Grupo 2 (CEMEI, CEU CEMEI)");
-    expect(radio).toBeDisabled();
+    expect(radio).not.toBeDisabled();
+
+    fireEvent.click(radio);
 
     const botaoGerar = screen.getByRole("button", { name: "Gerar Relatório" });
-    expect(botaoGerar).toBeDisabled();
+    expect(botaoGerar).not.toBeDisabled();
   });
 
   it("permite selecionar um grupo habilitado 3 e habilita o botão de gerar relatório", () => {

--- a/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/components/ModalRelatorio/index.jsx
+++ b/src/components/screens/LancamentoInicial/AcompanhamentoDeLancamentos/components/ModalRelatorio/index.jsx
@@ -81,7 +81,7 @@ const ModalRelatorio = ({
   };
 
   function desabilitaRadioButton(grupo) {
-    const gruposBloqueadosRecreio = ["Grupo 2", "Grupo 5", "Grupo 6"];
+    const gruposBloqueadosRecreio = ["Grupo 5", "Grupo 6"];
     if (nomeRelatorio === "Relatório Consolidado") {
       if (recreioNasFerias && gruposBloqueadosRecreio.includes(grupo)) {
         return true;


### PR DESCRIPTION
**Este pull request**
- Remove bloqueio de opção grupo 2 para Relatório Consolidado Recreio nas Férias.
- Ajusta teste de comportamento da opção.

Referência no Azure: [AB#147369](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/147369)