### PR TITLE
Hotfix/corrige botao solicitar correcao ocorrencia

### DIFF
--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/DRE/solicita_correcao_no_formulario_sem_ocorrencia.test.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/__tests__/DRE/solicita_correcao_no_formulario_sem_ocorrencia.test.jsx
@@ -75,11 +75,11 @@ describe("Teste Conferência de Lançamentos - Usuário DRE - Solicitação corr
     });
   });
 
-  it("Renderiza botão `Solicitar correção no formulário` sem estar habilitado", async () => {
+  it("Renderiza botão `Solicitar correção no formulário` habilitado para DRE quando medição tem status esperado", async () => {
     const span = screen.getByText("Solicitar correção no formulário");
     const botao = span.closest("button");
 
     expect(botao).toBeInTheDocument();
-    expect(botao).not.toBeEnabled();
+    expect(botao).toBeEnabled();
   });
 });

--- a/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
+++ b/src/components/screens/LancamentoInicial/ConferenciaDosLancamentos/index.jsx
@@ -286,17 +286,21 @@ export const ConferenciaDosLancamentos = () => {
       "MEDICAO_CORRIGIDA_PELA_UE",
     ].includes(solicitacao.ocorrencia.status);
 
+  const statusOcorrenciaEsperadoSolicitarCorrecaoCODAE = [
+    "OCORRENCIA_EXCLUIDA_PELA_ESCOLA",
+    "MEDICAO_APROVADA_PELA_DRE",
+    "MEDICAO_CORRECAO_SOLICITADA_CODAE",
+    "MEDICAO_APROVADA_PELA_CODAE",
+    "MEDICAO_CORRIGIDA_PARA_CODAE",
+  ].includes(solicitacao?.ocorrencia?.status);
+
   const desabilitarSolicitarCorrecaoOcorrenciaCODAE =
-    usuarioMedicaoOuManifestacaoTemPermissao &&
-    solicitacao &&
-    solicitacao.ocorrencia &&
-    ![
-      "OCORRENCIA_EXCLUIDA_PELA_ESCOLA",
-      "MEDICAO_APROVADA_PELA_DRE",
-      "MEDICAO_CORRECAO_SOLICITADA_CODAE",
-      "MEDICAO_APROVADA_PELA_CODAE",
-      "MEDICAO_CORRIGIDA_PARA_CODAE",
-    ].includes(solicitacao.ocorrencia.status);
+    (statusOcorrenciaEsperadoSolicitarCorrecaoCODAE &&
+      !usuarioEhCODAENutriManifestacao()) ||
+    (usuarioEhCODAENutriManifestacao() &&
+      solicitacao &&
+      solicitacao.ocorrencia &&
+      !statusOcorrenciaEsperadoSolicitarCorrecaoCODAE);
 
   const statusOcorrenciaEsperadoCODAE = [
     "MEDICAO_APROVADA_PELA_DRE",
@@ -1027,7 +1031,6 @@ export const ConferenciaDosLancamentos = () => {
                                         type={BUTTON_TYPE.BUTTON}
                                         style={BUTTON_STYLE.GREEN_OUTLINE_WHITE}
                                         disabled={
-                                          !usuarioEhCODAENutriManifestacao() ||
                                           (ocorrencia?.status ===
                                             "MEDICAO_CORRECAO_SOLICITADA" &&
                                             !solicitacao?.com_ocorrencias) ||


### PR DESCRIPTION
# Este PR:
- libera o botão "Solicitar correção ocorrência" para DRE
- corrige os testes unitários

<img width="1143" height="607" alt="Sem título (3)" src="https://github.com/user-attachments/assets/5967237b-319e-4f4d-a089-d7a79303ddb8" />


