### PR TITLE
Feature/152191 pre recebimento permitir inclusao de justificativa na aprovacao de alteracao de cronograma

### DIFF
--- a/src/components/screens/PreRecebimento/AlterarCronograma/__tests__/index.test.jsx
+++ b/src/components/screens/PreRecebimento/AlterarCronograma/__tests__/index.test.jsx
@@ -432,16 +432,14 @@ describe("AlterarCronograma - Testes Completos", () => {
     it("exibe campo de justificativa ao reprovar", async () => {
       await setup(true);
 
-      // Seleciona reprovar
       const radioReprovar = await screen.findByText(/Analise Reprovada/i);
       fireEvent.click(radioReprovar);
 
-      await waitFor(() => {
-        const justificativaFields = screen.getAllByPlaceholderText(
-          /Escreva as alterações necessárias/i,
-        );
-        expect(justificativaFields.length).toBeGreaterThan(0);
-      });
+      expect(
+        await screen.findByPlaceholderText(
+          "Escreva a justificativa da análise",
+        ),
+      ).toBeInTheDocument();
     });
   });
 
@@ -597,6 +595,48 @@ describe("AlterarCronograma - Testes Completos", () => {
           `/${PRE_RECEBIMENTO}/${SOLICITACAO_ALTERACAO_CRONOGRAMA}`,
         );
       });
+    });
+
+    it("envia justificativa opcional ao aprovar a análise", async () => {
+      await setup(true);
+
+      const radioAprovar = await screen.findByText(/Analise Aprovada/i);
+      fireEvent.click(radioAprovar);
+
+      const campoJustificativa = await screen.findByPlaceholderText(
+        /Escreva a justificativa da análise/i,
+      );
+
+      expect(campoJustificativa).toBeInTheDocument();
+
+      fireEvent.change(campoJustificativa, {
+        target: {
+          value: "Cronograma aprovado sem ressalvas",
+        },
+      });
+
+      expect(campoJustificativa).toHaveValue(
+        "Cronograma aprovado sem ressalvas",
+      );
+
+      await clicarBotao("Enviar DILOG");
+
+      const modalSim = await screen.findByText("Sim");
+      fireEvent.click(modalSim);
+
+      await waitFor(() => {
+        expect(mock.history.patch.length).toBe(1);
+        expect(mock.history.patch[0].url).toContain("/analise-abastecimento");
+      });
+
+      expect(JSON.parse(mock.history.patch[0].data)).toEqual({
+        aprovado: true,
+        justificativa_abastecimento: "Cronograma aprovado sem ressalvas",
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/${PRE_RECEBIMENTO}/${SOLICITACAO_ALTERACAO_CRONOGRAMA}`,
+      );
     });
   });
 

--- a/src/components/screens/PreRecebimento/AlterarCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/AlterarCronograma/index.jsx
@@ -77,7 +77,7 @@ export default ({ analiseSolicitacao }) => {
   };
 
   const exibirJustificativaAbastecimento = () =>
-    aprovacaoAbastecimento === false ||
+    aprovacaoAbastecimento !== null ||
     usuarioEhCronogramaOuCodae() ||
     ((usuarioEhDilogDiretoria() || usuarioEhDilogAbastecimento()) &&
       ["Aprovado Abastecimento", "Reprovado Abastecimento"].includes(
@@ -244,12 +244,9 @@ export default ({ analiseSolicitacao }) => {
     const urlParams = new URLSearchParams(window.location.search);
     const uuid = urlParams.get("uuid");
     const payload = {
-      aprovado: aprovado,
+      aprovado,
+      justificativa_abastecimento: values.justificativa_abastecimento || "",
     };
-    if (!aprovado) {
-      payload.justificativa_abastecimento =
-        values["justificativa_abastecimento"];
-    }
     await analiseAbastecimentoSolicitacaoAlteracaoCronograma(uuid, payload)
       .then(() => {
         toastSuccess("Análise da alteração enviada com sucesso!");
@@ -540,17 +537,27 @@ export default ({ analiseSolicitacao }) => {
                                   : "Aprovado Abastecimento"}
                               </p>
                             )}
-                            {(aprovacaoAbastecimento === false ||
-                              reprovadoPeloAbastecimento()) && (
+
+                            {(aprovacaoAbastecimento !== null ||
+                              analisadoPeloAbastecimento()) && (
                               <>
                                 <label className="label fw-normal">
-                                  <span>* </span>Justificativa
+                                  {(aprovacaoAbastecimento === false ||
+                                    reprovadoPeloAbastecimento()) && (
+                                    <span>* </span>
+                                  )}
+                                  Justificativa
                                 </label>
+
                                 <Field
                                   component={TextArea}
                                   disabled={analisadoPeloAbastecimento()}
                                   name="justificativa_abastecimento"
-                                  placeholder="Escreva as alterações necessárias"
+                                  placeholder={
+                                    analisadoPeloAbastecimento()
+                                      ? ""
+                                      : "Escreva a justificativa da análise"
+                                  }
                                   className="input-busca-produto"
                                 />
                               </>


### PR DESCRIPTION
 ### Referência azure:
- [AB#152191](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/152191)

Permite informar uma justificativa opcional ao aprovar uma alteração de cronograma pela DILOG Abastecimento. O campo passa a ser exibido tanto na aprovação quanto na reprovação, permanecendo obrigatório apenas quando a análise for reprovada. Também foi ajustado o envio da justificativa no payload e adicionados testes para validar o novo fluxo.
