### PR TITLE
hotfix(152993): corrige problema nos filtros do relatorio de recreio

### DIFF
--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/CODAE/relatorio.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/CODAE/relatorio.test.jsx
@@ -25,7 +25,7 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
   beforeEach(async () => {
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
     mock
-      .onGet("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
+      .onPost("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
       .reply(200, mockRelatorioRecreioNasFerias);
     mock.onGet("/lotes-simples/").reply(200, mockLotesSimples);
     mock.onGet("/classificacoes-dieta/").reply(200, mockGetClassificacaoDieta);
@@ -37,11 +37,11 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
     Object.defineProperty(global, "localStorage", { value: localStorageMock });
     localStorage.setItem(
       "perfil",
-      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
     localStorage.setItem(
       "tipo_perfil",
-      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
 
     await act(async () => {
@@ -61,14 +61,14 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
             <RelatorioRecreioFeriasPage />
             <ToastContainer />
           </MeusDadosContext.Provider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
   });
 
   it("Renderiza título e breadcrumb `Relatório de Dietas para Recreio nas Férias`", () => {
     expect(
-      screen.queryAllByText("Relatório de Dietas para Recreio nas Férias")
+      screen.queryAllByText("Relatório de Dietas para Recreio nas Férias"),
     ).toHaveLength(2);
   });
 
@@ -125,7 +125,7 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
 
     mock
       .onGet(
-        `/solicitacoes-dieta-especial/${mockRelatorioRecreioNasFerias.results[0].uuid}/protocolo/`
+        `/solicitacoes-dieta-especial/${mockRelatorioRecreioNasFerias.results[0].uuid}/protocolo/`,
       )
       .reply(200, new Blob(["conteúdo do PDF"], { type: "application/pdf" }));
 
@@ -145,8 +145,8 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
     });
 
     mock
-      .onGet(
-        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/"
+      .onPost(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/",
       )
       .reply(200, {
         detail: "Solicitação de geração de arquivo recebida com sucesso.",
@@ -158,7 +158,7 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Geração solicitada com sucesso.")
+        screen.getByText("Geração solicitada com sucesso."),
       ).toBeInTheDocument();
     });
   });

--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/Escola/relatorio.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/Escola/relatorio.test.jsx
@@ -24,7 +24,7 @@ describe("Teste Relatório Recreio Férias - Usuário Escola CEMEI", () => {
   beforeEach(async () => {
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosEscolaCEMEI);
     mock
-      .onGet("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
+      .onPost("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
       .reply(200, mockRelatorioRecreioNasFerias);
     mock.onGet("/lotes-simples/").reply(200, mockLotesSimples);
     mock.onGet("/classificacoes-dieta/").reply(200, mockGetClassificacaoDieta);
@@ -57,14 +57,14 @@ describe("Teste Relatório Recreio Férias - Usuário Escola CEMEI", () => {
             <RelatorioRecreioFeriasPage />
             <ToastContainer />
           </MeusDadosContext.Provider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
   });
 
   it("Renderiza título e breadcrumb `Relatório de Dietas para Recreio nas Férias`", () => {
     expect(
-      screen.queryAllByText("Relatório de Dietas para Recreio nas Férias")
+      screen.queryAllByText("Relatório de Dietas para Recreio nas Férias"),
     ).toHaveLength(2);
   });
 
@@ -91,8 +91,8 @@ describe("Teste Relatório Recreio Férias - Usuário Escola CEMEI", () => {
     });
 
     mock
-      .onGet(
-        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-excel/"
+      .onPost(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-excel/",
       )
       .reply(200, {
         detail: "Solicitação de geração de arquivo recebida com sucesso.",
@@ -104,7 +104,7 @@ describe("Teste Relatório Recreio Férias - Usuário Escola CEMEI", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("Geração solicitada com sucesso.")
+        screen.getByText("Geração solicitada com sucesso."),
       ).toBeInTheDocument();
     });
   });

--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_pdf.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_pdf.test.jsx
@@ -23,7 +23,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
   beforeEach(async () => {
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
     mock
-      .onGet("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
+      .onPost("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
       .reply(200, mockRelatorioRecreioNasFerias);
     mock.onGet("/lotes-simples/").reply(200, mockLotesSimples);
     mock.onGet("/classificacoes-dieta/").reply(200, mockGetClassificacaoDieta);
@@ -33,11 +33,11 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
       .reply(200, mockGetUnidadeEducacional);
     localStorage.setItem(
       "tipo_perfil",
-      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
     localStorage.setItem(
       "perfil",
-      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
 
     await act(async () => {
@@ -57,7 +57,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
             <RelatorioRecreioFeriasPage />
             <ToastContainer />
           </MeusDadosContext.Provider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
   });
@@ -78,8 +78,8 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
     });
 
     mock
-      .onGet(
-        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/"
+      .onPost(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/",
       )
       .reply(400, {});
 
@@ -89,7 +89,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
 
     await waitFor(() => {
       expect(
-        screen.getByText("Erro ao baixar PDF, tente novamente mais tarde.")
+        screen.getByText("Erro ao baixar PDF, tente novamente mais tarde."),
       ).toBeInTheDocument();
     });
   });

--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_xlsx.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_xlsx.test.jsx
@@ -23,7 +23,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
   beforeEach(async () => {
     mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosEscolaCEMEI);
     mock
-      .onGet("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
+      .onPost("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
       .reply(200, mockRelatorioRecreioNasFerias);
     mock.onGet("/lotes-simples/").reply(200, mockLotesSimples);
     mock.onGet("/classificacoes-dieta/").reply(200, mockGetClassificacaoDieta);
@@ -33,11 +33,11 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
       .reply(200, mockGetUnidadeEducacional);
     localStorage.setItem(
       "tipo_perfil",
-      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
     localStorage.setItem(
       "perfil",
-      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA,
     );
 
     await act(async () => {
@@ -57,7 +57,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
             <RelatorioRecreioFeriasPage />
             <ToastContainer />
           </MeusDadosContext.Provider>
-        </MemoryRouter>
+        </MemoryRouter>,
       );
     });
   });
@@ -78,8 +78,8 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
     });
 
     mock
-      .onGet(
-        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-excel/"
+      .onPost(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-excel/",
       )
       .reply(400, {});
 
@@ -89,7 +89,7 @@ describe("Verifica comportamento da interface ao receber retorno de erro na expo
 
     await waitFor(() => {
       expect(
-        screen.getByText("Erro ao baixar Excel, tente novamente mais tarde.")
+        screen.getByText("Erro ao baixar Excel, tente novamente mais tarde."),
       ).toBeInTheDocument();
     });
   });

--- a/src/services/dietaEspecial.service.jsx
+++ b/src/services/dietaEspecial.service.jsx
@@ -466,7 +466,7 @@ export const getDietasEspeciaisVigentesDeUmAlunoNaoMatriculado = async (
 
 export const getRelatorioRecreioFerias = async (params) => {
   const url = `/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/`;
-  const response = await axios.get(url, { params }).catch(ErrorHandlerFunction);
+  const response = await axios.post(url, params).catch(ErrorHandlerFunction);
   if (response) {
     const data = { data: response.data, status: response.status };
     return data;
@@ -476,7 +476,7 @@ export const getRelatorioRecreioFerias = async (params) => {
 export const gerarPdfRelatorioRecreioFerias = async (params) => {
   const url = `/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/`;
   const response = await axios
-    .get(url, { params, responseType: "blob" })
+    .post(url, params, { responseType: "blob" })
     .catch(ErrorHandlerFunction);
   if (response) {
     const data = { data: response.data, status: response.status };
@@ -487,7 +487,7 @@ export const gerarPdfRelatorioRecreioFerias = async (params) => {
 export const gerarExcelRelatorioRecreioFerias = async (params) => {
   const url = `/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-excel/`;
   const response = await axios
-    .get(url, { params, responseType: "blob" })
+    .post(url, params, { responseType: "blob" })
     .catch(ErrorHandlerFunction);
   if (response) {
     const data = { data: response.data, status: response.status };


### PR DESCRIPTION
Este PR:
- corrige problema onde filtro de escola era ignorado no relatorio de dietas de recreio
- transforma requisicoes em post pra evitar problema de request too long

[AB#152993](https://dev.azure.com/SME-Spassu/847972f0-f883-4d71-b1d8-5624af27ae9c/_workitems/edit/152993)