### PR TITLE
fix(153095): corrige exibição de linha Lanche 4h no CMCT

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/CMCT/corrige_lancamento.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/CMCT/corrige_lancamento.test.jsx
@@ -20,6 +20,8 @@ import { mockGetVinculosTipoAlimentacaoPorEscolaCMCT } from "src/mocks/services/
 import { PeriodoLancamentoMedicaoInicialPage } from "src/pages/LancamentoMedicaoInicial/PeriodoLancamentoMedicaoInicialPage";
 import mock from "src/services/_mock";
 
+import { debug } from "jest-preview";
+
 describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuário CMCT - Corrige Lançamentos", () => {
   const escolaUuid = mockMeusDadosEscolaCMCT.vinculo_atual.instituicao.uuid;
 
@@ -67,6 +69,19 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuá
     mock
       .onGet("/medicao-inicial/medicao/feriados-no-mes/")
       .reply(200, { results: ["07"] });
+
+    mock
+      .onGet(
+        "/medicao-inicial/solicitacao-medicao-inicial/dias-frequencia-zerada/",
+      )
+      .reply(200, {
+        alimentacoes: [],
+        dietas: {
+          "DIETA ESPECIAL - TIPO A": [],
+          "DIETA ESPECIAL - TIPO A - ENTERAL / RESTRIÇÃO DE AMINOÁCIDOS": [],
+          "DIETA ESPECIAL - TIPO B": [],
+        },
+      });
 
     mock.onGet("/tipos-alimentacao/").reply(200, mockTipoAlimentacao);
 
@@ -125,6 +140,9 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuá
   });
 
   it("Clica em corrige lançamentos e cancela", async () => {
+    const inputLanche4h = screen.getByTestId("lanche_4h__dia_03__categoria_1");
+    fireEvent.change(inputLanche4h, { target: { value: "1" } });
+
     const botaoSalvarCorrecoes = screen
       .getByText("Salvar Correções")
       .closest("button");
@@ -143,6 +161,11 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuá
   });
 
   it("Corrige lançamentos", async () => {
+    const inputLanche4h = screen.getByTestId("lanche_4h__dia_03__categoria_1");
+    fireEvent.change(inputLanche4h, { target: { value: "1" } });
+
+    debug();
+
     const botaoSalvarCorrecoes = screen
       .getByText("Salvar Correções")
       .closest("button");

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/CMCT/corrige_lancamento.test.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/__tests__/CMCT/corrige_lancamento.test.jsx
@@ -20,8 +20,6 @@ import { mockGetVinculosTipoAlimentacaoPorEscolaCMCT } from "src/mocks/services/
 import { PeriodoLancamentoMedicaoInicialPage } from "src/pages/LancamentoMedicaoInicial/PeriodoLancamentoMedicaoInicialPage";
 import mock from "src/services/_mock";
 
-import { debug } from "jest-preview";
-
 describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuário CMCT - Corrige Lançamentos", () => {
   const escolaUuid = mockMeusDadosEscolaCMCT.vinculo_atual.instituicao.uuid;
 
@@ -163,8 +161,6 @@ describe("Teste <PeriodoLancamentoMedicaoInicial> - Programas e Projetos - Usuá
   it("Corrige lançamentos", async () => {
     const inputLanche4h = screen.getByTestId("lanche_4h__dia_03__categoria_1");
     fireEvent.change(inputLanche4h, { target: { value: "1" } });
-
-    debug();
 
     const botaoSalvarCorrecoes = screen
       .getByText("Salvar Correções")

--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -345,6 +345,7 @@ export default () => {
   const trataTabelaAlimentacaoEscolaSemAlunosRegulares = (
     tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares,
     tiposAlimentacaoInclusaoContinua,
+    periodoPossuiLanche4h = false,
   ) => {
     if (!tiposAlimentacaoInclusaoContinua.includes("refeicao")) {
       const indexRefeicao1Oferta =
@@ -395,15 +396,20 @@ export default () => {
       );
     }
 
-    if (!tiposAlimentacaoInclusaoContinua.includes("lanche_4h")) {
+    if (
+      !tiposAlimentacaoInclusaoContinua.includes("lanche_4h") &&
+      !periodoPossuiLanche4h
+    ) {
       const indexLanche4h =
         tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares.findIndex(
           (ali) => ali.nome === "Lanche 4h",
         );
-      tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares.splice(
-        indexLanche4h,
-        1,
-      );
+      if (indexLanche4h !== -1) {
+        tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares.splice(
+          indexLanche4h,
+          1,
+        );
+      }
     }
     if (
       !tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares.find(
@@ -630,6 +636,10 @@ export default () => {
       const tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares =
         deepCopy(tiposAlimentacaoFormatadas);
 
+      const periodoPossuiLanche4h = tiposAlimentacaoFormatadas.some(
+        (taf) => taf.nome === "Lanche 4h",
+      );
+
       if (
         tiposAlimentacaoInclusaoContinua.includes("lanche_4h") &&
         !tiposAlimentacaoFormatadas.find((taf) => taf.nome === "Lanche 4h")
@@ -687,6 +697,7 @@ export default () => {
         trataTabelaAlimentacaoEscolaSemAlunosRegulares(
           tiposAlimentacaoProgramasProjetosOuEscolaSemAlunosRegulares,
           tiposAlimentacaoInclusaoContinua,
+          periodoPossuiLanche4h,
         ),
       );
 


### PR DESCRIPTION
# Este PR

 - Corrige a exibição da linha Lanche 4h evitando que o código remova a row quando 'Lanche 4h' fizer parte dos tipos_alimentacao daquela medição.
 - Corrige testes unitários do CMCT