### PR TITLE
hotfix(152775): usa duas classes de estilo para os títulos do relatório

### DIFF
--- a/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/corpoRelatorio/index_development.jsx
+++ b/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/corpoRelatorio/index_development.jsx
@@ -116,7 +116,7 @@ export default class CorpoRelatorioDesenvolvimento extends Component {
         <article className="flex-botoes-relatorio">
           <div className="row col-12">
             <div className="col-12 d-flex justify-content-between align-items-center px-0">
-              <span className="title">Status do Produto</span>
+              <div className="titulo-secao-relatorio">Status do Produto</div>
               <div className="d-flex align-items-center">
                 <Botao
                   type={BUTTON_TYPE.BUTTON}
@@ -219,7 +219,7 @@ export default class CorpoRelatorioDesenvolvimento extends Component {
         </article>
         <hr />
         <article className="informacoes-gerais">
-          <div className="title">Identificação do Produto</div>
+          <div className="titulo-secao-relatorio">Identificação do Produto</div>
 
           <div className="linha-marca-fabricante">
             <div className="linha-informacao">
@@ -271,7 +271,7 @@ export default class CorpoRelatorioDesenvolvimento extends Component {
         </article>
         <hr />
         <article className="informacoes-gerais">
-          <div className="title">Informações nutricionais</div>
+          <div className="titulo-secao-relatorio">Informações nutricionais</div>
 
           <div className="grid-marca-fabricante-info info-sem-grid">
             <div className="label-relatorio">Porção</div>
@@ -333,7 +333,9 @@ export default class CorpoRelatorioDesenvolvimento extends Component {
         </article>
         <hr />
         <article className="informacoes-gerais">
-          <div className="title">Informação do Produto (classificação)</div>
+          <div className="titulo-secao-relatorio">
+            Informação do Produto (classificação)
+          </div>
 
           <div className="info-sem-grid">
             <div className="label-relatorio">Tipo</div>

--- a/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/styles.scss
+++ b/src/components/screens/Produto/BuscaAvancada/components/RelatorioProduto/components/styles.scss
@@ -1,4 +1,13 @@
+@use "src/styles/variables.scss" as *;
+
 .corpo-reatorio-produto {
+
+  .titulo-secao-relatorio {
+    color: $green;
+    font-size: 16px;
+    font-weight: bold;
+  }
+
   .label-relatorio {
     color: #686868;
     font-style: normal;
@@ -401,12 +410,6 @@
   ::-webkit-scrollbar-thumb {
     -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.5);
   }
-}
-
-.title {
-  color: #198459;
-  font-size: 16px;
-  font-weight: bold;
 }
 
 .product-details-table {


### PR DESCRIPTION
 ### Referência azure:
- [AB#133034](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/133034)

Ajusta os títulos internos do relatório de produtos, substituindo a classe global **.title** por uma classe específica e isolada no componente.
